### PR TITLE
Speedup sphere selection

### DIFF
--- a/pynbody/analysis/_com.pyx
+++ b/pynbody/analysis/_com.pyx
@@ -39,16 +39,29 @@ def shrink_sphere_center(np.ndarray[np.float64_t, ndim=2] pos,
         cx=com_x[0]; cy=com_x[1]; cz=com_x[2]
         with nogil:
             npart = 0
-            for i in prange(npart_all, schedule='static', num_threads=num_threads):
-                pix=pos[i,0]-cx; piy=pos[i,1]-cy; piz=pos[i,2]-cz
-                r = pix*pix+piy*piy+piz*piz
-                if r<current_rmax :
-                    mi = mass[i]
-                    nx+=pix*mi
-                    ny+=piy*mi
-                    nz+=piz*mi
-                    tot_mass+=mi
-                    npart+=1
+
+            if num_threads > 1 : 
+                for i in prange(npart_all, schedule='static', num_threads=num_threads):
+                    pix=pos[i,0]-cx; piy=pos[i,1]-cy; piz=pos[i,2]-cz
+                    r = pix*pix+piy*piy+piz*piz
+                    if r<current_rmax :
+                        mi = mass[i]
+                        nx+=pix*mi
+                        ny+=piy*mi
+                        nz+=piz*mi
+                        tot_mass+=mi
+                        npart+=1
+            else : 
+                for i in range(npart_all):
+                    pix=pos[i,0]-cx; piy=pos[i,1]-cy; piz=pos[i,2]-cz
+                    r = pix*pix+piy*piy+piz*piz
+                    if r<current_rmax :
+                        mi = mass[i]
+                        nx+=pix*mi
+                        ny+=piy*mi
+                        nz+=piz*mi
+                        tot_mass+=mi
+                        npart+=1
 
         if npart==0:
             return com_x

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -139,7 +139,7 @@ class Sphere(Filter):
         if units.is_unit(self.radius[0]):
             return " & ".join(["Sphere('%s', %s)" % (str(radius), repr(cen)) for radius, cen in zip(self.radius, self.cen)])
         else:
-            return "Sphere(%.2e, %s)" % (self.radius, repr(self.cen))
+            return " & ".join(["Sphere(%.2e, %s)" % (radius, repr(cen)) for radius, cen in zip(self.radius, self.cen)])
 
 
 class Cuboid(Filter):

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -109,8 +109,10 @@ class Sphere(Filter):
         if isinstance(radius[0], str):
             radius = map(units.Unit,radius)
 
-        if len(cen) != len(radius) : 
-            radius = radius * len(cen)
+        # check if many different centers were passed in
+            if isinstance(cen, list) or isinstance(cen, np.ndarray) : 
+                if len(cen) != len(radius) : 
+                    radius = radius * len(cen)
 
         self.radius = radius
 
@@ -124,6 +126,8 @@ class Sphere(Filter):
         if units.is_unit_like(radius[0]):
             radius = np.asarray([r.in_units(pos.units, **pos.conversion_context()) for r in radius], dtype='float')
 
+        else : 
+            radius = np.asarray(radius, dtype='float')
 
         cen = self.cen
         if units.has_units(cen):

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -100,13 +100,20 @@ class Sphere(Filter):
     def __init__(self, radius, cen=(0, 0, 0)):
         self._descriptor = "sphere"
         self.cen = np.asarray(cen)
-        if self.cen.shape != (3,):
-            raise ValueError, "Centre must be length 3 array"
+#        if self.cen.shape != (3,):
+#            raise ValueError, "Centre must be length 3 array"
 
-        if isinstance(radius, str):
-            radius = units.Unit(radius)
+        if not isinstance(radius, list) : 
+            radius = [radius]
+
+        if isinstance(radius[0], str):
+            radius = map(units.Unit,radius)
+
+        if len(cen) != len(radius) : 
+            radius = radius * len(cen)
 
         self.radius = radius
+
 
     def __call__(self, sim):
         radius = self.radius
@@ -114,13 +121,17 @@ class Sphere(Filter):
         with sim.immediate_mode:
             pos = sim['pos']
 
-        if units.is_unit_like(radius):
-            radius = float(radius.in_units(pos.units,
-                                           **pos.conversion_context()))
+        if units.is_unit_like(radius[0]):
+            radius = np.asarray([r.in_units(pos.units, **pos.conversion_context()) for r in radius], dtype='float')
+
 
         cen = self.cen
         if units.has_units(cen):
             cen = cen.in_units(pos.units)
+
+        if len(cen.shape) == 1 : 
+            cen = np.expand_dims(cen,axis=0)
+
         return util._sphere_selection(np.asarray(pos),np.asarray(cen,dtype=pos.dtype),radius)
 
 

--- a/pynbody/filt.py
+++ b/pynbody/filt.py
@@ -136,9 +136,8 @@ class Sphere(Filter):
 
 
     def __repr__(self):
-        if units.is_unit(self.radius):
-
-            return "Sphere('%s', %s)" % (str(self.radius), repr(self.cen))
+        if units.is_unit(self.radius[0]):
+            return " & ".join(["Sphere('%s', %s)" % (str(radius), repr(cen)) for radius, cen in zip(self.radius, self.cen)])
         else:
             return "Sphere(%.2e, %s)" % (self.radius, repr(self.cen))
 


### PR DESCRIPTION
Stringing together a large number of filters is slow because the loop is over the full output for each filter. This PR modifies the `_sphere_selection` function to take an array of centers and radii and only loops over the full particle array once. 

It works something like this: 

```
s = pynbody.load(simulation)
filt = filt = pynbody.filt.Sphere('0.1 kpc', s.s['pos'][:2000])
```

this creates a filter that includes all particles within a radius 0.1 kpc around the first 2000 stars. 
