### PR TITLE
make arrays from subviews refer to the subview instead of global snapshot

### DIFF
--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -208,7 +208,6 @@ class SimArray(np.ndarray) :
         return new
 
     def __array_finalize__(self, obj) :
-     
         if obj is None :
             return
         elif obj is not self and hasattr(obj, 'units') :
@@ -282,7 +281,10 @@ class SimArray(np.ndarray) :
     @property
     def sim(self) :
         if hasattr(self.base, 'sim') :
-            return self.base.sim
+            if self.family and self.base.sim : 
+                return self.base.sim[self.family]
+            else : 
+                return self.base.sim
         return self._sim()
 
     @sim.setter
@@ -294,6 +296,17 @@ class SimArray(np.ndarray) :
                 self._sim = weakref.ref(s)
             else :
                 self._sim = lambda : None
+
+    @property
+    def family(self) : 
+        try : 
+            return self._family
+        except AttributeError : 
+            return None
+
+    @family.setter
+    def family(self,fam) : 
+        self._family = fam
 
     def __mul__(self, rhs) :
         if isinstance(rhs, _units.UnitBase) :
@@ -854,7 +867,7 @@ class IndexedSimArray(object) :
 
     @property
     def sim(self) :
-        return self.base.sim
+        return self.base.sim[self._ptr]
 
     @sim.setter
     def sim(self, s) :
@@ -864,7 +877,6 @@ class IndexedSimArray(object) :
     def dtype(self) :
         return self.base.dtype
 
-    
     def conversion_context(self) :
         return self.base.conversion_context()
 

--- a/pynbody/snapshot.py
+++ b/pynbody/snapshot.py
@@ -966,7 +966,6 @@ class SimSnap(object):
             shared = self._shared_arrays
 
         new_array = array._array_factory(dims, dtype, zeros, shared)
-
         new_array._sim = weakref.ref(self)
         new_array._name = array_name
         new_array.family = None
@@ -1657,7 +1656,7 @@ class SubSnap(SimSnap):
     def physical_units(self, *args, **kwargs):
         self.base.physical_units(*args, **kwargs)
 
-    def is_derived_array(self, v):
+    def is_derived_array(self, v, fam=None):
         return self.base.is_derived_array(v)
 
     def unlink_array(self, name):


### PR DESCRIPTION
previously `s.star['pos'].sim` returned the reference to the full snapshot -- but it seems to make more sense to return the reference to `s.star` -- these changes make it possible. However, I'm not sure whether this will break existing code...? It passes all the unit tests, but maybe I'm missing something else. 
