### PR TITLE
Fix not filter

### DIFF
--- a/nose/filter_test.py
+++ b/nose/filter_test.py
@@ -70,3 +70,7 @@ def test_logic():
 
     assert comp.union(not_test) == f
     assert len(comp.intersect(not_test)) == 0
+
+    assert len(comp)+len(not_test)==len(f)
+    assert len(comp)!=0
+    assert len(not_test)!=0

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -78,7 +78,7 @@ class Not(Filter):
 
     def __call__(self, sim):
         x = self.f(sim)
-        return ~x
+        return np.logical_not(x)
 
     def __repr__(self):
         return "~" + repr(self.f)


### PR DESCRIPTION
Fix error reported by Lauren on UG list:

```
I cannot get the annulus filter to work. I can cut out the center of a disk 
(like the solar neighborhood filter) but cannot cut out the center of the 
a sphere. I tried doing it manually but it still grabs the same number 
of particles as the full sphere. 

Here is the example for the disk: 

In [42]: h[~pynbody.filt.Disc(pynbody.units.Unit('5 kpc'), pynbody.units.Unit('2 kpc')) & pynbody.filt.Disc(pynbody.units.Unit('10 kpc'), pynbody.units.Unit('2 kpc'))]               
Out[42]: <SimSnap "cosmo8.33PLK.256g1bwK1C52.001950.tipsy:halo_29686:~disc&disc" len=30823>

In [43]: h[pynbody.filt.Disc(pynbody.units.Unit('10 kpc'), pynbody.units.Unit('2 kpc'))]
Out[43]: <SimSnap "cosmo8.33PLK.256g1bwK1C52.001950.tipsy:halo_29686:disc" len=1456276>

Here is the example for the sphere:

In [44]: h[~pynbody.filt.Sphere(pynbody.units.Unit('5 kpc')) & pynbody.filt.Sphere(pynbody.units.Unit('10 kpc'))]               
Out[44]: <SimSnap "cosmo8.33PLK.256g1bwK1C52.001950.tipsy:halo_29686:~sphere&sphere" len=1745018>

In [45]: h[pynbody.filt.Sphere(pynbody.units.Unit('10 kpc'))]
Out[45]: <SimSnap "cosmo8.33PLK.256g1bwK1C52.001950.tipsy:halo_29686:sphere" len=1745018>

Am I doing something silly?

Lauren 
```