### PR TITLE
make default for rockstar halos sort = True

### DIFF
--- a/pynbody/halo.py
+++ b/pynbody/halo.py
@@ -168,7 +168,7 @@ class RockstarIntermediateCatalogue(HaloCatalogue):
     _halo_type = np.dtype([('id',np.int64),('num_p',np.int64),('indstart',np.int64)])
     _part_type = np.dtype('int64')
 
-    def __init__(self, sim, sort=False, correct=False):
+    def __init__(self, sim, sort=True, correct=False):
         assert isinstance(sim,snapshot.SimSnap)
         self._correct=correct
         HaloCatalogue.__init__(self, sim)


### PR DESCRIPTION
could be important. Make more consistent with other halo catalogues that are ordered by mass, not randomly like the original rockstar output.