### PR TITLE
Introduce a common function to retrieve the `eps` quantity

### DIFF
--- a/nose/gravity_test.py
+++ b/nose/gravity_test.py
@@ -40,9 +40,19 @@ def test_gravity_float():
     pynbody.gravity.calc.all_direct(f)
 
 
-def test_eps_retrieval_unit():
+def test_eps_retrieval_str():
     f = pynbody.load("testdata/test_g2_snap.0")
     f.properties['eps'] = "0.3 kpc"
+    pynbody.gravity.calc.all_direct(f)
+    true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
+                            -0.06739005, -0.06748439, -0.0695245,
+                            -0.06803885, -0.0679833,  -0.07277965, -0.07189107])
+    npt.assert_allclose(f['phi'][:10], true_phi_10)
+
+
+def test_eps_retrieval_unit():
+    f = pynbody.load("testdata/test_g2_snap.0")
+    f.properties['eps'] = 0.3 * pynbody.units.kpc
     pynbody.gravity.calc.all_direct(f)
     true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
                             -0.06739005, -0.06748439, -0.0695245,

--- a/nose/gravity_test.py
+++ b/nose/gravity_test.py
@@ -38,3 +38,23 @@ def test_gravity_float():
     f['eps'] = np.ones(100,dtype=np.float32)
     f['mass'] = np.ones(100,dtype=np.float32)
     pynbody.gravity.calc.all_direct(f)
+
+
+def test_eps_retrieval_unit():
+    f = pynbody.load("testdata/test_g2_snap.0")
+    f.properties['eps'] = "0.3 kpc"
+    pynbody.gravity.calc.all_direct(f)
+    true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
+                            -0.06739005, -0.06748439, -0.0695245,
+                            -0.06803885, -0.0679833,  -0.07277965, -0.07189107])
+    npt.assert_allclose(f['phi'][:10], true_phi_10)
+
+
+def test_eps_retrieval_number():
+    f = pynbody.load("testdata/test_g2_snap.0")
+    f.properties['eps'] = 0.3
+    pynbody.gravity.calc.all_direct(f)
+    true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
+                            -0.06739005, -0.06748439, -0.0695245,
+                            -0.06803885, -0.0679833,  -0.07277965, -0.07189107])
+    npt.assert_allclose(f['phi'][:10], true_phi_10)

--- a/nose/test_profile.py
+++ b/nose/test_profile.py
@@ -34,3 +34,27 @@ def test_fourier_profile():
 
     assert(np.all(p['fourier']['amp'][2,4:20] > 0.1))
     assert(np.allclose(np.abs(p['fourier']['phi'][2,4:20]/2), np.pi/4.0, rtol=0.05))
+
+
+def test_potential_profile_fp64():
+    f = pynbody.new(100)
+    coords = np.random.normal(size=(100,3))
+    del f['pos']
+    del f['mass']
+    f['pos'] = np.array(coords,dtype=np.float64)
+    f['eps'] = np.ones(100,dtype=np.float64)
+    f['mass'] = np.ones(100,dtype=np.float64)
+    p = pynbody.analysis.profile.Profile(f, nbins=50)
+    p['pot']
+
+
+def test_potential_profile_fp32():
+    f = pynbody.new(100)
+    coords = np.random.normal(size=(100,3))
+    del f['pos']
+    del f['mass']
+    f['pos'] = np.array(coords,dtype=np.float32)
+    f['eps'] = np.ones(100,dtype=np.float32)
+    f['mass'] = np.ones(100,dtype=np.float32)
+    p = pynbody.analysis.profile.Profile(f, nbins=50)
+    p['pot']

--- a/pynbody/gravity/_gravity.pyx
+++ b/pynbody/gravity/_gravity.pyx
@@ -2,6 +2,7 @@
 
 cimport cython
 from pynbody import units, array, config, openmp
+from pynbody.util import get_eps
 import numpy as np
 cimport numpy as np
 DTYPE = np.double
@@ -10,7 +11,7 @@ ctypedef fused DTYPE_t:
     np.float32_t
     np.float64_t
 
-cdef extern from "math.h" nogil :
+cdef extern from "math.h" nogil:
       double sqrt(double)
       float sqrt(float)
 
@@ -35,6 +36,8 @@ def direct(f, np.ndarray[DTYPE_t, ndim=2] ipos, eps=None, int num_threads = 0):
 
     openmp.set_threads(num_threads)
 
+    if eps is None:
+        eps = get_eps(f)
 
     cdef unsigned int nips = len(ipos)
     cdef np.ndarray[DTYPE_t, ndim=2] m_by_r2 = np.zeros((nips,3), dtype = ipos.dtype)
@@ -42,12 +45,12 @@ def direct(f, np.ndarray[DTYPE_t, ndim=2] ipos, eps=None, int num_threads = 0):
     cdef np.ndarray[DTYPE_t, ndim=2] pos = f['pos'].view(np.ndarray)
     cdef np.ndarray[DTYPE_t, ndim=1] mass = f['mass'].view(np.ndarray)
     cdef unsigned int n = len(mass)
-    cdef np.ndarray[DTYPE_t, ndim=1] epssq = f['eps']*f['eps']
+    cdef np.ndarray[DTYPE_t, ndim=1] epssq = eps * eps
 
     cdef unsigned int pi, i
     cdef double dx, dy, dz, mass_i, epssq_i, drsoft, drsoft3
 
-    for pi in prange(nips,nogil=True,schedule='static'):
+    for pi in prange(nips, nogil=True, schedule='static'):
         for i in range(n):
             mass_i = mass[i]
             epssq_i = epssq[i]

--- a/pynbody/gravity/calc.py
+++ b/pynbody/gravity/calc.py
@@ -1,7 +1,7 @@
 from .. import units
 from .. import array
 from .. import config
-from ..util import get_eps
+from ..util import get_eps, eps_as_simarray
 
 import math
 import tree
@@ -84,6 +84,8 @@ def midplane_rot_curve(f, rxy_points, eps=None, mode=config['gravity_calculation
 
     if eps is None:
         eps = get_eps(f)
+    elif isinstance(eps, (str, units.UnitBase)):
+        eps = eps_as_simarray(f, eps)
 
     # u_out = (units.G * f['mass'].units / f['pos'].units)**(1,2)
 
@@ -137,6 +139,8 @@ def midplane_potential(f, rxy_points, eps=None, mode=config['gravity_calculation
 
     if eps is None:
         eps = get_eps(f)
+    elif isinstance(eps, (str, units.UnitBase)):
+        eps = eps_as_simarray(f, eps)
 
     u_out = units.G * f['mass'].units / f['pos'].units
 

--- a/pynbody/units.py
+++ b/pynbody/units.py
@@ -113,7 +113,6 @@ import keyword
 import numpy as np
 from . import backcompat
 from .backcompat import fractions
-from . import util
 import functools
 
 Fraction = fractions.Fraction
@@ -611,6 +610,8 @@ class CompositeUnit(UnitBase):
         # any
         # solution would not be unique.
         M_T_M = np.dot(matrix.transpose(), matrix)
+
+        from . import util
 
         try:
             M_T_M_inv = util.rational_matrix_inv(M_T_M)


### PR DESCRIPTION
Tidy up `eps` usage.
I added the function `get_eps` in util.py which tries to retrieve `eps` taking care of the correct dtype which sometimes could create problems (e.g. dtype mismatch like the one in #355).
