### PR TITLE
Massform read

### DIFF
--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -785,9 +785,14 @@ class TipsySnap(SimSnap):
         specified name. If fam is not None, read only the particles of
         the specified family."""
 
-        if filename is None and array_name in ['massform', 'rhoform', 'tempform', 'phiform', 'nsmooth',
-                                               'xform', 'yform', 'zform', 'vxform', 'vyform', 'vzform',
-                                               'posform', 'velform','h2form']:
+        starlog_keys = ['rhoform', 'tempform', 'phiform', 'nsmooth',
+                         'xform', 'yform', 'zform', 'vxform', 'vyform', 'vzform',
+                         'posform', 'velform','h2form']
+        # if massform available as auxiliary array, faster to load it instead
+        if 'massform' not in self.loadable_keys():
+            starlog_keys += ['massform']
+
+        if filename is None and array_name in starlog_keys:
 
             try:
                 self.read_starlog()

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -789,7 +789,7 @@ class TipsySnap(SimSnap):
                          'xform', 'yform', 'zform', 'vxform', 'vyform', 'vzform',
                          'posform', 'velform','h2form']
         # if massform available as auxiliary array, faster to load it instead
-        if 'massform' not in self.loadable_keys():
+        if array_name == 'massform' and 'massform' not in self.loadable_keys():
             starlog_keys += ['massform']
 
         if filename is None and array_name in starlog_keys:


### PR DESCRIPTION
Many tipsy simulations include massform values in both the starlog and an auxiliary array. Pynbody will by default read the massform values from the starlog, though reading them from the auxiliary array is faster (especially in the case of single halos).

I have changed the default to reading from the auxiliary array, if it exists.