### PR TITLE
GadgetHDF flexibility

### DIFF
--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -187,7 +187,7 @@ class GadgetHDFSnap(SimSnap):
         """Return the HDF dataset resolving /'s into nested groups, and returning
         an apparent Mass array even if the mass is actually stored in the header"""
 
-        if hdf_name == "Mass":
+        if _translate_array_name(hdf_name,reverse=True)=='mass':
             try:
                 pgid = int(particle_group.name[-1])
                 mtab = particle_group.parent['Header'].attrs['MassTable'][pgid]


### PR DESCRIPTION
On the user forum, Alex Fitts has shown us an example of a file where the mass array in the GadgetHDF format is called 'Masses' instead of 'Mass'. Also vel becomes 'Velocities' rather than 'Velocity'. 
