### PR TITLE
Allow disabling cosmological conversions in GadgetSnap at load time

### DIFF
--- a/nose/gadget_test.py
+++ b/nose/gadget_test.py
@@ -191,10 +191,17 @@ def test_issue321():
     assert f['pos'].dtype==np.dtype('float32')
     assert f['mass'].dtype==np.dtype('float32')
 
+
+def test_units_override():
+    f = pynbody.load("testdata/test_g2_snap.1")
+    assert_equals(f['pos'].units, "kpc a h^-1")
+    f_no_unit_override = pynbody.load("testdata/test_g2_snap.0")
+    assert_equals(f_no_unit_override['pos'].units, "Mpc a h^-1")
+
+
 def test_ignore_cosmology():
     f = pynbody.load("testdata/test_g2_snap.0")
     f.physical_units()
     assert_equals(f.properties['time'].in_units('Gyr'), 2.5769525238964737)
     f_no_cosmo = pynbody.load("testdata/test_g2_snap.0", ignore_cosmo=True)
-    f_no_cosmo.physical_units()
-    assert_equals(f_no_cosmo.properties['time'].in_units('Gyr'), 0.27161498843919685)
+    assert_equals(f_no_cosmo.properties['time'].in_units('Gyr'), 271.6149884391969)

--- a/nose/gadget_test.py
+++ b/nose/gadget_test.py
@@ -1,6 +1,6 @@
 import pynbody
 import numpy as np
-
+from nose.tools import assert_equals
 
 def setup():
     global snap
@@ -190,3 +190,11 @@ def test_issue321():
     f = pynbody.load("testdata/lpicola/lpicola_z0p000.0")
     assert f['pos'].dtype==np.dtype('float32')
     assert f['mass'].dtype==np.dtype('float32')
+
+def test_ignore_cosmology():
+    f = pynbody.load("testdata/test_g2_snap.0")
+    f.physical_units()
+    assert_equals(f.properties['time'].in_units('Gyr'), 2.5769525238964737)
+    f_no_cosmo = pynbody.load("testdata/test_g2_snap.0", ignore_cosmo=True)
+    f_no_cosmo.physical_units()
+    assert_equals(f_no_cosmo.properties['time'].in_units('Gyr'), 0.27161498843919685)

--- a/nose/gadget_test.py
+++ b/nose/gadget_test.py
@@ -193,15 +193,21 @@ def test_issue321():
 
 
 def test_units_override():
-    f = pynbody.load("testdata/test_g2_snap.1")
+    f = pynbody.load("testdata/test_g2_snap.0")
+    assert_equals(f.filename, "testdata/test_g2_snap")  # final '.0' is stripped
     assert_equals(f['pos'].units, "kpc a h^-1")
-    f_no_unit_override = pynbody.load("testdata/test_g2_snap.0")
-    assert_equals(f_no_unit_override['pos'].units, "Mpc a h^-1")
+
+    # In this case the unit override system is not effective because
+    # the final ".1" is not stripped away in the filename:
+    # the file `test_g2_snap.units` is not used
+    f_no_unit_override = pynbody.load("testdata/test_g2_snap.1")
+    assert_equals(f_no_unit_override.filename, "testdata/test_g2_snap.1")
+    assert_equals(f_no_unit_override['pos'].units, "Mpc a h^-1")  # from default_config.ini
 
 
 def test_ignore_cosmology():
-    f = pynbody.load("testdata/test_g2_snap.0")
+    f = pynbody.load("testdata/test_g2_snap.1")
     f.physical_units()
     assert_equals(f.properties['time'].in_units('Gyr'), 2.5769525238964737)
-    f_no_cosmo = pynbody.load("testdata/test_g2_snap.0", ignore_cosmo=True)
+    f_no_cosmo = pynbody.load("testdata/test_g2_snap.1", ignore_cosmo=True)
     assert_equals(f_no_cosmo.properties['time'].in_units('Gyr'), 271.6149884391969)

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -22,6 +22,7 @@ disk-fit-function: expsech
 
 # number of points to use in cosmological function interpolations e.g. t->a transformations
 cosmo-interpolation-points: 1000
+force_no_cosmological: False
 
 # The following section defines the families in the format
 #    main_name: alias1, alias2, ...

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -22,7 +22,6 @@ disk-fit-function: expsech
 
 # number of points to use in cosmological function interpolations e.g. t->a transformations
 cosmo-interpolation-points: 1000
-force_no_cosmological: False
 
 # The following section defines the families in the format
 #    main_name: alias1, alias2, ...

--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -1175,11 +1175,12 @@ def do_units(sim):
     vel_unit = config_parser.get('gadget-units', 'vel')
     dist_unit = config_parser.get('gadget-units', 'pos')
     mass_unit = config_parser.get('gadget-units', 'mass')
+    no_cosmo = config_parser.getboolean('general', 'force_no_cosmological')
 
     vel_unit, dist_unit, mass_unit = [
-        units.Unit(x) for x in vel_unit, dist_unit, mass_unit]
+        units.Unit(x) for x in (vel_unit, dist_unit, mass_unit)]
 
-    if not _header_suggests_cosmological(sim.header):
+    if no_cosmo or not _header_suggests_cosmological(sim.header):
         # remove a and h dependences
         vel_unit = units.Unit(
             "km s^-1") * vel_unit.in_units("km s^-1", a=1, h=1)
@@ -1194,7 +1195,9 @@ def do_units(sim):
 def do_properties(sim):
     h = sim.header
 
-    if _header_suggests_cosmological(h):
+    no_cosmo = config_parser.getboolean('general', 'force_no_cosmological')
+
+    if not(no_cosmo) and _header_suggests_cosmological(h):
         from .. import analysis
         sim.properties['omegaM0'] = h.Omega0
         # sim.properties['omegaB0'] = ... This one is non-trivial to calculate


### PR DESCRIPTION
It is useful for some Gadget snapshots I have (e.g. non cosmological simulations but with some header info about the cosmology) to ignore cosmological conversions.