### PR TITLE
Add option to write tipsy files as non-cosmological

### DIFF
--- a/nose/tipsy_test.py
+++ b/nose/tipsy_test.py
@@ -124,12 +124,21 @@ def test_write():
     f2.dm['test_array'] = np.ones(9)
     f2['x'] = np.arange(0, 40)
     f2['vx'] = np.arange(40, 80)
+    f2.properties['a'] = 0.5
+    f2.properties['time'] = 12.0
     f2.write(fmt=pynbody.tipsy.TipsySnap, filename="testdata/test_out.tipsy")
 
     f3 = pynbody.load("testdata/test_out.tipsy")
     assert all(f3['x'] == f2['x'])
     assert all(f3['vx'] == f3['vx'])
     assert all(f3.dm['test_array'] == f2.dm['test_array'])
+    assert f3.properties['a']==0.5
+
+    # this looks strange, but it's because the .param file in the testdata folder implies a cosmological tipsy snap
+    # whereas we have just written the snapshot asserting it is non-cosmological
+    f2.write(fmt=pynbody.tipsy.TipsySnap, filename="testdata/test_out.tipsy", cosmological=False)
+    f3 = pynbody.load("testdata/test_out.tipsy")
+    assert f3.properties['a']==12
 
 
 def test_array_write():

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -387,7 +387,7 @@ class TipsySnap(SimSnap):
             os.system("mv " + self.filename + ".tmp " + self.filename)
 
     @staticmethod
-    def _write(self, filename=None, double_pos=None, double_vel=None, binary_aux_arrays=None):
+    def _write(self, filename=None, double_pos=None, double_vel=None, binary_aux_arrays=None, cosmological=True):
         """
 
         Write a TIPSY (standard) formatted file.
@@ -413,6 +413,9 @@ class TipsySnap(SimSnap):
                                     arrays in binary format; if left 'None', the preference is
                                     taken from the param file
 
+        *cosmological* (True): if True (default), the header will store the self.properties['a'];
+                               otherwise it will store self.properties['time']
+
         """
 
         global config
@@ -424,9 +427,12 @@ class TipsySnap(SimSnap):
 
         f = util.open_(filename, 'wb')
 
-        t = 0
+        t = 0.0
         try:
-            t = self.properties['a']
+            if cosmological:
+                t = self.properties['a']
+            else:
+                t = self.properties['time']
         except KeyError:
             warnings.warn(
                 "Time is unknown: writing zero in header", RuntimeWarning)


### PR DESCRIPTION
This amounts to putting the time rather than the scalefactor in the header