### PR TITLE
Fix issue with HOPCatalogue + precalculate

### DIFF
--- a/nose/utils_test.py
+++ b/nose/utils_test.py
@@ -144,3 +144,10 @@ def test_invert():
     Minv = pynbody.util.rational_matrix_inv(M)
 
     assert (np.dot(Minv,M)==np.diag([1]*5)).all()
+
+def test_find_boundaries():
+    # regression test for failure of find_boundaries when negative indices are present
+
+    our_numbers = np.array([-1,-1,0,0,0,1,2,2,3,3,5,5,5], dtype=np.int32)
+    boundaries = pynbody.util.find_boundaries(our_numbers)
+    assert (boundaries==[2,5,6,8,-1,10]).all()

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -32,10 +32,9 @@ def find_boundaries(np.ndarray[fused_int, ndim=1] ordered) :
     cdef np.ndarray[fused_int, ndim=1] boundaries = np.zeros(ordered[len(ordered)-1]+1,dtype=ordered.dtype) - 1
     cdef int n, size = len(ordered), current=ordered[0]-1
 
-    ordered[0] = 0
     with nogil :
         for n in range(size) :
-            if current<ordered[n] :
+            if ordered[n]>=0 and current<ordered[n] :
                 current = ordered[n]
                 boundaries[current] = n
 


### PR DESCRIPTION
When precalculating the HOPCatalogue indices, a tacit assumption was
made that there were no halos with index -1. This was false, leading to
halo 0 containing a bunch of intergalactic particles.

Added unit test.