### PR TITLE
Fix bug in auto-importing plot module

### DIFF
--- a/nose/import_test.py
+++ b/nose/import_test.py
@@ -1,0 +1,5 @@
+def test_import_plot_module():
+    import pynbody
+    pl_dir = dir(pynbody.plot)
+    im = pynbody.plot.sph.image
+    assert callable(im)

--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -33,7 +33,8 @@ class PlotModuleProxy(object):
     def _do_import(self):
         global plot
         del plot
-        from . import plot
+        from . import plot as plot_module
+        plot = plot_module
 
     def __hasattr__(self, key):
         self._do_import()
@@ -41,11 +42,18 @@ class PlotModuleProxy(object):
 
     def __getattr__(self, key):
         self._do_import()
+        global plot
         return getattr(plot, key)
 
     def __setattr__(self, key, value):
         self._do_import()
+        global plot
         return setattr(plot, key, value)
+
+    def __dir__(self):
+        self._do_import()
+        global plot
+        return dir(plot)
 
     def __repr__(self):
         return "<Unloaded plot module>"


### PR DESCRIPTION
Calling dir(pynbody.plot) before accessing any members would prevent the auto-import from subsequently taking place.

This was particularly problematic when used with ipython which automatically calls dir() for command-line completion purposes.