### PR TITLE
Spectrograph plotting routine

### DIFF
--- a/pynbody/analysis/__init__.py
+++ b/pynbody/analysis/__init__.py
@@ -4,6 +4,7 @@ from . import ionfrac, pkdgrav_cosmo
 from . import ramses_util
 from . import hifrac
 from . import interpolate
+from . import spectrograph
 
 from .decomp import decomp
 from .hmf import halo_mass_function

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -58,7 +58,7 @@ def calc_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
 
     nhalos = len(halos)
 
-    unit_factor = units.kpc.in_units(halo['x'], **halo.conversion_context())
+    unit_factor = units.kpc.in_units(halos[0]['x'], **halo.conversion_context())
 
     W = np.zeros((radial_bins, nhalos))*(1. + 1j)
     r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)*unit_factor

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -18,7 +18,7 @@ def calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
     =================
 
     This function calculates spectrograph data for a sequence of simulation outputs (equally
-    spaced in time). It is called by pynbody.plot.spectrographs().
+    spaced in time). It is called by pynbody.plot.spectrographs module.
 
     **Input**:
 

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -9,6 +9,7 @@ in galaxy disks.
 
 import numpy as np
 from . import profile, angmom
+from .. import units
 
 def calc_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=20,
     radial_bins=10, aligned=False, family='stars'):
@@ -56,8 +57,10 @@ def calc_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=
 
     nsims = len(sims)
 
+    unit_factor = pynbody.units.kpc.in_units(sim['x'], **sim.conversion_context())
+
     W = np.zeros((radial_bins, nsims))*(1. + 1j)
-    r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)
+    r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)*unit_factor
     omega_bin_edges = np.linspace(*frequency_range, num=frequency_bins+1)
     omega = np.array([omega_bin_edges[:-1] + .5*np.diff(omega_bin_edges)])
     omega = np.array([omega.repeat(W.shape[0], axis=0)]).repeat(W.shape[1], axis=0).T

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -1,0 +1,112 @@
+"""
+spectrographs
+=============
+
+Calculate spectrographs of non-axisymmetric perturbations (bars/spirals)
+in galaxy disks.
+
+"""
+
+import numpy as np
+from . import profile, angmom
+
+def calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
+    radial_range=[0, 20], radial_bins=10, aligned=False, family='stars'):
+    """
+    
+    calc_spectrograph
+    =================
+
+    This function calculates spectrograph data for a sequence of simulation outputs (equally
+    spaced in time). It is called by pynbody.plot.spectrographs().
+
+    **Input**:
+
+    *sims* : an ordered list of simulation snapshots that have to be equally spaced in time.
+        The number of outputs in the list is ideally not even.
+
+    *mode* : the azimuthal multiplicity of which the spectrograph is to be calculated
+
+    *frequency_range* ([0, 400]) : Range of frequencies to be considered in 1/Gyr. This is
+        the frequency at which the pattern recurs, i.e. the mode-fold of the pattern speed.
+
+    *frequency_bins* (20) : Number of bins to split the frequency range into
+
+    *radial_range* ([0, 400]) : Range of radii to be considered in kpc
+
+    *radial_bins* (20) : Number of bins to split the radial range into
+
+    *aligned* (False) : If False, the snapshot will be centered on the central galaxy and
+        its disk will be aligned to be in the xy-plane. The snapshots are only modified for this
+        analysis. After the routine they will be in their original state. If true, the snapshot
+        is assumed to be aligned.
+
+    *family* ('stars') : Consider only the respective family portion of the snapshots.
+
+    **Returns**:
+
+    *spectrum* : 2D array, the first index represents the radial, the second index the
+        frequency coordinate.
+
+    """
+
+    times = [sim.properties['time'].in_units('Gyr') for sim in sims]
+    dts = np.diff(times)
+    test_dts(dts)
+
+    nsims = len(sims)
+
+    W = np.zeros((radial_bins, nsims))*(1. + 1j)
+    r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)
+    omega_bin_edges = np.linspace(*frequency_range, num=frequency_bins+1)
+    omega = np.array([omega_bin_edges[:-1] + .5*np.diff(omega_bin_edges)])
+    omega = np.array([omega.repeat(W.shape[0], axis=0)]).repeat(W.shape[1], axis=0).T
+    for i, sim in enumerate(sims):
+        s = {'stars': sim.s, 'gas': sim.g, 'dark': sim.d}[family]
+        if not aligned:
+            with angmom.faceon(s, vcen=0):
+                W[:,i] = calc_fourier_modes(s, mode, r_bin_edges)
+        else:
+            W[:,i] = calc_fourier_modes(s, mode, r_bin_edges)
+    W *= np.hanning(nsims)
+    Wf = np.exp(1j*omega*times)*W
+    return (.5*(Wf[:,:,:-1]+Wf[:,:,1:])*dts).sum(axis=2)
+
+def calc_fourier_modes(sim, mode, r_bin_edges):
+    """
+
+    Calculate Fourier coefficients of azimuthal mass distribution of multiplicity mode for bins
+    according to given bin edges.
+
+    **Input**:
+
+    *sim* : Simulation snapshot
+
+    *mode* : Multiplicity of the perturbation
+
+    *r_bin_edges* : Radial bin edges in kpc
+
+    """
+
+    prof = profile.Profile(sim, bins=r_bin_edges)
+    return prof['fourier']['c'][mode]
+
+def test_dts(dts, tol=1e-10):
+
+    """
+
+    test_dts
+    ========
+
+    Simple routine to test whether times are equally spaced. Raises an error if not.
+
+    **Input**:
+
+    *dts* : Array of time differences
+
+    *tol* (1e-10) : relative tolerance (std/mean)
+
+    """
+
+    if np.abs(dts.std()/dts.mean()) > tol:
+        raise ValueError("The simulation outputs are not equally spaced in time or not ordered.")

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -94,7 +94,7 @@ def calc_fourier_modes(sim, mode, r_bin_edges):
     prof = profile.Profile(sim, bins=r_bin_edges)
     return prof['fourier']['c'][mode]
 
-def test_dts(dts, tol=1e-10):
+def test_dts(dts, tol=1e-6):
 
     """
 
@@ -107,7 +107,7 @@ def test_dts(dts, tol=1e-10):
 
     *dts* : Array of time differences
 
-    *tol* (1e-10) : relative tolerance (std/mean)
+    *tol* (1e-6) : relative tolerance (std/mean)
 
     """
 

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -58,7 +58,7 @@ def calc_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
 
     nhalos = len(halos)
 
-    unit_factor = pynbody.units.kpc.in_units(halo['x'], **halo.conversion_context())
+    unit_factor = units.kpc.in_units(halo['x'], **halo.conversion_context())
 
     W = np.zeros((radial_bins, nhalos))*(1. + 1j)
     r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)*unit_factor

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -10,8 +10,8 @@ in galaxy disks.
 import numpy as np
 from . import profile, angmom
 
-def calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
-    radial_range=[0, 20], radial_bins=10, aligned=False, family='stars'):
+def calc_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=20,
+    radial_bins=10, aligned=False, family='stars'):
     """
     
     calc_spectrograph
@@ -27,12 +27,12 @@ def calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
 
     *mode* : the azimuthal multiplicity of which the spectrograph is to be calculated
 
-    *frequency_range* ([0, 400]) : Range of frequencies to be considered in 1/Gyr. This is
+    *frequency_range* : Range of frequencies to be considered in 1/Gyr. This is
         the frequency at which the pattern recurs, i.e. the mode-fold of the pattern speed.
 
-    *frequency_bins* (20) : Number of bins to split the frequency range into
+    *radial_range* : Range of radii to be considered in kpc
 
-    *radial_range* ([0, 400]) : Range of radii to be considered in kpc
+    *frequency_bins* (20) : Number of bins to split the frequency range into
 
     *radial_bins* (20) : Number of bins to split the radial range into
 

--- a/pynbody/analysis/spectrograph.py
+++ b/pynbody/analysis/spectrograph.py
@@ -58,7 +58,7 @@ def calc_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
 
     nhalos = len(halos)
 
-    unit_factor = units.kpc.in_units(halos[0]['x'], **halo.conversion_context())
+    unit_factor = units.kpc.in_units(halos[0]['x'].units, **halos[0].conversion_context())
 
     W = np.zeros((radial_bins, nhalos))*(1. + 1j)
     r_bin_edges = np.linspace(*radial_range, num=radial_bins+1)*unit_factor

--- a/pynbody/plot/__init__.py
+++ b/pynbody/plot/__init__.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from . import generic, stars, gas, profile, metals, util
+from . import generic, stars, gas, profile, metals, util, spectrograph
 import imp
 
 imp.reload(profile)

--- a/pynbody/plot/__init__.py
+++ b/pynbody/plot/__init__.py
@@ -9,6 +9,7 @@ imp.reload(stars)
 imp.reload(gas)
 imp.reload(metals)
 imp.reload(util)
+imp.reload(spectrograph)
 
 from .profile import rotation_curve, fourier_profile, density_profile
 from .generic import hist2d, gauss_kde, fourier_map, qprof

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -1,0 +1,85 @@
+"""
+spectrographs
+=============
+
+Plot spectrographs of non-axisymmetric perturbations (bars/spirals)
+in galaxy disks.
+
+"""
+
+import numpy as np
+#import matplotlib
+from matplotlib import pyplot as plt
+import warnings
+
+from ..analysis import calc_spectrograph from spectrograph #profile, angmom, halo
+#from .. import filt, units, config, array
+#from .sph import image
+#from .. import units as _units
+
+#import logging
+#logger = logging.getLogger('pynbody.plot.stars')
+
+def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
+    radial_range=[0, 20], radial_bins=10, aligned=False, family='stars', ax=None,
+    fig_kw=None, ax_kw=None):
+    """
+    
+    plot_spectrograph
+    =================
+
+    This is a wrapper to plot the results of spectral analysis of non-axisymmetric perturbation
+    (bars/spirals) in galaxy disks. It plots the results of the pynbody.analysis.spectrograph
+    module.
+
+    **Input**:
+
+    *sims* : an ordered list of simulation snapshots that have to be equally spaced in time.
+        The number of outputs in the list is ideally not even.
+
+    *mode* : the azimuthal multiplicity of which the spectrograph is to be calculated
+
+    *frequency_range* ([0, 400]) : Range of frequencies to be considered in 1/Gyr. This is
+        the frequency at which the pattern recurs, i.e. the mode-fold of the pattern speed.
+
+    *frequency_bins* (20) : Number of bins to split the frequency range into
+
+    *radial_range* ([0, 400]) : Range of radii to be considered in kpc
+
+    *radial_bins* (20) : Number of bins to split the radial range into
+
+    *aligned* (False) : If False, the snapshot will be centered on the central galaxy and
+        its disk will be aligned to be in the xy-plane. The snapshots are only modified for this
+        analysis. After the routine they will be in their original state. If true, the snapshot
+        is assumed to be aligned.
+
+    *family* ('stars') : Consider only the respective family portion of the snapshots.
+
+    *ax* (None) : The axis instance to be used for plotting.
+
+    *fig_kw* (None) : Keywords for figure instance
+
+    *ax_kw* (None) : Keywords for axis instance
+
+    **Returns**:
+
+    *fig* : The figure instance used for plotting.
+
+    *ax* : The axis instance used for plotting.
+
+    """
+
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, subplot_kw=ax_kw, **fig_kw)
+    else:
+        fig = ax.get_figure()
+
+    spectrum = calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
+        radial_range=[0, 20], radial_bins=10, aligned=False, family='stars')
+
+    extent = list(radial_range) + list(np.array(frequency_range)/mode)
+    aspect = np.diff(exent[:2])/np.diff(extent[2:])
+    ax.imshow(np.abs(spec), origin='lower', extent=extent, aspect=aspect)
+    ax.set_xlabel(
+
+    return fig, ax

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -86,7 +86,7 @@ def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
         radial_range=radial_range, radial_bins=radial_bins, aligned=aligned, family=family)
 
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
-    aspect = np.diff(extent[:2]).astype(np.float)/np.diff(extent[2:])
+    aspect = (.0+extent[1]-extent[0])/(extent[3]-extent[2])
     plot_spec = np.abs(spectrum)
     ax.imshow(plot_spec, origin='lower', extent=extent, aspect=aspect,
         norm=matplotlib.colors.LogNorm(), cmap=cmap, vmin=plot_spec.max()*10**(-dynamic_range))

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -20,7 +20,7 @@ from ..analysis.spectrograph import calc_spectrograph #profile, angmom, halo
 #import logging
 #logger = logging.getLogger('pynbody.plot.stars')
 
-def plot_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=20,
+def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins=20,
     radial_bins=20, pattern_speed=True, aligned=False, family='stars', ax=None, fig_kw=None,
     ax_kw=None, cmap='viridis'):
     """
@@ -34,8 +34,9 @@ def plot_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=
 
     **Input**:
 
-    *sims* : an ordered list of simulation snapshots that have to be equally spaced in time.
-        The number of outputs in the list is ideally not even.
+    *halos* : an ordered list of subviews of simulation snapshots that contain the halo in
+        question. They have to be equally spaced in time. The number of outputs in the list
+        is ideally not even.
 
     *mode* : the azimuthal multiplicity of which the spectrograph is to be calculated
 
@@ -79,7 +80,7 @@ def plot_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=
     else:
         fig = ax.get_figure()
 
-    spectrum = calc_spectrograph(sims, mode, frequency_range=frequency_range, frequency_bins=frequency_bins,
+    spectrum = calc_spectrograph(halos, mode, frequency_range=frequency_range, frequency_bins=frequency_bins,
         radial_range=radial_range, radial_bins=radial_bins, aligned=False, family='stars')
 
     extent = list(radial_range) + list(np.array(frequency_range)/mode)

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -86,7 +86,7 @@ def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
     aspect = np.diff(extent[:2])/np.diff(extent[2:])
     ax.imshow(np.abs(spectrum), origin='lower', extent=extent, aspect=aspect,
-        norm=matplotlib.color.LogNorm(), cmap=cmap)
+        norm=matplotlib.colors.LogNorm(), cmap=cmap)
     ax.set_xlabel(r'$R$ [kpc]')
     ax.set_ylabel(r'pattern speed [1/Gyr]')
     ax.text(.95, .95, r'$m={0:d}$'.format(mode), ha='right', va='top', transform=ax.transAxes)

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -8,7 +8,7 @@ in galaxy disks.
 """
 
 import numpy as np
-#import matplotlib
+import matplotlib
 from matplotlib import pyplot as plt
 import warnings
 
@@ -20,9 +20,9 @@ from ..analysis.spectrograph import calc_spectrograph #profile, angmom, halo
 #import logging
 #logger = logging.getLogger('pynbody.plot.stars')
 
-def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
-    radial_range=[0, 20], radial_bins=10, aligned=False, family='stars', ax=None,
-    fig_kw=None, ax_kw=None):
+def plot_spectrograph(sims, mode, frequency_range, radial_range, frequency_bins=20,
+    radial_bins=20, pattern_speed=True, aligned=False, family='stars', ax=None, fig_kw=None,
+    ax_kw=None, cmap='viridis'):
     """
     
     plot_spectrograph
@@ -39,14 +39,17 @@ def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
 
     *mode* : the azimuthal multiplicity of which the spectrograph is to be calculated
 
-    *frequency_range* ([0, 400]) : Range of frequencies to be considered in 1/Gyr. This is
+    *frequency_range* : Range of frequencies to be considered in 1/Gyr. This is
         the frequency at which the pattern recurs, i.e. the mode-fold of the pattern speed.
 
     *frequency_bins* (20) : Number of bins to split the frequency range into
 
-    *radial_range* ([0, 400]) : Range of radii to be considered in kpc
+    *radial_range* : Range of radii to be considered in kpc
 
     *radial_bins* (20) : Number of bins to split the radial range into
+
+    *pattern_speed* (True) : If true, the actual pattern speed is plotted on the y-axis instead of
+        frequency at which the pattern itself repeats (the mode-fold of the pattern speed).
 
     *aligned* (False) : If False, the snapshot will be centered on the central galaxy and
         its disk will be aligned to be in the xy-plane. The snapshots are only modified for this
@@ -61,6 +64,8 @@ def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
 
     *ax_kw* (None) : Keywords for axis instance
 
+    *cmap* ('viridis') : Color map to use
+
     **Returns**:
 
     *fig* : The figure instance used for plotting.
@@ -74,12 +79,13 @@ def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
     else:
         fig = ax.get_figure()
 
-    spectrum = calc_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
-        radial_range=[0, 20], radial_bins=10, aligned=False, family='stars')
+    spectrum = calc_spectrograph(sims, mode, frequency_range=frequency_range, frequency_bins=frequency_bins,
+        radial_range=radial_range, radial_bins=radial_bins, aligned=False, family='stars')
 
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
-    aspect = np.diff(exent[:2])/np.diff(extent[2:])
-    ax.imshow(np.abs(spec), origin='lower', extent=extent, aspect=aspect)
+    aspect = np.diff(extent[:2])/np.diff(extent[2:])
+    ax.imshow(np.abs(spectrum), origin='lower', extent=extent, aspect=aspect,
+        norm=matplotlib.color.LogNorm(), cmap=cmap)
     ax.set_xlabel(r'$R$ [kpc]')
     ax.set_ylabel(r'pattern speed [1/Gyr]')
     ax.text(.95, .95, r'$m={0:d}$'.format(mode), ha='right', va='top', transform=ax.transAxes)

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -83,10 +83,10 @@ def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
         fig = ax.get_figure()
 
     spectrum = calc_spectrograph(halos, mode, frequency_range=frequency_range, frequency_bins=frequency_bins,
-        radial_range=radial_range, radial_bins=radial_bins, aligned=False, family='stars')
+        radial_range=radial_range, radial_bins=radial_bins, aligned=aligned, family=family)
 
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
-    aspect = np.diff(extent[:2])/np.diff(extent[2:])
+    aspect = np.diff(extent[:2]).astype(np.float)/np.diff(extent[2:])
     plot_spec = np.abs(spectrum)
     ax.imshow(plot_spec, origin='lower', extent=extent, aspect=aspect,
         norm=matplotlib.colors.LogNorm(), cmap=cmap, vmin=plot_spec.max()*10**(-dynamic_range))

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -12,7 +12,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 import warnings
 
-from ..analysis import calc_spectrograph from spectrograph #profile, angmom, halo
+from ..analysis import calc_spectrograph.spectrograph #profile, angmom, halo
 #from .. import filt, units, config, array
 #from .sph import image
 #from .. import units as _units

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -21,8 +21,8 @@ from ..analysis.spectrograph import calc_spectrograph #profile, angmom, halo
 #logger = logging.getLogger('pynbody.plot.stars')
 
 def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins=20,
-    radial_bins=20, pattern_speed=True, aligned=False, family='stars', ax=None, fig_kw=None,
-    ax_kw=None, cmap='viridis'):
+    radial_bins=20, pattern_speed=True, aligned=False, family='stars', ax=None, fig_kw={},
+    ax_kw={}, cmap='viridis', dynamic_range=1):
     """
     
     plot_spectrograph
@@ -61,11 +61,13 @@ def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
 
     *ax* (None) : The axis instance to be used for plotting.
 
-    *fig_kw* (None) : Keywords for figure instance
+    *fig_kw* ({}) : Keywords for figure instance
 
-    *ax_kw* (None) : Keywords for axis instance
+    *ax_kw* ({}) : Keywords for axis instance
 
     *cmap* ('viridis') : Color map to use
+
+    *dynamic_range (1) : Dynamic range to be plotted in log-scale (orders of magnitude)
 
     **Returns**:
 
@@ -85,8 +87,9 @@ def plot_spectrograph(halos, mode, frequency_range, radial_range, frequency_bins
 
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
     aspect = np.diff(extent[:2])/np.diff(extent[2:])
-    ax.imshow(np.abs(spectrum), origin='lower', extent=extent, aspect=aspect,
-        norm=matplotlib.colors.LogNorm(), cmap=cmap)
+    plot_spec = np.abs(spectrum)
+    ax.imshow(plot_spec, origin='lower', extent=extent, aspect=aspect,
+        norm=matplotlib.colors.LogNorm(), cmap=cmap, vmin=plot_spec.max()*10**(-dynamic_range))
     ax.set_xlabel(r'$R$ [kpc]')
     ax.set_ylabel(r'pattern speed [1/Gyr]')
     ax.text(.95, .95, r'$m={0:d}$'.format(mode), ha='right', va='top', transform=ax.transAxes)

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -80,6 +80,8 @@ def plot_spectrograph(sims, mode, frequency_range=[0, 400], frequency_bins=20,
     extent = list(radial_range) + list(np.array(frequency_range)/mode)
     aspect = np.diff(exent[:2])/np.diff(extent[2:])
     ax.imshow(np.abs(spec), origin='lower', extent=extent, aspect=aspect)
-    ax.set_xlabel(
+    ax.set_xlabel(r'$R$ [kpc]')
+    ax.set_ylabel(r'pattern speed [1/Gyr]')
+    ax.text(.95, .95, r'$m={0:d}$'.format(mode), ha='right', va='top', transform=ax.transAxes)
 
     return fig, ax

--- a/pynbody/plot/spectrograph.py
+++ b/pynbody/plot/spectrograph.py
@@ -12,7 +12,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 import warnings
 
-from ..analysis import calc_spectrograph.spectrograph #profile, angmom, halo
+from ..analysis.spectrograph import calc_spectrograph #profile, angmom, halo
 #from .. import filt, units, config, array
 #from .sph import image
 #from .. import units as _units


### PR DESCRIPTION
I added a plotting routine that plots spectrographs from azimuthal Fourier decompositions of disk outputs that are equally spaced in time and have a small time difference between the respective outputs.

It is a first working example that is very slow at this point. It needs some speedup. I see potential for a speedup in the following points:

- The azimuthal Fourier decomposition of the individual snapshots could be done in parallel
- In case the results for different multiplicities (`mode`) are needed they would have to be calculated separately for each case in the current version. We should come up with a more clever way to exploit the fact that the `Profile` class does the azimuthal Fourier decomposition for all multiplicities simultaneously.

I would need some suggestions on how to do this more efficiently.