### PR TITLE
Addresses matplotlib 3.+ warrning for vmin/vmax in image creation.

### DIFF
--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -458,10 +458,10 @@ def image(sim, qty='rho', width="10 kpc", resolution=500, units=None, log=True,
 
         if ret_im:
             return p.imshow(im[::-1, :].view(np.ndarray), extent=(-width / 2, width / 2, -width / 2, width / 2),
-                            vmin=vmin, vmax=vmax, cmap=cmap, norm = norm)
+                            cmap=cmap, norm = norm)
 
         ims = p.imshow(im[::-1, :].view(np.ndarray), extent=(-width / 2, width / 2, -width / 2, width / 2),
-                       vmin=vmin, vmax=vmax, cmap=cmap, norm = norm)
+                       cmap=cmap, norm = norm)
 
         u_st = sim['pos'].units.latex()
         if not subplot:


### PR DESCRIPTION
Matplotlib 3.3+ issues a warning when specifying vmin/vmax in image creation. The params are part of the normalization specification. Removed from sph.py image(...).