### PR TITLE
gadgethdf5 fixes (issue #212)

### DIFF
--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -231,8 +231,7 @@ class GadgetHDFSnap(SimSnap):
                 try:
                     dset0 = self._get_hdf_dataset(hdf[
                             _type_map[famx][0]], translated_name)
-                    break
-                except ValueError:
+                except KeyError:
                     continue
             
             assert len(dset0.shape) <= 2


### PR DESCRIPTION
Fixes dependency on all PartType being in the 0th hdf file

Please note that there is one thing I did not fix because I only have one family in my files and I wasn't sure how to fix it in that case.
I also added another commit which adds the option of using gadget-units instead of storing the units in the HDF5 files.

A temporary test file is here:
https://www.dropbox.com/sh/otg8a26qnkuvt4a/AACFGcJfLwACEGgy3P2sxaKwa?dl=0
Note that since the positions in this test file are stored in 32 bit floats, I had to edit DummyHDFData to use dtype np.float32 for producing the kdtree.
