### PR TITLE
Fix bug introduced by e74e7cb, which broke dependency tracker thread safety

### DIFF
--- a/pynbody/dependencytracker.py
+++ b/pynbody/dependencytracker.py
@@ -10,9 +10,10 @@ class DependencyContext(object):
         self.name = name
 
     def __enter__(self):
-        if self.name in self.tracker._current_calculation_stack:
-            raise DependencyError, "Circular dependency"
         self.tracker._calculation_lock.__enter__()
+        if self.name in self.tracker._current_calculation_stack:
+            self.tracker._calculation_lock.__exit__(None, None, None)
+            raise DependencyError, "Circular dependency"
         self.tracker._push(self.name)
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
The commit e74e7cb fixed a deadlock but also allowed the current set of calculations to mutate between
checking and entering the calculation lock. This caused an intermittent error in multi-threaded
code (especially image rendering).