### PR TITLE
Percentile profiles

### DIFF
--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -379,11 +379,16 @@ class Profile:
             return self._profiles[name]
             # else :
             #    raise RuntimeError, "Derivatives only possible for profiles of fixed bin width."
+        elif "_percentile" in name and name[:name.find("_percentile")] in self.keys() or name[:name.find("_percentile")] in self.derivable_keys() or name[:name.find("_percentile")] in self.sim.all_keys():
+            name_end_ind = name.find("_percentile")
+            p = float(name[name_end_ind+11:])
+            logger.info("Auto-deriving {0:f}-th percentile of {1}".format(p, name[:name_end_ind]))
+            self._profiles[name] = self._auto_profile(name[:name_end_ind], percentile=p)
 
         else:
             raise KeyError, name + " is not a valid profile"
 
-    def _auto_profile(self, name, dispersion=False, rms=False, median=False):
+    def _auto_profile(self, name, dispersion=False, rms=False, median=False, percentile=None):
         result = np.zeros(self.nbins)
 
         # force derivation of array if necessary:
@@ -411,6 +416,8 @@ class Profile:
             elif median:
                 sorted_name = sorted(name_array)
                 result[i] = sorted_name[int(np.floor(0.5 * len(subs)))]
+            elif percentile is not None:
+                result[i] = np.percentile(name_array, percentile)
             else:
                 result[i] = (name_array * mass_array).sum() / self['mass'][i]
 

--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -379,7 +379,7 @@ class Profile:
             return self._profiles[name]
             # else :
             #    raise RuntimeError, "Derivatives only possible for profiles of fixed bin width."
-        elif "_percentile" in name and name[:name.find("_percentile")] in self.keys() or name[:name.find("_percentile")] in self.derivable_keys() or name[:name.find("_percentile")] in self.sim.all_keys():
+        elif "_percentile" in name and (name[:name.find("_percentile")] in self.keys() or name[:name.find("_percentile")] in self.derivable_keys() or name[:name.find("_percentile")] in self.sim.all_keys()):
             name_end_ind = name.find("_percentile")
             p = float(name[name_end_ind+11:])
             logger.info("Auto-deriving {0:f}-th percentile of {1}".format(p, name[:name_end_ind]))


### PR DESCRIPTION
For any simulation quantity `qty` (e.g. self defined values using `@pynbody.derived_array`), this pull request introduces the possibility to calculate the percentile of the respective quantity for every bin by invoking `prof['qyt_percentile50']`. This particular case returns the median. The general syntax is the quantity name followed by `"_percentile"` and any string representation of the percentage, e.g. '12.5', '16', '2e1' as long as the respective number is in the range 0...100.
```
prof = pynbody.analysis.profile.Profile(sim)
prof['vphi_percentile16.5']
```