### PR TITLE
Update default_config.ini

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -63,6 +63,7 @@ star: PartType4
 [gadgethdf-name-mapping]
 Coordinates: pos
 Velocity: vel
+Velocities: vel
 ParticleIDs: iord
 Masses: mass
 Mass: mass

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -67,6 +67,7 @@ Velocities: vel
 ParticleIDs: iord
 Masses: mass
 Mass: mass
+InternalEnergy: u
 Temperature: temp
 Metallicity: metals
 SmoothedMetallicity: smetals


### PR DESCRIPTION
As noted in #207, 'vel' should be able to be mapped also with 'Velocities', not only with 'Velocity'.
With this change, GIZMO snapshot file can be properly loaded with 'vel' key.
In addition, the name mapping of 'InternalEnergy' to the key 'u' seems missing.