### PR TITLE
Fix to ramses_util to put corrected star particle birth times in ramses output_xxxx dir

### DIFF
--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -434,17 +434,21 @@ def get_tform(sim, part2birth_path=part2birth_path):
 
     for i in range(ncpu):
         try:
-            f = open('%s/birth/birth_%s.out%05d' %
-                     (parent_dir, top._timestep_id, i + 1))
+            f = open('%s/output_%s/birth_%s.out%05d' %
+                     (parent_dir, top._timestep_id, top._timestep_id, i + 1))
         except IOError:
             import os
 
-            os.system("cd %s; mkdir birth;" % (parent_dir))
+            # birth_xxx doesn't exist, create it with ramses part2birth util
+            #os.system("cd %s; mkdir birth;" % (parent_dir))
             with open(os.devnull, 'w') as fnull:
                 exit_code = subprocess.call([part2birth_path, '-inp', 'output_%s' % top._timestep_id],
                                             stdout=fnull, stderr=fnull)
-            f = open('%s/birth/birth_%s.out%05d' %
-                     (parent_dir, top._timestep_id, i + 1))
+                # part2birth put the files in output_<top._timestep_id>
+                #os.system("cd %s; mv output_%s/birth_%s.out%05d %sbirth/;" %
+                #          (parent_dir, top._timestep_id, top._timestep_id, i+1, parent_dir))
+            f = open('%s/output_%s/birth_%s.out%05d' %
+                     (parent_dir, top._timestep_id,top._timestep_id, i + 1))
 
         n = fromfile(f, 'i', 1)
         if n > 0:


### PR DESCRIPTION
This version of the ramses_util.py file creates the birth_xxxx files in the appropriate output_xxxx dir. There was a bug in the previous implementation: the birth files were created in a dir ("birth") as the output directories  -- resulting in (possibly) 100's of thousands of files in a single dir... The code was also not looking for the birth files where ramses_util created them!

This patch ensures the birth files are put in the output directory to which they belong.

Rick