### PR TITLE
Projection plots before and after snap.physical_units()

### DIFF
--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -408,7 +408,7 @@ def image(sim, qty='rho', width="10 kpc", resolution=500, units=None, log=True,
             im = im / im2
 
     else:
-        im = sph.render_image(sim, qty, width / 2, resolution, out_units=units,
+        im = (sim.properties['boxsize'].in_units(sim['x'].units))**(3-kernel.h_power)* sph.render_image(sim, qty, width / 2, resolution, out_units=units,
                               kernel=kernel,  z_camera=z_camera, **kwargs)
 
     if fill_nan:


### PR DESCRIPTION
For RAMSES, projection plots after doing snap.physical_units() gives different (and wrong) results than the ones obtained with snap.original_units().

This change seems to solve the problem.