### PR TITLE
Update gadget.py

### DIFF
--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -280,7 +280,7 @@ class GadgetFile(object):
         while True:
             block = GadgetBlock()
             (name, block.length) = self.read_block_head(fd)
-            if block.length == 0:
+            if name == "    ":
                 break
             # Do special things for the HEAD block
             if name[0:4] == b"HEAD":


### PR DESCRIPTION
Hi all. Gadget format should not have problems (I belive) with blocks with zero lenghts.

With the `block.length == 0` we basically stop reading the file _after_ we encounter a block of zero length (ignoring all other blocks).

With my check (`name == "    "`) we actually wait for the "fake" null-named block to end.
