### PR TITLE
Adaptahop support improvement

### DIFF
--- a/nose/adaptahop_test.py
+++ b/nose/adaptahop_test.py
@@ -1,8 +1,7 @@
-import pynbody
-from pynbody.halo.adaptahop import AdaptaHOPCatalogue
-
-from scipy.io import FortranFile as FF
 import numpy as np
+from scipy.io import FortranFile as FF
+
+import pynbody
 
 
 def test_load_adaptahop_catalogue():
@@ -12,9 +11,17 @@ def test_load_adaptahop_catalogue():
 
 
 def test_load_one_halo():
-    f = pynbody.load("testdata/output_00080")
-    h = f.halos()
-    np.testing.assert_allclose(h[1].properties["members"], h[1]["iord"])
+    def helper(path, nhalos):
+        f = pynbody.load(path)
+        h = f.halos()
+        np.testing.assert_allclose(h[1].properties["members"], h[1]["iord"])
+        assert len(h) == nhalos
+
+    for path, nhalos in (
+        ("testdata/output_00080", 170),
+        ("testdata/new_adaptahop_output_00080", 2),
+    ):
+        yield helper, path, nhalos
 
 
 def test_get_group():

--- a/nose/adaptahop_test.py
+++ b/nose/adaptahop_test.py
@@ -6,43 +6,45 @@ import numpy as np
 
 
 def test_load_adaptahop_catalogue():
-    f = pynbody.load('testdata/output_00080')
+    f = pynbody.load("testdata/output_00080")
     h = f.halos()
-    assert len(h) == h._headers['nhalos'] + h._headers['nsubs']
+    assert len(h) == h._headers["nhalos"] + h._headers["nsubs"]
+
 
 def test_load_one_halo():
-    f = pynbody.load('testdata/output_00080')
+    f = pynbody.load("testdata/output_00080")
     h = f.halos()
-    np.testing.assert_allclose(h[1].properties['members'], h[1]['iord'])
+    np.testing.assert_allclose(h[1].properties["members"], h[1]["iord"])
+
 
 def test_get_group():
-    f = pynbody.load('testdata/output_00080')
+    f = pynbody.load("testdata/output_00080")
     h = f.halos()
 
     group_array = h.get_group_array()
-    iord = f.dm['iord']
+    iord = f.dm["iord"]
 
-    for halo_id in range(1, len(h)+1):
+    for halo_id in range(1, len(h) + 1):
         mask = group_array == halo_id
 
         # Check that the indices
         # - read from halo (h[halo_id]['iord'])
         # - obtained from get_group_array masking
         # are the same (in term of sets)
-        assert len(np.setdiff1d(iord[mask], h[halo_id]['iord'])) == 0
-        assert len(np.setdiff1d(h[halo_id]['iord']), iord[mask]) == 0
+        assert len(np.setdiff1d(iord[mask], h[halo_id]["iord"])) == 0
+        assert len(np.setdiff1d(h[halo_id]["iord"]), iord[mask]) == 0
 
 
 def test_halo_particle_ids():
-    f = pynbody.load('testdata/output_00080')
+    f = pynbody.load("testdata/output_00080")
     h = f.halos()
 
     with FF(h._fname, mode="r") as f:
-        for halo_id in range(1, len(h)+1):
+        for halo_id in range(1, len(h) + 1):
             # Manually read the particle ids and make sure pynbody is reading them as it should
             f._fp.seek(h[halo_id].properties["file_offset"])
 
             f.read_ints()  # number of particles
             expected_members = f.read_ints("i")  # halo members
 
-            np.testing.assert_equal(expected_members, h[halo_id].properties['members'])
+            np.testing.assert_equal(expected_members, h[halo_id].properties["members"])

--- a/nose/adaptahop_test.py
+++ b/nose/adaptahop_test.py
@@ -31,8 +31,10 @@ def test_get_group():
         # - read from halo (h[halo_id]['iord'])
         # - obtained from get_group_array masking
         # are the same (in term of sets)
-        assert len(np.setdiff1d(iord[mask], h[halo_id]["iord"])) == 0
-        assert len(np.setdiff1d(h[halo_id]["iord"]), iord[mask]) == 0
+        iord_1 = np.sort(iord[mask])
+        iord_2 = np.sort(h[halo_id]["iord"])
+
+        np.testing.assert_equal(iord_1, iord_2)
 
 
 def test_halo_particle_ids():

--- a/nose/adaptahop_test.py
+++ b/nose/adaptahop_test.py
@@ -13,3 +13,19 @@ def test_load_one_halo():
     f = pynbody.load('testdata/output_00080')
     h = f.halos()
     np.testing.assert_allclose(h[1].properties['members'], h[1]['iord'])
+
+def test_get_group():
+    f = pynbody.load('testdata/output_00080')
+    h = f.halos()
+
+    group_array = h.get_group_array()
+    iord = f.dm['iord']
+
+    for halo_id in range(1, len(h)+1):
+        mask = group_array == halo_id
+
+        # Check that the indices
+        # - read from halo (h[halo_id]['iord'])
+        # - obtained from get_group_array masking
+        # are the same (in term of sets)
+        assert len(np.setdiff1d(iord[mask], h[halo_id]['iord'])) == 0

--- a/nose/adaptahop_test.py
+++ b/nose/adaptahop_test.py
@@ -1,6 +1,7 @@
 import pynbody
 from pynbody.halo.adaptahop import AdaptaHOPCatalogue
 
+from scipy.io import FortranFile as FF
 import numpy as np
 
 
@@ -29,3 +30,19 @@ def test_get_group():
         # - obtained from get_group_array masking
         # are the same (in term of sets)
         assert len(np.setdiff1d(iord[mask], h[halo_id]['iord'])) == 0
+        assert len(np.setdiff1d(h[halo_id]['iord']), iord[mask]) == 0
+
+
+def test_halo_particle_ids():
+    f = pynbody.load('testdata/output_00080')
+    h = f.halos()
+
+    with FF(h._fname, mode="r") as f:
+        for halo_id in range(1, len(h)+1):
+            # Manually read the particle ids and make sure pynbody is reading them as it should
+            f._fp.seek(h[halo_id].properties["file_offset"])
+
+            f.read_ints()  # number of particles
+            expected_members = f.read_ints("i")  # halo members
+
+            np.testing.assert_equal(expected_members, h[halo_id].properties['members'])

--- a/nose/utils_test.py
+++ b/nose/utils_test.py
@@ -176,3 +176,23 @@ def test_binary_search():
         indices = pynbody.util.binary_search(a, b, b_argsort, num_threads=nthreads)
         mask = (indices != len(b))
         np.testing.assert_array_equal(a[mask], b[indices[mask]])
+
+def test_is_sorted():
+    """Unit test for is_sorted function"""
+    # Pathological cases
+    assert pynbody.util.is_sorted(np.array([])) == 1
+    assert pynbody.util.is_sorted(np.array([1])) == 1
+    arr = np.zeros(100)
+    assert pynbody.util.is_sorted(arr) == 1
+
+    # Constant to begin with, then increasing/decreasing
+    arr = np.zeros(100)
+    arr[-1] = 1
+    assert pynbody.util.is_sorted(arr) == 1
+    arr[-1] = -1
+    assert pynbody.util.is_sorted(arr) == -1
+
+    # Simple cases
+    assert pynbody.util.is_sorted(np.array([1, 2, 3])) == 1
+    assert pynbody.util.is_sorted(np.array([1, 2, 1])) == 0
+    assert pynbody.util.is_sorted(np.array([3, 2, 1])) == -1

--- a/nose/utils_test.py
+++ b/nose/utils_test.py
@@ -151,3 +151,28 @@ def test_find_boundaries():
     our_numbers = np.array([-1,-1,0,0,0,1,2,2,3,3,5,5,5], dtype=np.int32)
     boundaries = pynbody.util.find_boundaries(our_numbers)
     assert (boundaries==[2,5,6,8,-1,10]).all()
+
+def test_binary_search():
+    """Unit test for binary search algorithm"""
+    seed = 16091992
+    np.random.seed(seed)
+    b = np.random.choice(10000, size=10000, replace=False)
+    a = np.sort(np.random.choice(b, size=100))
+
+    b_argsort = np.argsort(b)
+
+    # Test that algorithm works with different number of threads
+    # for nthreads in range(10, 1, -1):
+    for nthreads in range(1, 10):
+        indices = pynbody.util.binary_search(a, b, b_argsort, num_threads=nthreads)
+        np.testing.assert_array_equal(a, b[indices])
+
+    # Test that algorithm works for missing elements in b
+    b = np.random.choice(np.arange(100), size=100, replace=False)
+    b_argsort = np.argsort(b)
+
+    a = np.array([0, 10, 100, 1000])
+    for nthreads in range(1, 10):
+        indices = pynbody.util.binary_search(a, b, b_argsort, num_threads=nthreads)
+        mask = (indices != len(b))
+        np.testing.assert_array_equal(a[mask], b[indices[mask]])

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -240,7 +240,7 @@ cdef np.int64_t search(fused_int a, fused_int_2[:] B,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(
-        fused_int[:] a, fused_int[:] b,
+        fused_int[:] a, fused_int_2[:] b,
         np.ndarray[fused_int_3, ndim=1] sorter, int num_threads=-1):
     """Search elements of a in b, assuming a, b[sorter] are sorted in increasing order.
 

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -212,9 +212,9 @@ def _sphere_selection(np.ndarray[fused_float, ndim=2] pos_ar,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nogil(True)
-cdef np.int64_t search(fused_int a, fused_int[:] B, fused_int2[:] sorter, fused_int2 ileft, fused_int2 iright, fused_int2 Nb) nogil:
+cdef np.int64_t search(fused_int a, fused_int[:] B, fused_int_2[:] sorter, fused_int_2 ileft, fused_int_2 iright, fused_int_2 Nb) nogil:
     cdef fused_int b
-    cdef fused_int2 imid
+    cdef fused_int_2 imid
     while ileft <= iright:
         imid = (ileft + iright) // 2
         b = B[sorter[imid]]
@@ -229,7 +229,7 @@ cdef np.int64_t search(fused_int a, fused_int[:] B, fused_int2[:] sorter, fused_
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nogil(True)
-cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_int[:] b, np.ndarray[fused_int2, ndim=1] sorter, int num_threads=-1):
+cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_int[:] b, np.ndarray[fused_int_2, ndim=1] sorter, int num_threads=-1):
     """Search elements of a in b, assuming a, b[sorter] are sorted in increasing order.
 
     Parameters
@@ -247,16 +247,20 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_in
     -------
     indices : array(N, )
         An array such that b[indices] == a
+
+    Notes
+    -----
+    The code does *not* check that a and b[sorted] are effectively sorted in increasing order.
     """
 
-    cdef fused_int2 Na = len(a), Nb = len(b)
+    cdef fused_int_2 Na = len(a), Nb = len(b)
 
-    cdef fused_int2 ileft=0, iright=Nb - 1
+    cdef fused_int_2 ileft=0, iright=Nb - 1
     cdef int i, ii, j, pivot
-    cdef fused_int2 index
+    cdef fused_int_2 index
 
-    cdef fused_int2[:] indices = np.empty(Na, dtype=sorter.dtype)
-    cdef fused_int2[:] sorter_mview = sorter
+    cdef fused_int_2[:] indices = np.empty(Na, dtype=sorter.dtype)
+    cdef fused_int_2[:] sorter_mview = sorter
 
     cdef int ichunk, chunk_size, Nchunk = openmp.omp_get_num_threads(), this_chunk
 

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -246,7 +246,7 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_in
         The input arrays
 
     num_threads : int, optional
-        If larger than one, use parallelism
+        If greater than zero, use that many parallel threads.
 
 
     Returns
@@ -270,7 +270,7 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_in
 
     cdef int ichunk, chunk_size, Nchunk = openmp.omp_get_num_threads(), this_chunk
 
-    if num_threads > -1:
+    if num_threads > 0:
         Nchunk = num_threads
     openmp.omp_set_num_threads(Nchunk)
 

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -254,11 +254,25 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(
     Returns
     -------
     indices : array(N, )
-        An array such that b[indices] == a
+        An array such that b[indices] == a, for elements found in b.
+        Elements of a that cannot be found have the index M.
 
     Notes
     -----
     The code does *not* check that a and b[sorted] are effectively sorted in increasing order.
+
+    This functions can be used in place of np.searchsorted (note however that the order of the argument differ).
+    The algorithm performs particularly well when a is much smaller than b and can be found at close locations in b.
+
+    Algorithm
+    ---------
+    The algorithm implemented is a binary search algorithm of the elements of a into b. The algorithm consumes elements
+    of a from both ends. Since a is sorted, the index of a[0] and a[-1] give boundaries to look for the next elements
+    of a in b, resulting in the next binary search being faster.
+    If the elements of a are almost contiguous in b, the algorithm scales as N log(N), with N = len(a) instead of 
+    N log(M) with M = len(b).
+    
+    Note that the algorithm performs similarly to np.searchsorted when N~M.
     """
 
     cdef fused_int_2 Na = len(a), Nb = len(b)

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -27,6 +27,12 @@ ctypedef fused fused_int_2:
     np.int32_t
     np.int64_t
 
+ctypedef fused int_or_float:
+    np.float32_t
+    np.float64_t
+    np.int32_t
+    np.int64_t
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -300,5 +306,51 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_in
                     indices[j] = Nb
     return np.asarray(indices)
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nogil(True)
+cpdef int is_sorted(int_or_float[:] A):
+    """Check whether input is sorted in ascending order.
+
+    Arguments
+    ---------
+    A : array
+
+    Returns
+    -------
+    ret : int
+        +1 if A is in ascending order
+        -1 if A is in descending order
+        0 otherwise
+    """
+    cdef int Na = len(A), i, i0
+    cdef ret = 0
+
+    # Special case for single-valued arrays
+    if Na <= 1:
+        return 1
+
+    # Iterate until finding two consecutive non-null elements
+    i0 = 1
+    while i0 < Na:
+        if A[i0] != A[0]:
+            break
+        i0 += 1
+
+    # Special case if array is constant
+    if i0 == Na:
+        return 1
+
+    if A[i0] >= A[0]:
+        for i in range(i0, Na):
+            if A[i] < A[i-1]:
+                return 0
+        return 1
+    else:
+        for i in range(i0, Na):
+            if A[i] > A[i-1]:
+                return 0
+        return -1
+
 __all__ = ['grid_gen','find_boundaries', 'sum', 'sum_if_gt', 'sum_if_lt',
-           '_sphere_selection', 'binary_search']
+           '_sphere_selection', 'binary_search', 'is_sorted']

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -217,7 +217,6 @@ def _sphere_selection(np.ndarray[fused_float, ndim=2] pos_ar,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-@cython.nogil(True)
 cdef np.int64_t search(fused_int a, fused_int[:] B,
                        fused_int_2[:] sorter,
                        fused_int_2 ileft, fused_int_2 iright) nogil:
@@ -236,7 +235,6 @@ cdef np.int64_t search(fused_int a, fused_int[:] B,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-@cython.nogil(True)
 cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(
         fused_int[:] a, fused_int[:] b,
         np.ndarray[fused_int_2, ndim=1] sorter, int num_threads=-1):
@@ -320,7 +318,6 @@ cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-@cython.nogil(True)
 cpdef int is_sorted(int_or_float[:] A):
     """Check whether input is sorted in ascending order.
 
@@ -336,7 +333,7 @@ cpdef int is_sorted(int_or_float[:] A):
         0 otherwise
     """
     cdef int Na = len(A), i, i0
-    cdef ret = 0
+    cdef int ret = 0
 
     # Special case for single-valued arrays
     if Na <= 1:

--- a/pynbody/_util.pyx
+++ b/pynbody/_util.pyx
@@ -230,7 +230,24 @@ cdef np.int64_t search(fused_int a, fused_int[:] B, fused_int2[:] sorter, fused_
 @cython.wraparound(False)
 @cython.nogil(True)
 cpdef np.ndarray[ndim=1, dtype=fused_int] binary_search(fused_int[:] a, fused_int[:] b, np.ndarray[fused_int2, ndim=1] sorter, int num_threads=-1):
-    """Search elements of a in b, assuming a, b[sorter] are sorted in increasing order."""
+    """Search elements of a in b, assuming a, b[sorter] are sorted in increasing order.
+
+    Parameters
+    ----------
+    a : int array (N, )
+    b : int array (M, )
+    sorter : int array(M, )
+        The input arrays
+
+    num_threads : int, optional
+        If larger than one, use parallelism
+
+
+    Returns
+    -------
+    indices : array(N, )
+        An array such that b[indices] == a
+    """
 
     cdef fused_int2 Na = len(a), Nb = len(b)
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -8,7 +8,7 @@
 [general]
 verbose: False
 snap-class-priority: RamsesSnap, GrafICSnap, NchiladaSnap, GadgetSnap, EagleLikeHDFSnap, GadgetHDFSnap, SubFindHDFSnap, TipsySnap, AsciiSnap
-halo-class-priority: GrpCatalogue, AmigaGrpCatalogue, RockstarIntermediateCatalogue, RockstarCatalogue, AHFCatalogue, SubfindCatalogue, HOPCatalogue, AdaptaHOPCatalogue
+halo-class-priority: GrpCatalogue, AmigaGrpCatalogue, RockstarIntermediateCatalogue, RockstarCatalogue, AHFCatalogue, SubfindCatalogue, HOPCatalogue, NewAdaptaHOPCatalogue, AdaptaHOPCatalogue
 
 centering-scheme: ssc
 

--- a/pynbody/derived.py
+++ b/pynbody/derived.py
@@ -308,3 +308,8 @@ def tform(self):
     from . import analysis
     t = analysis.cosmology.age(self, 1./self['aform'] - 1.)
     return t
+
+@SimSnap.derived_quantity
+def iord_argsort(self):
+    """Indices so that particles are ordered by increasing ids"""
+    return np.argsort(self['iord'])

--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -288,7 +288,7 @@ class AmigaGrpCatalogue(GrpCatalogue):
 
 from pynbody.halo.ahf import AHFCatalogue
 from pynbody.halo.hop import HOPCatalogue
-from pynbody.halo.adaptahop import AdaptaHOPCatalogue
+from pynbody.halo.adaptahop import NewAdaptaHOPCatalogue, AdaptaHOPCatalogue
 from pynbody.halo.legacy import RockstarIntermediateCatalogue
 from pynbody.halo.rockstar import RockstarCatalogue
 from pynbody.halo.subfind import SubfindCatalogue
@@ -297,8 +297,11 @@ from pynbody.halo.subfindhdf import SubFindHDFSubhaloCatalogue, SubFindHDFHaloCa
 def _get_halo_classes():
     # AmigaGrpCatalogue MUST be scanned first, because if it exists we probably
     # want to use it, but an AHFCatalogue will probably be on-disk too.
-    _halo_classes = [GrpCatalogue, AmigaGrpCatalogue, AHFCatalogue,
-                     RockstarCatalogue, SubfindCatalogue, SubFindHDFHaloCatalogue,
-                     RockstarIntermediateCatalogue, HOPCatalogue, AdaptaHOPCatalogue]
+    _halo_classes = [
+        GrpCatalogue, AmigaGrpCatalogue, AHFCatalogue,
+        RockstarCatalogue, SubfindCatalogue, SubFindHDFHaloCatalogue,
+        RockstarIntermediateCatalogue, HOPCatalogue,
+        NewAdaptaHOPCatalogue, AdaptaHOPCatalogue,
+    ]
 
     return _halo_classes

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -208,6 +208,8 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         indicating which halo that particle is associated with. If there are multiple
         levels (i.e. subhalos), the number returned corresponds to the lowest level, i.e.
         the smallest subhalo."""
+        if family is None:
+            family == 'dm'
         data = getattr(self.base, family)
 
         iord = data['iord']

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -236,9 +236,21 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         igrp : int array
             An array that contains the index of the group that contains each particle.
         """
+        logger.debug('Get_group_array')
         if family is None:
-            family == 'dm'
-        data = getattr(self.base, family)
+            family == self.base.families()[0]
+        elif isinstance(family, str):
+            families = self.base.families()
+            matched_families = [f for f in families if f.name == family]
+            if len(matched_families) != 1:
+                raise Exception('Could not find family %s' % family)
+            family = matched_families[0]
+        try:
+            data = self.base[family]
+        except:
+            logger.error((type(self.base)))
+            logger.error((type(family)))
+            raise
 
         iord = data['iord']
         iord_argsort = data['iord_argsort']

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -156,7 +156,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
                     # Store dtype for next time
                     self.base._iord_dtype = dtype
 
-                    if not util.is_sorted(iord_array):
+                    if not util.is_sorted(iord_array) == 1:
                         return np.sort(iord_array)
                     else:
                         return iord_array

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -87,6 +87,14 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         self._ahop_compute_offset()
         logger.debug("AdaptaHOPCatalogue loaded")
 
+    def precalculate(self):
+        """Speed up future operations by precalculating the indices
+        for all halos in one operation. This is slow compared to
+        getting a single halo, however."""
+        # Get the mapping from particle to halo
+        self._group_array = self.get_group_array()
+
+
     def _ahop_compute_offset(self):
         """
         Compute the offset in the brick file of each halo.
@@ -196,9 +204,13 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         props["members"] = iord_array
 
         # Create halo object and fill properties
-        halo = Halo(
-            halo_id, self, self.base.dm, index_array=None, iord_array=iord_array
-        )
+        if hasattr(self, '_group_array'):
+            index_array = np.nonzero(self._group_array == halo_id)
+            iord_array = None
+        else:
+            index_array = None
+            iord_array = iord_array
+        halo = Halo(halo_id, self, self.base.dm, index_array=index_array, iord_array=iord_array)
         halo.properties.update(props)
 
         return halo

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -132,7 +132,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
 
         halo = self._halos[halo_id]
         halo_dummy = self._halos[halo_id]
-        halo = self._read_halo_data(halo_id, halo.properties['file_offset'])
+        halo = self._read_halo_data(halo_id, halo.properties["file_offset"])
         halo.dummy = halo_dummy
 
         return halo
@@ -194,7 +194,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         # /!\: AdaptaHOP assumes that 1Mpc == 3.08e24 (exactly)
         boxsize = self.base.properties["boxsize"]
         Mpc2boxsize = boxsize.in_units("cm") / 3.08e24  # Hard-coded in AdaptaHOP...
-        for k in 'xyz':
+        for k in "xyz":
             props[k] = boxsize.in_units("Mpc") * (props[k] / Mpc2boxsize + 0.5)
 
         # Add units for known fields
@@ -207,18 +207,20 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         props["members"] = iord_array
 
         # Create halo object and fill properties
-        if hasattr(self, '_group_to_indices'):
+        if hasattr(self, "_group_to_indices"):
             index_array = self._group_to_indices[halo_id]
             iord_array = None
         else:
             index_array = None
             iord_array = iord_array
-        halo = Halo(halo_id, self, self._base_dm, index_array=index_array, iord_array=iord_array)
+        halo = Halo(
+            halo_id, self, self._base_dm, index_array=index_array, iord_array=iord_array
+        )
         halo.properties.update(props)
 
         return halo
 
-    def get_group_array(self, family='dm', group_to_indices=False):
+    def get_group_array(self, family="dm", group_to_indices=False):
         """Return an array with an integer for each particle in the simulation
         indicating which halo that particle is associated with. If there are multiple
         levels (i.e. subhalos), the number returned corresponds to the lowest level, i.e.
@@ -236,14 +238,14 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         igrp : int array
             An array that contains the index of the group that contains each particle.
         """
-        logger.debug('Get_group_array')
+        logger.debug("Get_group_array")
         if family is None:
             family == self.base.families()[0]
         elif isinstance(family, str):
             families = self.base.families()
             matched_families = [f for f in families if f.name == family]
             if len(matched_families) != 1:
-                raise Exception('Could not find family %s' % family)
+                raise Exception("Could not find family %s" % family)
             family = matched_families[0]
         try:
             data = self.base[family]
@@ -252,8 +254,8 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
             logger.error((type(family)))
             raise
 
-        iord = data['iord']
-        iord_argsort = data['iord_argsort']
+        iord = data["iord"]
+        iord_argsort = data["iord_argsort"]
 
         igrp = np.zeros(len(data), dtype=int) - 1
 
@@ -261,9 +263,9 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
             grp2indices = {}
         with FortranFile(self._fname) as fpu:
             for halo_id, halo in self._halos.items():
-                fpu.seek(halo.properties['file_offset'])
+                fpu.seek(halo.properties["file_offset"])
                 fpu.skip(1)  # number of particles
-                particle_ids = fpu.read_vector('i')
+                particle_ids = fpu.read_vector("i")
 
                 indices = util.binary_search(particle_ids, iord, iord_argsort)
                 assert all(indices < len(iord))

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -3,6 +3,7 @@ import re
 import struct
 from itertools import repeat
 from scipy.io import FortranFile as FF
+import weakref
 
 import numpy as np
 
@@ -76,6 +77,8 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         super(BaseAdaptaHOPCatalogue, self).__init__(sim)
 
         # Initialize internal data
+        self._base_dm = sim.dm
+
         self._halos = {}
         self._fname = fname
         self._AdaptaHOP_fname = fname
@@ -92,6 +95,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         for all halos in one operation. This is slow compared to
         getting a single halo, however."""
         # Get the mapping from particle to halo
+        self._base_dm._family_index()  # filling the cache
         self._group_array = self.get_group_array(group_to_indices=True)
 
     def _ahop_compute_offset(self):
@@ -188,9 +192,9 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
 
         # Convert positions between [-Lbox/2, Lbox/2] to [0, Lbox].
         # /!\: AdaptaHOP assumes that 1Mpc == 3.08e24 (exactly)
-        boxsize = self._base().properties["boxsize"]
+        boxsize = self.base.properties["boxsize"]
         Mpc2boxsize = boxsize.in_units("cm") / 3.08e24  # Hard-coded in AdaptaHOP...
-        for k in "xyz":
+        for k in 'xyz':
             props[k] = boxsize.in_units("Mpc") * (props[k] / Mpc2boxsize + 0.5)
 
         # Add units for known fields
@@ -209,7 +213,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
         else:
             index_array = None
             iord_array = iord_array
-        halo = Halo(halo_id, self, self.base.dm, index_array=index_array, iord_array=iord_array)
+        halo = Halo(halo_id, self, self._base_dm, index_array=index_array, iord_array=iord_array)
         halo.properties.update(props)
 
         return halo

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -120,10 +120,10 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
             raise Exception()
 
         halo = self._halos[halo_id]
-        if not isinstance(halo, Halo):
-            halo = self._halos[halo_id] = self._read_halo_data(
-                halo_id, halo.properties["file_offset"]
-            )
+        halo_dummy = self._halos[halo_id]
+        halo = self._read_halo_data(halo_id, halo.properties['file_offset'])
+        halo.dummy = halo_dummy
+
         return halo
 
     def _read_halo_data(self, halo_id, offset):

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -1915,8 +1915,8 @@ class IndexedSubSnap(SubSnap):
 
         # Find index of particles using a search sort
         iord_base = self.base['iord']
-        iord_argsort = self.base['iord_argsort']
-        index_array = util.binary_search(iord, iord_base, sorter=iord_argsort)
+        iord_base_argsort = self.base['iord_argsort']
+        index_array = util.binary_search(iord, iord_base, sorter=iord_base_argsort)
 
         # TODO: custom search sort to prevent this check
         # Check that the iord match

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -1918,9 +1918,9 @@ class IndexedSubSnap(SubSnap):
         iord_base_argsort = self.base['iord_argsort']
         index_array = util.binary_search(iord, iord_base, sorter=iord_base_argsort)
 
-        # TODO: custom search sort to prevent this check
         # Check that the iord match
-        assert np.all(iord_base[index_array] == iord)
+        if np.any(index_array == len(iord_base)):
+            raise Exception('Some of the requested ids cannot be found in the dataset.')
 
         return index_array
 

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -1909,8 +1909,6 @@ class IndexedSubSnap(SubSnap):
     def _iord_to_index(self, iord):
         # Maps iord to indices. Note that this requires to perform an argsort (O(N log N) operations)
         # and a binary search (O(M log N) operations) with M = len(iord) and N = len(self.base).
-        if 'iord_argsort' not in self.base:
-            self.base['iord_argsort'] = np.argsort(self.base['iord'])
 
         if not util.is_sorted(iord) == 1:
             raise Exception('Expected iord to be sorted in increasing order.')

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -1912,10 +1912,13 @@ class IndexedSubSnap(SubSnap):
         if 'iord_argsort' not in self.base:
             self.base['iord_argsort'] = np.argsort(self.base['iord'])
 
+        if not util.is_sorted(iord) == 1:
+            raise Exception('Expected iord to be sorted in increasing order.')
+
         # Find index of particles using a search sort
         iord_base = self.base['iord']
         iord_argsort = self.base['iord_argsort']
-        index_array = iord_argsort[np.searchsorted(iord_base, iord, sorter=iord_argsort)]
+        index_array = util.binary_search(iord, iord_base, sorter=iord_argsort)
 
         # TODO: custom search sort to prevent this check
         # Check that the iord match


### PR DESCRIPTION
This PR improves the support of adaptahop in pynbody (see #546 for the original PR).

It changes the following behaviour:
- the halo data is not cached any more, as it was causing memory issues,
- to mitigate the computational cost of the aforementioned change, I added an OpenMP-parallelized binary search algorithm that finds items of a sorted array into another sorted array. This improves by a factor of ~2xNCPU the performance compared to the `np.searchsorted` function. This was used to generate an `IndexedSubSnap` from a list of particle ids,
- a new derived array has been defined, namely `iord_argsort` which is the result of `np.argsort(sim['iord'])`,
- implement `get_group_array` for adaptahop, to make it usable with https://github.com/pynbody/tangos (see https://github.com/pynbody/tangos/issues/112).