### PR TITLE
Fix for #485

### DIFF
--- a/nose/array_test.py
+++ b/nose/array_test.py
@@ -160,8 +160,8 @@ def test_issue_485_1():
     s = pynbody.load("testdata/test_g2_snap.1")
     stars = s.s
     indexed_arr = stars[1,2]
-    np.testing.assert_almost_equal(np.sum(indexed_arr['vz'].in_units('km s^-1')), -38.2072944641)
-    np.testing.assert_almost_equal(np.std(indexed_arr['vz'].in_units('km s^-1')), 21.0478305817)
+    np.testing.assert_almost_equal(np.sum(indexed_arr['vz'].in_units('km s^-1')), -20.13701057434082031250)
+    np.testing.assert_almost_equal(np.std(indexed_arr['vz'].in_units('km s^-1')), 11.09318065643310546875)
 
 def test_issue_485_2():
     # Adaptation of examples/vdisp.py
@@ -184,7 +184,8 @@ def test_issue_485_2():
         sigvt[i] = np.std(stars[bininds]['vt'].in_units('km s^-1'))
         rxy[i] = np.mean(stars[bininds]['rxy'].in_units('kpc'))
 
-    np.testing.assert_almost_equal(sigvz, np.array([37.34634781, 55.9630661,   0. ]))
-    np.testing.assert_almost_equal(sigvr, np.array([48.65430069, 49.35913467,  0. ]))
-    np.testing.assert_almost_equal(sigvt, np.array([54.0749054,  35.75136566,  0. ]))
-    np.testing.assert_almost_equal(rxy, np.array([2905.89624023, 4107.21972656, 4116.42480469]))
+
+    np.testing.assert_almost_equal(sigvz, np.array([19.68325233, 29.49512482,  0.]))
+    np.testing.assert_almost_equal(sigvr, np.array([25.64306641, 26.01454544,  0.]))
+    np.testing.assert_almost_equal(sigvt, np.array([28.49997711, 18.84262276,  0.]))
+    np.testing.assert_almost_equal(rxy, np.array([1136892.125, 1606893.625, 1610494.75]))

--- a/nose/array_test.py
+++ b/nose/array_test.py
@@ -68,6 +68,7 @@ def test_iop_units():
     z.units = 'm s^-1'
 
     print(repr(x))
+    assert repr(x) == "SimArray([1, 2, 3, 4], 'kpc')"
 
     try:
         x += y
@@ -159,8 +160,8 @@ def test_issue_485_1():
     s = pynbody.load("testdata/test_g2_snap.1")
     stars = s.s
     indexed_arr = stars[1,2]
-    np.std(indexed_arr['vz'].in_units('km s^-1'))
-    np.std(indexed_arr['vtheta'].in_units('km s^-1'))
+    np.testing.assert_almost_equal(np.sum(indexed_arr['vz'].in_units('km s^-1')), -38.2072944641)
+    np.testing.assert_almost_equal(np.std(indexed_arr['vz'].in_units('km s^-1')), 21.0478305817)
 
 def test_issue_485_2():
     # Adaptation of examples/vdisp.py
@@ -175,9 +176,15 @@ def test_issue_485_2():
     sigvt = np.zeros(nrbins)
     rxy = np.zeros(nrbins)
 
+    assert len(np.unique(rxyinds)) == 3
     for i, ind in enumerate(np.unique(rxyinds)):
         bininds = np.where(rxyinds == ind)
         sigvz[i] = np.std(stars[bininds]['vz'].in_units('km s^-1'))
         sigvr[i] = np.std(stars[bininds]['vr'].in_units('km s^-1'))
         sigvt[i] = np.std(stars[bininds]['vt'].in_units('km s^-1'))
         rxy[i] = np.mean(stars[bininds]['rxy'].in_units('kpc'))
+
+    np.testing.assert_almost_equal(sigvz, np.array([37.34634781, 55.9630661,   0. ]))
+    np.testing.assert_almost_equal(sigvr, np.array([48.65430069, 49.35913467,  0. ]))
+    np.testing.assert_almost_equal(sigvt, np.array([54.0749054,  35.75136566,  0. ]))
+    np.testing.assert_almost_equal(rxy, np.array([2905.89624023, 4107.21972656, 4116.42480469]))

--- a/nose/array_test.py
+++ b/nose/array_test.py
@@ -154,3 +154,9 @@ def test_dimensionful_comparison():
 
     assert (y['b'] < y['a']).all()
     assert not (y['b'] > y['a']).any()
+
+def test_issue_485():
+    s = pynbody.load("testdata/test_g2_snap.1")
+    stars = s.s
+    indexed_arr = stars[1,2]
+    indexed_arr['vz'].in_units('km s^-1')

--- a/nose/array_test.py
+++ b/nose/array_test.py
@@ -155,8 +155,29 @@ def test_dimensionful_comparison():
     assert (y['b'] < y['a']).all()
     assert not (y['b'] > y['a']).any()
 
-def test_issue_485():
+def test_issue_485_1():
     s = pynbody.load("testdata/test_g2_snap.1")
     stars = s.s
     indexed_arr = stars[1,2]
-    indexed_arr['vz'].in_units('km s^-1')
+    np.std(indexed_arr['vz'].in_units('km s^-1'))
+    np.std(indexed_arr['vtheta'].in_units('km s^-1'))
+
+def test_issue_485_2():
+    # Adaptation of examples/vdisp.py
+    s = pynbody.load("testdata/test_g2_snap.1")
+
+    stars = s.s
+    rxyhist, rxybins = np.histogram(stars['rxy'], bins=20)
+    rxyinds = np.digitize(stars['rxy'], rxybins)
+    nrbins = len(np.unique(rxyinds))
+    sigvz = np.zeros(nrbins)
+    sigvr = np.zeros(nrbins)
+    sigvt = np.zeros(nrbins)
+    rxy = np.zeros(nrbins)
+
+    for i, ind in enumerate(np.unique(rxyinds)):
+        bininds = np.where(rxyinds == ind)
+        sigvz[i] = np.std(stars[bininds]['vz'].in_units('km s^-1'))
+        sigvr[i] = np.std(stars[bininds]['vr'].in_units('km s^-1'))
+        sigvt[i] = np.std(stars[bininds]['vt'].in_units('km s^-1'))
+        rxy[i] = np.mean(stars[bininds]['rxy'].in_units('kpc'))

--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -904,7 +904,10 @@ class IndexedSimArray(object):
 
     @property
     def sim(self):
-        return self.base.sim[self._ptr]
+        if self.base.sim is not None:
+            return self.base.sim[self._ptr]
+        else:
+            return None
 
     @sim.setter
     def sim(self, s):

--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -956,7 +956,7 @@ _override = "__eq__", "__ne__", "__gt__", "__ge__", "__lt__", "__le__"
 
 for x in set(np.ndarray.__dict__).union(SimArray.__dict__):
     w = getattr(SimArray, x)
-    if 'array' not in x and ((not hasattr(IndexedSimArray, x)) or x in _override) and hasattr(w, '__call__'):
+    if 'array' not in x and '__del__' != x and ((not hasattr(IndexedSimArray, x)) or x in _override) and hasattr(w, '__call__'):
         setattr(IndexedSimArray, x, _wrap_fn(w))
 
 

--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -956,7 +956,7 @@ _override = "__eq__", "__ne__", "__gt__", "__ge__", "__lt__", "__le__"
 
 for x in set(np.ndarray.__dict__).union(SimArray.__dict__):
     w = getattr(SimArray, x)
-    if 'array' not in x and '__del__' != x and ((not hasattr(IndexedSimArray, x)) or x in _override) and hasattr(w, '__call__'):
+    if 'array' not in x and ((not hasattr(IndexedSimArray, x)) or x in _override) and hasattr(w, '__call__'):
         setattr(IndexedSimArray, x, _wrap_fn(w))
 
 


### PR DESCRIPTION
When using the `in_units` method of an `IndexedSimArray`, a new instance of `IndexedSimArray` is created. After that, for some reason the `SimArray.__del__` method is called and, due to how this is coded [here](https://github.com/pynbody/pynbody/blob/3fac16d1a2fe8170e73828613378021c4726a7ea/pynbody/array.py#L653), it calls in turn the [`SimArray.__new__`](https://github.com/pynbody/pynbody/blob/3fac16d1a2fe8170e73828613378021c4726a7ea/pynbody/array.py#L193) method. This last call produces the issue #485 in python3.

~~I think we don't have to wrap the `SimArray.__del__` method around `IndexedSimArray`~~

As described [here](https://github.com/pynbody/pynbody/issues/485#issuecomment-425438948) I removed the exception thown in `IndexedSimArray.sim` property
