### PR TITLE
use num_threads in calls to shrink_sphere_center

### DIFF
--- a/pynbody/analysis/_com.pyx
+++ b/pynbody/analysis/_com.pyx
@@ -14,6 +14,7 @@ def shrink_sphere_center(np.ndarray[np.float64_t, ndim=2] pos,
                          int min_particles,
                          float shrink_factor,
                          float starting_rmax,
+                         int num_threads,
                          int itermax=1000) :
 
     cdef int npart = len(pos)
@@ -38,7 +39,7 @@ def shrink_sphere_center(np.ndarray[np.float64_t, ndim=2] pos,
         cx=com_x[0]; cy=com_x[1]; cz=com_x[2]
         with nogil:
             npart = 0
-            for i in prange(npart_all,schedule='static'):
+            for i in prange(npart_all, schedule='static', num_threads=num_threads):
                 pix=pos[i,0]-cx; piy=pos[i,1]-cy; piz=pos[i,2]-cz
                 r = pix*pix+piy*piy+piz*piz
                 if r<current_rmax :

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -46,7 +46,7 @@ def center_of_mass_velocity(sim):
     return v
 
 
-def shrink_sphere_center(sim, r=None, shrink_factor=0.7, min_particles=100, verbose=False):
+def shrink_sphere_center(sim, r=None, shrink_factor=0.7, min_particles=100, verbose=False, num_threads = config['number_of_threads']):
     """
 
     Return the center according to the shrinking-sphere method of
@@ -90,7 +90,7 @@ def shrink_sphere_center(sim, r=None, shrink_factor=0.7, min_particles=100, verb
     mass = np.asarray(sim['mass'], dtype='double')
     pos = np.asarray(sim['pos'], dtype='double')
 
-    com = _com.shrink_sphere_center(pos, mass, min_particles, shrink_factor, r)
+    com = _com.shrink_sphere_center(pos, mass, min_particles, shrink_factor, r, num_threads)
     logger.info("Final SSC=%s", com)
 
     return array.SimArray(com, sim['pos'].units)


### PR DESCRIPTION
add option to use `num_threads` in calls to `shrink_sphere_center` -- otherwise it uses all cores by default which can cause problems. 
