### PR TITLE
fix the bug on vr calculation in derived.py

### DIFF
--- a/pynbody/derived.py
+++ b/pynbody/derived.py
@@ -38,7 +38,7 @@ def rxy(self):
 @SimSnap.derived_quantity
 def vr(self):
     """Radial velocity"""
-    return (self['pos'] * self['vel']).sum(axis=1) / self['r']
+    return np.sqrt(((self['pos'] * self['vel'])**2).sum(axis=1)) / self['r']
 
 
 @SimSnap.derived_quantity


### PR DESCRIPTION
In original derived.py, the way to calculate radial velocity vr is

vr = (vx*x + vy*y + vz*z) / r

However, it is not true, the correct way should be

vr = sqrt(vx^2*x^2 + vy^2*y^2 + vz^2*z^2) / r.

I replace the old code 
`return (self['pos'] * self['vel']).sum(axis=1) / self['r']`
by
`return np.sqrt(((self['pos'] * self['vel'])**2).sum(axis=1)) / self['r']`
in line 41 of derived.py
