### PR TITLE
ensure that the group array is returned as integers

### DIFF
--- a/pynbody/halo.py
+++ b/pynbody/halo.py
@@ -1002,7 +1002,7 @@ class AHFCatalogue(HaloCatalogue):
 
                 ar[id_t] = hcnt[cnt]
             cnt += 1
-        return ar
+        return ar.astype(np.int)
 
     def _setup_children(self):
         """


### PR DESCRIPTION
as it is, the group array is returned as floats which can cause issues, e.g. in bridge