### PR TITLE
Fixes issue #385

### DIFF
--- a/pynbody/analysis/luminosity.py
+++ b/pynbody/analysis/luminosity.py
@@ -155,4 +155,4 @@ def half_light_r(sim, band='v'):
         else:
             min_low_r = test_r
 
-    return test_r * sim.star['r'].units
+    return test_r


### PR DESCRIPTION
The squared units from #385 are corrected.

If it really is due to the changed behavior of `np.max()` and `np.min()` in pynbody this bug has been around for a long time. How come no one has noticed it yet?