### PR TITLE
added family check when returning loadable arrays

### DIFF
--- a/nose/gadgethdf_test.py
+++ b/nose/gadgethdf_test.py
@@ -28,6 +28,14 @@ def test_standard_arrays() :
         s.gas['rho']
        # s.gas['u']
         s.star['mass']
+
+def test_issue_256() :
+    assert 'pos' in snap.loadable_keys()
+    assert 'pos' in snap.dm.loadable_keys()
+    assert 'pos' in snap.gas.loadable_keys()
+    assert 'He' not in snap.loadable_keys()
+    assert 'He' not in snap.dm.loadable_keys()
+    assert 'He' in snap.gas.loadable_keys()
         
 def test_halo_loading() : 
     """ Check that halo loading works """

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -211,8 +211,12 @@ class GadgetHDFSnap(SimSnap):
         return list(set(l))
 
     def loadable_keys(self, fam=None):
-        return self._loadable_keys
+        if fam is not None:
+            return [x for x in self._loadable_keys if self._family_has_loadable_array(fam, x)]
+        else:
+            return [x for x in self._loadable_keys if self._family_has_loadable_array(None, x)]
 
+        
     @staticmethod
     def _write(self, filename=None):
         raise RuntimeError("Not implemented")


### PR DESCRIPTION
we omitted a check for family arrays when constructing loadable keys as reported in #256 -- this PR adds the few lines from gadget.py to make it work properly. Output is now: 
```ipython
In [1]: import pynbody

In [2]: s =pynbody.load('python_src/pynbody/nose/testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5')

In [3]: s.loadable_keys()
Out[3]: ['pos', 'phi', 'mass', 'vel', 'iord']

In [4]: s.g.loadable_keys()
Out[4]:
['temp',
 u'SmoothedElementAbundance/Helium',
 'rho',
 'Fe',
 u'AExpMaximumEntropy',
 'pos',
 'H',
 'phi',
 u'SmoothedElementAbundance/Oxygen',
 u'SmoothedElementAbundance/Hydrogen',
 'O',
 'Ne',
 u'AExpMaximumTemperature',
 u'InternalEnergy',
 u'SmoothedElementAbundance/Iron',
 'smooth',
 'metals',
 'C',
 u'MetallicityWeightedRedshift',
 u'SmoothedElementAbundance/Carbon',
 'smetals',
 u'StarFormationRate',
 'N',
 'mass',
 u'WindFlag',
 'vel',
 'Mg',
 u'SmoothedElementAbundance/Nitrogen',
 u'MaximumTemperature',
 'Si',
 'He',
 u'MaximumEntropy',
 u'SmoothedElementAbundance/Neon',
 u'SmoothedIronFromSNIa',
 u'IronFromSNIa',
 u'SmoothedElementAbundance/Magnesium',
 u'OnEquationOfState',
 u'SmoothedElementAbundance/Silicon',
 'iord']

In [5]: s.d.loadable_keys()
Out[5]: ['pos', 'phi', 'mass', 'vel', 'iord']

In [6]: s.s.loadable_keys()
Out[6]:
[u'SmoothedElementAbundance/Helium',
 'rho',
 'Fe',
 u'AExpMaximumEntropy',
 'pos',
 u'InitialMass',
 'H',
 'phi',
 u'SmoothedElementAbundance/Oxygen',
 u'SmoothedElementAbundance/Hydrogen',
 'O',
 'Ne',
 u'AExpMaximumTemperature',
 u'SmoothedElementAbundance/Iron',
 'tform',
 'smooth',
 'metals',
 'C',
 u'MetallicityWeightedRedshift',
 u'SmoothedElementAbundance/Carbon',
 'smetals',
 'N',
 'mass',
 u'WindFlag',
 'vel',
 'Mg',
 u'SmoothedElementAbundance/Nitrogen',
 u'MaximumTemperature',
 'Si',
 'He',
 u'MaximumEntropy',
 u'SmoothedElementAbundance/Neon',
 u'SmoothedIronFromSNIa',
 u'IronFromSNIa',
 u'SmoothedElementAbundance/Magnesium',
 u'SmoothedElementAbundance/Silicon',
 'iord']
```