### PR TITLE
Fixed noplot argument in plot.sph.image()

### DIFF
--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -239,7 +239,8 @@ def image(sim, qty='rho', width="10 kpc", resolution=500, units=None, log=True,
         p.savefig(filename)
         
     
-    plt.draw()
+	if not noplot:
+		plt.draw()
     # plt.show() - removed by AP on 30/01/2013 - this should not be here as
     #              for some systems you don't get back to the command prompt
 


### PR DESCRIPTION
The image() function takes a bunch of arguments, but the noplot one, which is supposed to not actually call the matplotlib plot() or draw() method didn't actually do anything.  I just added a single line near the end that prevents plt.draw() from being called if noplot=True.
