### PR TITLE
Halo shape

### DIFF
--- a/pynbody/analysis/_com.pyx
+++ b/pynbody/analysis/_com.pyx
@@ -73,3 +73,14 @@ def shrink_sphere_center(np.ndarray[np.float64_t, ndim=2] pos,
             raise RuntimeError, "shrink_sphere_center failed to converge after %d iterations"%itermax
 
     return com_x
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def inertia_tensor(np.ndarray[np.float64_t, ndim=2] pos) :
+
+    i_t = np.zeros((3,3))
+    for p in pos:
+        i_t += p*np.array([p]).T
+
+    return i_t

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -294,3 +294,58 @@ def center(sim, mode=None, retcen=False, vel=True, cen_size="1 kpc", move_all=Tr
         tx = transformation.inverse_v_translate(tx, velc)
 
     return tx
+
+def shape(sim):
+    from numpy import linalg as LA
+    import pylab as plt
+    """
+
+    Iteratively determine the b and c shape values 
+    (normalized so that 'a', the long
+    axis, is 1) using the eigenvalues of the inertia tensor.
+    Iterations cut out particles that aren't part of 
+
+    """
+    gs = sim
+    
+    a=b=c=1
+    x=y=z=gs['r'].max()
+    s = b/a
+    q = c/a
+    
+    for ii in np.arange(5):
+        
+        r2 = x*x +(y/s)**2 + (z/q)**2
+
+        pos = np.asarray(gs['pos'], dtype='double')
+        inertia_tensor = _com.inertia_tensor(pos)
+            
+        evals, evecs = LA.eig(inertia_tensor / r2)
+        
+        sold = s
+        qold = q
+        a,b,c = np.sqrt(evals)
+        s = b/a
+        q = c/a
+
+        logger.info( 'Iteration %d'%ii )
+        logger.info( '# particles: %d'%len(gs) )
+        logger.info( 'a,b,c:  %g, %g, %g'%(a,b,c) )
+        logger.info( 's,q:    %g, %g'%(s,q) )
+
+        if ((np.abs((s-sold)/sold) < 0.01) and (np.abs((q-qold)/qold) < 0.01)):
+            break
+    
+        sim.ancestor.transform(np.array(evecs))
+        
+        plt.clf()
+        plt.scatter(gs['x'],gs['z'])
+        plt.savefig('shapepartsit%d.png'%ii )
+
+        ellipsoidf = filt.Ellipsoid(a=str(a)+' kpc',b=str(b)+' kpc',
+                                    c=str(c)+' kpc')
+        
+        gs = gs[ellipsoidf]
+
+
+    return s,q

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -163,6 +163,39 @@ class Cuboid(Filter):
                                   for x in self.x1, self.y1, self.z1, self.x2, self.y2, self.z2]
         return "Cuboid(%s, %s, %s, %s, %s, %s)" % (x1, y1, z1, x2, y2, z2)
 
+class Ellipsoid(Filter):
+
+    """Create an ellipsoid with specified dimensions centered on the orgin
+    and aligned with the x,y,z coordinate system. See 
+    `pynbody.analysis.halo.shape` for how to use the eigenvectors of the 
+    inertia tensor to align your particle group with coordinate system.
+    `a` is the half-length along the x-axis, `b` is the half length along 
+    the y-axis and `c` is half-length along the z-axis.  If the coordinates 
+    `b` or `c` are not specified they are determined as `b=a` and `c=b`.
+
+    """
+
+    def __init__(self, a, b=None, c=None):
+
+        self._descriptor = "ellipsoid"
+        a,b,c = [units.Unit(x) if isinstance(x, str) else x for x in a,b,c]
+        if b is None:
+            b = a
+        if c is None:
+            c = b
+        self.a, self.b, self.c = a,b,c
+
+    def __call__(self, sim):
+        a,b,c = [x.in_units(sim["pos"].units, **sim["pos"].conversion_context())
+                 if units.is_unit_like(x) else x
+                 for x in self.a, self.b, self.c]
+
+        return (sim["x"]*sim["x"]/a/a + sim["y"]*sim["y"]/b/b + sim["z"]*sim["z"]/c/c < 1)
+
+    def __repr__(self):
+        a,b,c = ["'%s'" % str(x) if units.is_unit_like(x) else x
+                 for x in self.a, self.b, self.c]
+        return "Ellipsoid(%s, %s, %s)" % (a,b,c)
 
 class Disc(Filter):
 


### PR DESCRIPTION
This pull request adds a shape calculation based on the inertia tensor.  It might be able to optimized more.  At this stage, I left in debugging plots and timing code.  Delete these before merging!

Issues:
Slowness:  This method is iterative with a rotation every iteration, so recalculating 'r' is the slowest part even though 'r' is not used during the iteration.  Is there a way to turn off the 'r' re-calculation temporarily?

Does anyone know why the b and c axes flip?  In my test case, I'm getting a shorter b than c.
