### PR TITLE
Corrected halo_shape() binning with equal number of particles per shell

### DIFF
--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -398,8 +398,6 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
         mid = sn(np.sort(posr[np.where((posr >= rin) & (posr <= rout))]),N*2)
         rbin = mid[1:N*2+1:2]
         mid = mid[0:N*2+1:2]
-        print(rbin)
-        print(mid)
         
     elif (bins == 'log'): # Bins are logarithmically spaced
         mid = profile.Profile(sim.dm, type='log', ndim=3, min=rin, max=rout, nbins=N+1)['rbins']

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -420,9 +420,6 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
     elif (bins == 'lin'): # Bins are linearly spaced
         mid = profile.Profile(sim.dm, type='lin', ndim=3, min=rin, max=rout, nbins=N+1)['rbins']
         rbin = 0.5*(mid[0:N]+mid[1:N+1])
-        print(rbin)
-        print(mid)
-        print(len(rbin), len(mid))
 
     # Define b/a and c/a ratios and angle arrays:
     ba,ca,angle = np.zeros(N),np.zeros(N),np.zeros(N)

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -366,6 +366,7 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
 
     #-----------------------------FUNCTIONS-----------------------------
     # Define an ellipsoid shell with lengths a,b,c and orientation E:
+    print("CHECK!!!!!!!!!!!!!!!!!!")
     def Ellipsoid(r, a,b,c, E):
         x,y,z = np.dot(E,[r[:,0],r[:,1],r[:,2]])
         return (x/a)**2 + (y/b)**2 + (z/c)**2

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -244,7 +244,7 @@ def vel_center(sim, mode=None, cen_size="1 kpc", retcen=False, move_all=True, **
         cen = sim.gas[filt.Sphere(cen_size)]
     if len(cen) < 5:
         # very weird snapshot, or mis-centering!
-        raise ValueError, "Insufficient particles around center to get velocity"
+        raise ValueError("Insufficient particles around center to get velocity")
 
     vcen = (cen['vel'].transpose() * cen['mass']).sum(axis=1) / \
         cen['mass'].sum()
@@ -375,7 +375,7 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
                                for i in range(3)])
 
     # Splits data into number of steps N:
-    sn = lambda r,N: np.append([r[i*len(r)/N:(1+i)*len(r)/N][0]\
+    sn = lambda r,N: np.append([r[i*int(len(r)/N):(1+i)*int(len(r)/N)][0]\
                                for i in range(N)],r[-1])
 
     # Retrieves alignment angle:
@@ -384,7 +384,7 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
 
     if (rout == None): rout = sim.dm['r'].max()
     if (rin == None): rin = rout/1E3
-
+    
     posr = np.array(sim.dm['r'])[np.where(sim.dm['r'] < rout)]
     pos = np.array(sim.dm['pos'])[np.where(sim.dm['r'] < rout)]
     mass = np.array(sim.dm['mass'])[np.where(sim.dm['r'] < rout)]
@@ -398,7 +398,9 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
         mid = sn(np.sort(posr[np.where((posr >= rin) & (posr <= rout))]),N*2)
         rbin = mid[1:N*2+1:2]
         mid = mid[0:N*2+1:2]
-
+        print(rbin)
+        print(mid)
+        
     elif (bins == 'log'): # Bins are logarithmically spaced
         mid = profile.Profile(sim.dm, type='log', ndim=3, min=rin, max=rout, nbins=N+1)['rbins']
         rbin = np.sqrt(mid[0:N]*mid[1:N+1])

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -366,7 +366,6 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
 
     #-----------------------------FUNCTIONS-----------------------------
     # Define an ellipsoid shell with lengths a,b,c and orientation E:
-    print("CHECK!!!!!!!!!!!!!!!!!!")
     def Ellipsoid(r, a,b,c, E):
         x,y,z = np.dot(E,[r[:,0],r[:,1],r[:,2]])
         return (x/a)**2 + (y/b)**2 + (z/c)**2


### PR DESCRIPTION
I noticed two possible issues in the pynbody.analysis.halo.halo_shape() method, when one selects the bins='equal' option:
1. The code crashes because at some point an array is being sliced with floats;
2. The implemented binning seems to be just a linear one, contrary to what is described in the documentation.

I am providing a solution for the two above points. Please comment, and correct me if I missed something.