### PR TITLE
skip the mass block if all the particles have masses defined in the header

### DIFF
--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -292,6 +292,10 @@ class GadgetFile(object):
                 if record_size != 256:
                     raise IOError("Bad record size for HEAD in " + filename)
                 t_part = self.header.npart.sum()
+                if ((self.header.npart!=0)*(self.header.mass==0)).sum()==0:
+                    # The "Spec" says that if all the existing particle masses
+                    # are in the header, we shouldn't have a MASS block
+                    self.block_names.remove('MASS')
                 continue
             # Set the partlen, using our amazing heuristics
             success = False

--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -292,7 +292,8 @@ class GadgetFile(object):
                 if record_size != 256:
                     raise IOError("Bad record size for HEAD in " + filename)
                 t_part = self.header.npart.sum()
-                if ((self.header.npart!=0)*(self.header.mass==0)).sum()==0:
+                if  ((not self.format2) and 
+                	((self.header.npart != 0) * (self.header.mass == 0)).sum()==0):
                     # The "Spec" says that if all the existing particle masses
                     # are in the header, we shouldn't have a MASS block
                     self.block_names.remove('MASS')


### PR DESCRIPTION
Hi,

I  have a Gadget file where the masses are only defined in the header and the mass block is absent. In that case pynbody fails when trying to get masses from the snapshot. 
```
In [3]: d=pynbody.load('test_sim/OUTPUTS/snapshot_000')

In [4]: d['mass']
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-b036f6064c1a> in <module>()
----> 1 d['mass']

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/pynbody/snapshot.pyc in __getitem__(self, i)
    273                         try:
    274                             if not self.lazy_load_off:
--> 275                                 self.__load_array_with_magic(i)
    276                             else:
    277                                 raise IOError

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/pynbody/snapshot.pyc in __load_array_with_magic(self, array_name, fam)
    840             else:
    841                 try:
--> 842                     self._load_array(array_name, fam)
    843                 except IOError:
    844                     for fam_x in self.families():

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/pynbody/gadget.pyc in _load_array(self, name, fam)
    902 
    903         if fam is None:
--> 904             self[name] = data.reshape(dims, order='C').view(array.SimArray)
    905             self[name].set_default_units(quiet=True)
    906         else:

ValueError: total size of new array must be unchanged
```
=================

The pull request fixes that. 
Here is the file that shows the problem:
https://www.dropbox.com/s/tyqqn23stkbps0c/snapshot_000?dl=0

Cheers, 
       Sergey