### PR TITLE
class StarLog(SimSnap): handle multiple entries from restart correctly.

### DIFF
--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1185,9 +1185,10 @@ class StarLog(SimSnap):
 
         if sort:
             tmp = g['iord'].flatten()
-            perm = tmp.argsort()
+            # mergesort for stability
+            perm = tmp.argsort(kind='mergesort')
             aux = tmp[perm]
-            flag = np.concatenate(([True], aux[1:] != aux[:-1]))
+            flag = np.concatenate((aux[1:] != aux[:-1], [True]))
             iord = aux[flag]
             indices = perm[flag]
             self._num_particles = len(indices)


### PR DESCRIPTION
When starlog files are written by Gasoline or ChaNGa, multiple instances of a particlular iOrder can be present because of a restart.  The correct thing to do is to take the last instance of any given iOrder in the starlog file, since that will come from the restart.

This fixes the StarLog reader to make that happen.  I've verified that it gives expected results on a restarted zoom in simulation with ChaNGa.
