### PR TITLE
Add ability to return the "top level" grp array from an AHF object

### DIFF
--- a/pynbody/halo.py
+++ b/pynbody/halo.py
@@ -839,10 +839,14 @@ class AHFCatalogue(HaloCatalogue):
         """
         self.base[name] = self.get_group_array()
 
-    def get_group_array(self):
+    def get_group_array(self, top_level=False):
         ar = np.zeros(len(self.base), dtype=int)
-        for halo in self._halos.values():
-            ar[halo.get_index_list(self.base)] = halo._halo_id
+        if top_level is False:
+            for halo in self._halos.values():
+                ar[halo.get_index_list(self.base)] = halo._halo_id
+        else:
+            for halo in self._halos.values()[::-1]:
+                ar[halo.get_index_list(self.base)] = halo._halo_id
         return ar
 
     def _setup_children(self):


### PR DESCRIPTION
The previous grp array would include only the largest halo a given particle was associated with. Now the added keyword top_level=True/False to the get_group_array function allows you to return group numbers for the smallest halo a particle is associated with (if top_level is True)