### PR TITLE
changed docs theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 
 import sys, os
 
+import sphinx_bootstrap_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -106,7 +108,18 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'bootstrap'
+
+# set up bootstrap
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
+
+html_theme_options = {
+    'bootswatch_theme': 'spacelab',
+
+    'navbar_site_name': 'Sections',
+
+    'source_link_position': 'footer'
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
this change makes the documentation layout a bit more modern, using the twitter-developed bootstrap theme. A sample build is here: http://www.ics.uzh.ch/~roskar/pynbody/docs/html/

We can choose a different theme and alter the CSS if this is desired. Themes are here: http://bootswatch.com/

I'm using the spacelab theme at the moment.
