### PR TITLE
Numpy 1.10.x fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - PYTHON=2.7  NUMPY_VERSION=1.7.1 CYTHON="cython>=0.20" IPYTHON="ipython=3"
   - PYTHON=2.7  NUMPY_VERSION=1.9.2 CYTHON="cython>=0.20" IPYTHON="ipython>=3"
   - PYTHON=3.4  NUMPY_VERSION=1.9.2 CYTHON="cython>=0.20" IPYTHON="ipython>=3"
-
+  - PYTHON=3.5  NUMPY_VERSION=1.10.4 CYTHON="cython>=0.20" IPYTHON="ipython>=3"
 
 before_install:
 #  - git clone https://github.com/github/git-lfs.git

--- a/nose/array_test.py
+++ b/nose/array_test.py
@@ -93,7 +93,7 @@ def test_iop_units():
 
 
 def test_iop_sanity():
-    x = SA([1, 2, 3, 4])
+    x = SA([1.0, 2.0, 3.0, 4.0])
     x_id = id(x)
     x += 1
     assert id(x) == x_id

--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -410,6 +410,10 @@ class SimArray(np.ndarray):
                 if hasattr(b, 'units'):
                     b.units = None
 
+                if not np.can_cast(b.dtype,self.dtype):
+                    b = np.asarray(b, dtype=x.dtype)
+
+
                 r = add_op(self, b)
 
             return r


### PR DESCRIPTION
Fix compatibility with numpy 1.10.x releases, which seem to enforce stricter casting rules. If a unit conversion changes the dtype, so that an operation which would have succeeded with no unit conversion then fails, we intervene and manually cast back to the original dtype.