### PR TITLE
Reduce memory usage for active AHF halos

### DIFF
--- a/nose/snapshot_test.py
+++ b/nose/snapshot_test.py
@@ -263,3 +263,8 @@ def test_nd_array_slicing():
 
     # rho doesn't exist in f.loadable_keys(), only f.gas.loadable_keys():
     assert not f._array_name_implies_ND_slice('rho_x')
+
+def test_index_list():
+    f = pynbody.load("testdata/g15784.lr.01024")
+    h = f.halos()
+    index_list = h[1].get_index_list(f)

--- a/pynbody/halo.py
+++ b/pynbody/halo.py
@@ -1091,6 +1091,7 @@ class AHFCatalogue(HaloCatalogue):
             if not isinstance(f, gzip.GzipFile):
                 data = (np.fromfile(
                     f, dtype=int, sep=" ", count=nparts * 2).reshape(nparts, 2))[:, 0]
+                data = np.ascontiguousarray(data)
             else:
                 # unfortunately with gzipped files there does not
                 # seem to be an efficient way to load nparts lines


### PR DESCRIPTION
From 24 to 16 bytes per particle