### PR TITLE
Fortran file reading fix

### DIFF
--- a/pynbody/util.py
+++ b/pynbody/util.py
@@ -624,7 +624,7 @@ def read_fortran(f, dtype, n=1):
 def skip_fortran(f, n=1):
     for i in xrange(n):
         alen = np.fromfile(f, _head_type, 1)
-        f.seek(alen, 1)
+        f.seek(alen[0], 1)
         alen2 = np.fromfile(f, _head_type, 1)
         assert alen == alen2
 


### PR DESCRIPTION
Without this line I had a problem while reading a RAMSES output:

```
  File "/users/me/hast/hast.py", line 367, in select
    sim_zinit = sim_zinit[np.argsort(sim_zinit['iord'])]
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/__init__.py", line 263, in __getitem__
    return self._get_array_with_lazy_actions(i)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/__init__.py", line 354, in _get_array_with_lazy_actions
    self.__load_if_required(name)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/__init__.py", line 365, in __load_if_required
    self.__load_array_and_perform_postprocessing(name)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/__init__.py", line 889, in __load_array_and_perform_postprocessing
    self._load_array(array_name, fam_x)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/ramses.py", line 721, in _load_array
    self._load_particle_block(array_name)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/ramses.py", line 654, in _load_particle_block
    self._nstar)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/ramses.py", line 70, in remote_map
    return map(*args[1:], **kwargs)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/ramses.py", line 65, in q
    r = fn(*args)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/snapshot/ramses.py", line 110, in _cpui_load_particle_block
    skip_fortran(f, offset)
  File "/users/me/.local/lib/python2.7/site-packages/pynbody/util.py", line 627, in skip_fortran
    f.seek(alen, 1)
TypeError: only integer scalar arrays can be converted to a scalar index
```