### PR TITLE
add pyproject.toml to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ recursive-include pynbody *.py *.pyx *.c *.h
 recursive-include nose *.py
 recursive-include docs *.rst *.py
 include docs/Makefile
+pyproject.toml
+


### PR DESCRIPTION
Installing directly from PyPI still does not seem to work: 

```
Collecting pynbody (from -r /tmp/requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/72/f2/39fe332802298e235db2ac8662911394cd5f4558f680067d33ec2f83af3c/pynbody-0.46.tar.gz (2.4MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-3urwh9dp/pynbody/setup.py", line 4, in <module>
        import numpy
    ModuleNotFoundError: No module named 'numpy'
```

I believe adding `pyproject.toml` to the manifest should fix it. 