### PR TITLE
Fix bug #532 in ordering of locks in dependencytracker.py

### DIFF
--- a/nose/sph_image_test.py
+++ b/nose/sph_image_test.py
@@ -85,3 +85,12 @@ def test_render_stars():
     compare= np.load("test_stars_2d.npy")
 
     npt.assert_allclose(compare,im[40:60],atol=0.01)
+
+
+@pynbody.derived_array
+def intentional_circular_reference(sim):
+    return sim['intentional_circular_reference']
+
+def test_exception_propagation():
+    with npt.assert_raises(RuntimeError):
+        pynbody.plot.sph.image(f.gas, qty='intentional_circular_reference')

--- a/pynbody/dependencytracker.py
+++ b/pynbody/dependencytracker.py
@@ -10,9 +10,9 @@ class DependencyContext(object):
         self.name = name
 
     def __enter__(self):
-        self.tracker._calculation_lock.__enter__()
         if self.name in self.tracker._current_calculation_stack:
             raise DependencyError, "Circular dependency"
+        self.tracker._calculation_lock.__enter__()
         self.tracker._push(self.name)
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
This could lead to deadlock.

Add unit test