### PR TITLE
Fix to utils_test.py not passing the nosetests

### DIFF
--- a/nose/utils_test.py
+++ b/nose/utils_test.py
@@ -122,10 +122,12 @@ def test_openmp_summations():
 
     start = time.time()
     sum_a = np.dot(a,(b>1.0))
+    print(sum_a)
     np_timing = time.time()-start
 
     start = time.time()
     sum_a_ne = pynbody.util.sum_if_gt(a,b,1.0)
+    print(sum_a_ne)
     ne_timing = time.time()-start
 
 


### PR DESCRIPTION
The test  `utils_test.test_openmp_simulations()` does not pass with Python 3.8.5, numpy 1.19.2. Please see below the error after running the nosetests.

I do not exactly understand what triggers the issue. If you run the code that is inside the function line-by-line in an interactive shell, the test passes. Instead, if you run the function itself in an interactive shell (i.e. `test_openmp_summations()`) the test fails just like when running `nosetests`. After a few more tests, I figured out that the issue lies in defining the arrays by drawing random variables but I didn't get much beyond that.

The easiest fix I found is to add print stamenents to the function (although I do not understand why it fixes the issue). It is not a very elegant solution but it fixes the issue. 

```
======================================================================
FAIL: utils_test.test_openmp_summations
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/luisals/anaconda3/lib/python3.8/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/luisals/Software/pynbody/nose/utils_test.py", line 134, in test_openmp_summations
    npt.assert_allclose(sum_a_ne,sum_a)
  File "/Users/luisals/anaconda3/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 1527, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/Users/luisals/anaconda3/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 840, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference: 258.51905067
Max relative difference: 1.00640654
 x: array(1.645671)
 y: array(-256.87338)
-------------------- >> begin captured stdout << ---------------------
NP: 316.7 NE: 110.0
  vals 1.6 -256.9

--------------------- >> end captured stdout << ----------------------
```