### PR TITLE
Add functionality to infer starlog from log file

### DIFF
--- a/nose/tipsy_test.py
+++ b/nose/tipsy_test.py
@@ -3,6 +3,7 @@ import numpy as np
 import glob
 import os
 from nose.tools import assert_raises
+import warnings
 
 
 def setup():
@@ -18,6 +19,8 @@ def setup():
 def teardown():
     global f
     del f
+    if os.path.exists("testdata/g15784.lr.log"):
+        os.remove("testdata/g15784.lr.log")
 
 
 def test_get():
@@ -372,3 +375,36 @@ def test_issue_313():
 
 def test_issue_315():
     assert np.allclose(f.g['cs'][:3], [ 319.46246429,  359.4923197,   300.13751002])
+
+def test_read_starlog_no_log():
+    rhoform = f.s['rhoform'].in_units('Msol kpc**-3')[:1000:100]
+    correct = np.array([ 2472533.42024787,  5336799.91228041, 64992197.77874849,
+            16312128.27530325,  2514281.61028265, 14384682.79060703,
+             3334026.53876033, 30041215.63578063, 24977741.02041524,
+            10758492.68887316])
+    assert np.all(np.abs(rhoform - correct) < 1e-7)
+    # h2form should not be in the available starlog keys
+    with assert_raises(Exception):
+        h2form = s.s['h2form']
+
+def test_read_starlog_with_log():
+    # the last key is incorrectly labeled in order to ensure
+    # that the log file is being read
+    with open('testdata/g15784.lr.log', 'w') as logf:
+        logf.write('# ilbDumpIteration: 0\n# bDoSimulateLB: 0\n# starlog data:\n'
+                   '# iOrdStar i4\n# iOrdGas i4\n# timeForm f8\n# rForm[0] f8\n'
+                   '# rForm[1] f8\n# rForm[2] f8\n# vForm[0] f8\n# vForm[1] f8\n#'
+                   ' vForm[2] f8\n# massForm f8\n# rhoForm f8\n# H2FracForm f8\n# end'
+                   ' starlog data\n# TimeOut: none\n\n')
+    rhoform = f.s['rhoform'].in_units('Msol kpc**-3')[:1000:100]
+    correct = np.array([ 2472533.42024787,  5336799.91228041, 64992197.77874849,
+            16312128.27530325,  2514281.61028265, 14384682.79060703,
+             3334026.53876033, 30041215.63578063, 24977741.02041524,
+            10758492.68887316])
+    assert np.all(np.abs(rhoform - correct) < 1e-7)
+
+    correct = np.array([11696.64846193, 11010.78848271, 11035.32739625, 10133.30674776,
+          10795.18204699, 10549.8055167 , 10365.82267086, 10389.80826619,
+          10766.11592458, 10514.57288485])
+    h2form = f.s['h2form'][:1000:100]
+    assert np.all(np.abs(h2form - correct) < 1e-7)

--- a/nose/tipsy_test.py
+++ b/nose/tipsy_test.py
@@ -3,7 +3,6 @@ import numpy as np
 import glob
 import os
 from nose.tools import assert_raises
-import warnings
 
 
 def setup():

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1414,7 +1414,7 @@ class StarLog(SimSnap):
         if meta_name in conversion_dict.keys():
             return conversion_dict[meta_name]
         else:  # this is where cleverness will be needed in the future
-            raise ValueError(f'Unknown starlog entry: {meta_name}')
+            raise ValueError('Unknown starlog entry: ' + meta_name)
 
 
 @TipsySnap.decorator

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1173,11 +1173,12 @@ class StarLog(SimSnap):
         molecH = False
         bigIOrds = False
 
+        # replace only the .starlog suffix with .log
+        self._logfile = '.'.join([x for x in filename.split('.')[:-1]]) + '.log'
 
         if use_log:
             # assumes log file would be in the same location as starlog file
             logger.info('Attempting to load starlog metadata from log file')
-            self._logfile = filename.replace('starlog', 'log')
             try:
                 with open(self._logfile, 'r') as g: 
                     read_metadata = False 


### PR DESCRIPTION
A recent [changa update](https://github.com/N-BodyShop/changa/commit/125d7e92808744f493cba51b6dc39506601b131d) adds metadata about the starlog file to the output log file. This PR adds functionality to first try to read the log file to determine the starlog structure, and then if that fails continues as before with a guess-and-check approach.

The new `StarLog` method `_infer_name_from_tipsy_log` converts from file types written in the changa output log to the standard pynbody keys.