### PR TITLE
A quick fix to ensure the type of MASS is the same as POS (fixes #321)

### DIFF
--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -372,9 +372,10 @@ class GadgetFile(object):
             block = GadgetBlock()
             block.length = 0
             block.start = 0
-            # In the header, mass is a double
-            block.partlen = 8
-            block.data_type = np.float64
+
+            # Mass should be the same type as POS (see issue #321)
+            block.data_type = self.blocks[b'POS '].data_type
+            block.partlen = np.dtype(block.data_type).itemsize
             self.blocks[b'MASS'] = block
 
     def get_block_types(self, block, npart):


### PR DESCRIPTION
This is a quick fix to ensure that the `mass` SimArray comes out with the same time as `pos`. It seems that if the snapshot has `pos` as single precision, this can break the `kdtree` generation later on (see #321).

This seems to get things working fine though maybe there is a cleaner way to do this.