### PR TITLE
Issue 520

### DIFF
--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -147,3 +147,14 @@ def test_forcegas_dmo():
 
 def test_metals_field_correctly_copied_from_metal():
     np.testing.assert_allclose(f.st['metals'][::5000], f.st['metal'][::5000], rtol=1e-5)
+
+
+def test_tform_and_tform_raw():
+    # Tform is not available for test data, so test warning generation and that the array is full of -1
+    with np.testing.assert_warns(UserWarning):
+        assert len(f.st['tform']) == len(f.st['tform_raw']) == 2655
+        np.testing.assert_allclose(f.st['tform'], - np.ones((2655,), dtype=np.float64), rtol=1e-5)
+
+    np.testing.assert_allclose(f.st['tform_raw'][:10], [4.58574701, 4.58100771, 4.58284129, 3.18777836, 4.55801122,
+                                                        4.50733498, 4.5100136,  4.57288808, 4.55926183, 4.52128465],
+                               rtol=1e-5)

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -143,3 +143,7 @@ def test_forcegas_dmo():
             2.25179981e+15,   2.25179981e+15,   2.25179981e+15,
             2.25179981e+15,   2.25179981e+15,   2.25179981e+15,
             1.80143985e+16], rtol=1e-5)
+
+
+def test_metals_field_correctly_copied_from_metal():
+    np.testing.assert_allclose(f.st['metals'][::5000], f.st['metal'][::5000], rtol=1e-5)

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -8,13 +8,6 @@ demo on how to use RAMSES outputs with pynbody, have a look at the
 `ipython notebook demo
 <http://nbviewer.ipython.org/github/pynbody/pynbody/blob/master/examples/notebooks/pynbody_demo-ramses.ipynb>`_
 
-
-Loading and centering
----------------------
-
->>> s = pynbody.analysis.ramses_util.load_center('output_00101', align=False) # centered on halo 0 
->>> pynbody.analysis.ramses_util.hop_center(s,10) # centered on the halo 10
-
 File Conversion
 ---------------
 
@@ -74,106 +67,7 @@ from .. import config_parser
 
 ramses_utils = config_parser.get('ramses', 'ramses_utils')
 
-hop_script_path = ramses_utils + 'scripts/script_hop.sh'
 part2birth_path = ramses_utils + 'f90/part2birth'
-
-
-def load_hop(s, hop=hop_script_path):
-    """
-    Loads the hop catalog for the given RAMSES snapshot. If the
-    catalog doesn't exist, it tries to run hop to create one via the
-    'script_hop.sh' script found in the RAMSES distribution. The hop
-    output should be in a 'hop' directory in the base directory of the
-    simulation.
-
-    **Input**:
-
-    *s* : loaded RAMSES snapshot
-
-    **Optional Keywords**:
-
-    *hop* : path to `script_hop.sh`
-
-    """
-
-    if s.filename[-1] == '/':
-        name = s.filename[-6:-1]
-        filename = s.filename[:-13] + 'hop/grp%s.pos' % name
-    else:
-        name = s.filename[-5:]
-        filename = s.filename[:-12] + 'hop/grp%s.pos' % name
-
-    try:
-        data = np.genfromtxt(filename, unpack=True)
-    except IOError:
-        import os
-        dir = s.filename[:-12] if len(s.filename[:-12]) else './'
-
-        os.system(
-            'cd %s;%s %d;cd ..' % (dir, hop_script_path, int(name)))
-        data = np.genfromtxt(filename, unpack=True)
-
-    return data
-
-
-def hop_center(s, halo=0):
-    """
-    Center the simulation snapshot on the specified halo using the halo data from hop. 
-
-    **Input**: 
-
-    *s* : RAMSES snapshot
-
-    **Optional Keywords**:
-
-    *halo* : halo ID to use for centering (default = 0)
-
-    """
-
-    data = load_hop(s)
-
-    cen = data.T[halo][4:7]
-    vcen = data.T[halo][7:10]
-
-    s['pos'] -= cen
-    s['vel'] -= vcen
-
-
-def load_center(output, align=True, halo=0):
-    """
-    Loads a RAMSES output and centers it on the desired halo. The hop
-    center is used for an initial estimate, but for more precise
-    centering, a shrinking-sphere center is calculated.
-
-    **Inputs**:    
-
-    *output* : path to RAMSES output directory
-
-    **Optional Keywords**: 
-
-    *align* : whether to align the snapshot based on the angular momentum in the central region (default = True)
-
-    *halo* : halo to center on (default = 0)
-    """
-
-    s = pynbody.load(output)
-    hop_center(s, halo)
-
-    st = s[pynbody.filt.Sphere('100 kpc')]
-
-    cen = pynbody.analysis.halo.center(
-        st, retcen=True, mode='ssc', verbose=True)
-
-    if align:
-        pynbody.analysis.angmom.faceon(
-            st.s, disk_size='10 kpc', cen=cen, mode='ssc')
-    else:
-        s['pos'] -= cen
-
-    s['pos'].convert_units('kpc')
-    s['vel'].convert_units('km s^-1')
-
-    return s
 
 
 def convert_to_tipsy_simple(output, halo=0, filt=None):

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -335,19 +335,19 @@ def get_tform(sim, part2birth_path=part2birth_path):
         birthfile_path = os.path.join(top.filename, birthfile_name)
         try:
             birth_file = FortranFile(birthfile_path)
-        except IOError:
+        except (IOError, OSError):      # Both are necessary as python 2 throws OSError, while python 3 throws IOError
             try:
                 # birth_xxx doesn't exist, create it with ramses part2birth util
                 with open(os.devnull, 'w') as fnull:
                     subprocess.call([part2birth_path, '-inp', 'output_%s' % top._timestep_id],
                                     stdout=fnull, stderr=fnull)
                 birth_file = FortranFile(birthfile_path)
-            except IOError:
+            except (IOError, OSError):
                 import warnings
                 warnings.warn("Failed to read 'tform' from birth files at %s and to generate them with utility at %s.\n"
                               "Formation times in Ramses code units can be accessed through the 'tform_raw' array."
                               % (birthfile_path, part2birth_path))
-                raise IOError
+                raise OSError
 
         ages = birth_file.read_reals(np.float64)
         new = np.where(ages > 0)[0]

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -347,7 +347,7 @@ def get_tform(sim, part2birth_path=part2birth_path):
                 warnings.warn("Failed to read 'tform' from birth files at %s and to generate them with utility at %s.\n"
                               "Formation times in Ramses code units can be accessed through the 'tform_raw' array."
                               % (birthfile_path, part2birth_path))
-                raise OSError
+                return
 
         ages = birth_file.read_reals(np.float64)
         new = np.where(ages > 0)[0]

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -294,7 +294,7 @@ def write_ahf_input(sim, tipsyfile):
     f.close()
 
 
-def get_tform(sim, part2birth_path=part2birth_path, cpu_range=None):
+def get_tform(sim, part2birth_path=part2birth_path):
     """Use `part2birth` to calculate the formation time of stars in
     Gyr and **replaces** the original `tform` array.
 
@@ -309,9 +309,6 @@ def get_tform(sim, part2birth_path=part2birth_path, cpu_range=None):
      `default_config.ini` in your pynbody install directory. You can
      override this like so -- make a file called ".pynbodyrc" in your
      home directory, and include
-
-     *cpu_range*: a list of cpus to process tform for. If specified, birth time
-      will only be processed for cpus in the list. - RS
 
     [ramses]
 

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -335,14 +335,19 @@ def get_tform(sim, part2birth_path=part2birth_path):
         birthfile_path = os.path.join(top.filename, birthfile_name)
         try:
             birth_file = FortranFile(birthfile_path)
-        except FileNotFoundError:
-
-            # birth_xxx doesn't exist, create it with ramses part2birth util
-            with open(os.devnull, 'w') as fnull:
-                subprocess.call([part2birth_path, '-inp', 'output_%s' % top._timestep_id],
-                                stdout=fnull, stderr=fnull)
-
-            birth_file = FortranFile(birthfile_path)
+        except IOError:
+            try:
+                # birth_xxx doesn't exist, create it with ramses part2birth util
+                with open(os.devnull, 'w') as fnull:
+                    subprocess.call([part2birth_path, '-inp', 'output_%s' % top._timestep_id],
+                                    stdout=fnull, stderr=fnull)
+                birth_file = FortranFile(birthfile_path)
+            except IOError:
+                import warnings
+                warnings.warn("Failed to read 'tform' from birth files at %s and to generate them with utility at %s.\n"
+                              "Formation times in Ramses code units can be accessed through the 'tform_raw' array."
+                              % (birthfile_path, part2birth_path))
+                raise IOError
 
         ages = birth_file.read_reals(np.float64)
         new = np.where(ages > 0)[0]

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -347,7 +347,7 @@ def get_tform(sim, part2birth_path=part2birth_path):
                 warnings.warn("Failed to read 'tform' from birth files at %s and to generate them with utility at %s.\n"
                               "Formation times in Ramses code units can be accessed through the 'tform_raw' array."
                               % (birthfile_path, part2birth_path))
-                return
+                raise IOError
 
         ages = birth_file.read_reals(np.float64)
         new = np.where(ages > 0)[0]

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -182,7 +182,7 @@ type-mapping-negative: tracer
 type-sink: bh
 
 # The default particle blocks for RAMSES files
-particle-blocks=x,y,z,vx,vy,vz,mass,iord,level,age,metal
+particle-blocks=x,y,z,vx,vy,vz,mass,iord,level,tform,metal
 particle-format=f8,f8,f8,f8,f8,f8,f8,i4,i4,f8,f8
 
 # For RAMSES format up to November 2017:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -936,6 +936,19 @@ class RamsesSnap(SimSnap):
         # could potentially be improved with reference to stored namelist.txt, if present
         return self._info['omega_k'] == self._info['omega_l'] == 0
 
+    def _convert_tform(self):
+        from ..analysis import ramses_util
+        # Copy the existing array in weird Ramses format into a hidden raw array
+        self.star['tform_raw'] = self.star['tform']
+        self.star['tform_raw'].units = self._file_units_system[1]
+        # Replace the tform array by its usual meaning using the birth files
+        ramses_util.get_tform(self)
+
+    def _convert_metal_name(self):
+        # Name of ramses metallicity has no 's' at the end, contrary to tipsy and gadget
+        # Correcting this prevents analysis routines relying on 'metals' field from breaking.
+        self.star['metals'] = self.star['metal']
+
     def _load_array(self, array_name, fam=None):
         # Framework always calls with 3D name. Ramses particle blocks are
         # stored as 1D slices.
@@ -947,7 +960,15 @@ class RamsesSnap(SimSnap):
 
         elif fam is not family.gas and fam is not None:
 
-            if array_name in self._split_arrays:
+            if array_name == 'tform' or array_name == 'tform_raw' :
+                self._load_particle_block('tform')
+                self._convert_tform()
+
+            elif array_name == 'metals' or array_name == 'metal':
+                self._load_particle_block('metal')
+                self._convert_metal_name()
+
+            elif array_name in self._split_arrays:
                 for array_1D in self._array_name_ND_to_1D(array_name):
                     self._load_particle_block(array_1D)
 
@@ -955,6 +976,7 @@ class RamsesSnap(SimSnap):
                 self._load_particle_block(array_name)
             else:
                 raise IOError, "No such array on disk"
+
         elif fam is family.gas:
 
             if array_name == 'pos' or array_name == 'smooth':
@@ -1040,11 +1062,6 @@ def translate_info(sim):
 @RamsesSnap.derived_quantity
 def mass(sim):
     return sim['rho'] * sim['smooth'] ** 3
-
-
-@RamsesSnap.derived_quantity
-def tform(sim):
-    return sim.properties['time'] - sim['age']
 
 
 @RamsesSnap.derived_quantity


### PR DESCRIPTION
Hi again,

Here is a first shot at resolving the problems highlighted in #520. 

Specifically, this PR addresses 1) path mishandling of ramses tform by simplifying its logic and 3) deleting redundant HOP utilities. 

For 2), I need to think about it a bit more. The current routine replaces the 'tform' array in place, as it is also the name of the simulation array that is read from the actual ramses file (specified in the ramses header). Having it as a derived array would require some name mapping and would be very different in spirit to existing derived arrays.

Martin