### PR TITLE
Fix bug for GadgetHDF masses

### DIFF
--- a/nose/gadgethdf_test.py
+++ b/nose/gadgethdf_test.py
@@ -180,3 +180,15 @@ def test_hdf_ordering():
     assert snap._family_slice[pynbody.family.gas] == slice(0, 2076907, None)
     assert snap._family_slice[pynbody.family.dm] == slice(2076907, 4174059, None)
     assert snap._family_slice[pynbody.family.star] == slice(4174059, 4194304, None)
+
+
+def test_mass_in_header():
+    f = pynbody.load("testdata/snap_028_z000p000.0.hdf5")
+    f.physical_units()
+    f['mass'] # load all masses
+    assert np.allclose(f.dm['mass'][0], 3981879.2046075417)
+
+    f = pynbody.load("testdata/snap_028_z000p000.0.hdf5")
+    f.physical_units()
+    # don't load all masses, allow it to be loaded for DM only
+    assert np.allclose(f.dm['mass'][0], 3981879.2046075417)

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -353,7 +353,7 @@ class GadgetHDFSnap(SimSnap):
     @staticmethod
     def _get_cosmo_factors(hdf, arr_name) :
         """Return the cosmological factors for a given array"""
-        match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((arr_name in s) & ('PartType' in s))]
+        match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((s.endswith("/"+arr_name)) & ('PartType' in s))]
         if len(match) > 0 : 
             aexp = hdf[match[0]].attrs['aexp-scale-exponent']
             hexp = hdf[match[0]].attrs['h-scale-exponent']


### PR DESCRIPTION
When the mass was stored in a GadgetHDF header, the wrong units could be
inferred in some circumstances.

This was due to the file units system being used to guess the right units.
The file units system in turn had been wrongly inferred, which in turn was
because multiple HDF array names ending in "Mass" were found, some of
which had different units.