### PR TITLE
Ameliorate issue 501

### DIFF
--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -121,7 +121,7 @@ def _cpui_load_particle_block(filename, arrays, offset, first_index, type_, fami
     with FortranFile(filename) as f:
         header = f.read_series(ramses_particle_header)
         f.skip_fields(offset)
-        data = f.read_field(type_, header['npart'])
+        data = f.get_field_memmapped(type_, header['npart'])
         for fam_id, ar in enumerate(arrays):
             data_this_family = data[family_mask == fam_id]
             ind0 = first_index[fam_id]
@@ -303,7 +303,7 @@ def _cpui_load_gas_vars(dims, maxlevel, ndim, filename, cpu, lia, i1,
                             i0 = i1
                             i1 = i0 + (refine[icel] == 0).sum()
                             for ar in dims:
-                                ar[i0:i1] = f.read_field(
+                                ar[i0:i1] = f.get_field_memmapped(
                                     _float_type, ncache)[(refine[icel] == 0)]
     
                             f.skip_fields((nvar_file - nvar))

--- a/pynbody/util.py
+++ b/pynbody/util.py
@@ -641,7 +641,9 @@ if sys.version_info[0]>2:
         # that numpy works around the python 3 buffering. This simple implementation is almost as fast as
         # the python 2 numpy.fromfile
         buf = np.empty(num, dtype)
-        f.readinto(buf)
+        bytes_read = f.readinto(buf)
+        if bytes_read!=buf.nbytes:
+            return buf[:bytes_read//np.dtype(dtype).itemsize] # this seems to be the behaviour of np.fromfile
         return buf
 else:
     _fromfile = np.fromfile

--- a/pynbody/util.py
+++ b/pynbody/util.py
@@ -16,6 +16,7 @@ import time
 import functools
 import logging
 import math
+import sys
 
 import numpy as np
 import scipy
@@ -633,20 +634,31 @@ def threadsafe_inline(*args, **kwargs):
 
 _head_type = np.dtype('i4')
 
+if sys.version_info[0]>2:
+    def _fromfile(f, dtype, num):
+        # Relates to issue 501:
+        # in python 3, numpy.fromfile is very slow for repeated small data chunks. This is due to the way
+        # that numpy works around the python 3 buffering. This simple implementation is almost as fast as
+        # the python 2 numpy.fromfile
+        buf = np.empty(num, dtype)
+        f.readinto(buf)
+        return buf
+else:
+    _fromfile = np.fromfile
 
 def read_fortran(f, dtype, n=1):
     if not isinstance(dtype, np.dtype):
         dtype = np.dtype(dtype)
 
     length = n * dtype.itemsize
-    alen = np.fromfile(f, _head_type, 1)
+    alen = _fromfile(f, _head_type, 1)
     if alen != length:
         raise IOError, "Unexpected FORTRAN block length %d!=%d" % (
             alen, length)
 
-    data = np.fromfile(f, dtype, n)
+    data = _fromfile(f, dtype, n)
 
-    alen = np.fromfile(f, _head_type, 1)
+    alen = _fromfile(f, _head_type, 1)
     if alen != length:
         raise IOError, "Unexpected FORTRAN block length (tail) %d!=%d" % (
             alen, length)

--- a/pynbody/util.py
+++ b/pynbody/util.py
@@ -717,6 +717,9 @@ class FortranFile(object):
             assert alen==alen2
 
     def read_field(self, dtype, field_length=1):
+        return self.get_field_memmapped(dtype, field_length).copy()
+
+    def get_field_memmapped(self, dtype, field_length=1):
         if not isinstance(dtype, np.dtype):
             dtype = np.dtype(dtype)
 
@@ -726,7 +729,7 @@ class FortranFile(object):
             raise IOError, "Unexpected FORTRAN block length %d!=%d" % (
                 alen, length)
 
-        data = self._get_next(dtype, field_length).copy() # need to copy as don't want to leave whole memmap alive
+        data = self._get_next(dtype, field_length)
 
         alen = self._get_next(_head_type, 1)
         if alen != length:


### PR DESCRIPTION
Issue #501 is caused by a change in the implementation of files in python 3, and numpy's workaround for that.

This implements a function rather like numpy's fromfile which is much faster on python 3 in the limit of multiple small reads. 

Note on python 2 numpy's fromfile remains faster for all types of read. Thus, this makes python 3 performance on RAMSES files very considerably better but does not make it quite as good as python 2 performance on RAMSES files.