### PR TITLE
Fix for the selection of haloes based on precalculated indices

### DIFF
--- a/nose/gadgethdf_test.py
+++ b/nose/gadgethdf_test.py
@@ -180,3 +180,15 @@ def test_hdf_ordering():
     assert snap._family_slice[pynbody.family.gas] == slice(0, 2076907, None)
     assert snap._family_slice[pynbody.family.dm] == slice(2076907, 4174059, None)
     assert snap._family_slice[pynbody.family.star] == slice(4174059, 4194304, None)
+
+
+def test_mass_in_header():
+    f = pynbody.load("testdata/snap_028_z000p000.0.hdf5")
+    f.physical_units()
+    f['mass'] # load all masses
+    assert np.allclose(f.dm['mass'][0], 3981879.2046075417)
+
+    f = pynbody.load("testdata/snap_028_z000p000.0.hdf5")
+    f.physical_units()
+    # don't load all masses, allow it to be loaded for DM only
+    assert np.allclose(f.dm['mass'][0], 3981879.2046075417)

--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -213,8 +213,8 @@ class GrpCatalogue(HaloCatalogue):
         getting a single halo, however."""
         self._sorted = np.argsort(
             self.base[self._array], kind='mergesort')  # mergesort for stability
-        self._boundaries = util.find_boundaries(
-            self.base[self._array][self._sorted])
+        self._unique_i = np.unique(self.base[self._array])
+        self._boundaries = np.searchsorted(self.base[self._array][self._sorted],self._unique_i)
 
     def get_group_array(self, family=None):
         if family is not None:
@@ -234,20 +234,18 @@ class GrpCatalogue(HaloCatalogue):
             return index
         else:
             # pre-calculated
-            if i >= len(self._boundaries) or i < 0:
-                raise no_exist
-            if self._boundaries[i] < 0:
+            if not np.isin(i,self._unique_i):
                 raise no_exist
 
-            start = self._boundaries[i]
-            if start is None:
-                raise no_exist
+            match = np.where(self._unique_i==i)[0]
 
-            end = None
-            j = i + 1
-            while j < len(self._boundaries) and end is None:
-                end = self._boundaries[j]
-                j += 1
+            start = self._boundaries[match][0]
+            
+            if start == self._boundaries[-1]:
+                # This is the final halo
+                end = None
+            else:
+                end = self._boundaries[match+1][0]
 
             return self._sorted[start:end]
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -516,11 +516,13 @@ class GadgetHDFSnap(SimSnap):
         # Create a dictionary for the units, this will come in handy later
         unitvar = {'U_V': vel_unit, 'U_L': dist_unit, 'U_M': mass_unit,
                    'U_T': time_unit, '[K]': units.K,
-                   'SEC_PER_YEAR': units.yr, 'SOLAR_MASS': units.Msol}
+                   'SEC_PER_YEAR': units.yr, 'SOLAR_MASS': units.Msol,
+                   'solar masses / yr': units.Msol/units.yr}
         # Last two units are to catch occasional arrays like StarFormationRate which don't
         # follow the patter of U_ units unfortunately
         cgsvar = {'U_M': 'g', 'SOLAR_MASS': 'g', 'U_T': 's',
-                  'SEC_PER_YEAR': 's', 'U_V': 'cm s**-1', 'U_L': 'cm', '[K]': 'K'}
+                  'SEC_PER_YEAR': 's', 'U_V': 'cm s**-1', 'U_L': 'cm', '[K]': 'K',
+                  'solar masses / yr': 'g s**-1'}
 
         self._hdf_cgsvar = cgsvar
         self._hdf_unitvar = unitvar
@@ -642,7 +644,8 @@ class SubFindHDFSnap(GadgetHDFSnap) :
 
 class EagleLikeHDFSnap(GadgetHDFSnap):
     """Reads Eagle-like HDF snapshots (download at http://data.cosma.dur.ac.uk:8080/eagle-snapshots/)"""
-    _readable_hdf5_test_key = "PartType0/SubGroupNumber"
+    # _readable_hdf5_test_key = "PartType0/SubGroupNumber"
+    _readable_hdf5_test_key = "PartType1/SubGroupNumber"
 
     def halos(self, subs=None):
         """Load the Eagle FOF halos, or if subs is specified the Subhalos of the given FOF halo number.

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -353,7 +353,7 @@ class GadgetHDFSnap(SimSnap):
     @staticmethod
     def _get_cosmo_factors(hdf, arr_name) :
         """Return the cosmological factors for a given array"""
-        match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((arr_name in s) & ('PartType' in s))]
+        match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((s.endswith("/"+arr_name)) & ('PartType' in s))]
         if len(match) > 0 : 
             aexp = hdf[match[0]].attrs['aexp-scale-exponent']
             hexp = hdf[match[0]].attrs['h-scale-exponent']


### PR DESCRIPTION
With pynbody, one can sort a SimSnap by the unique ids assigned by the halo finder (or by pynbody itself), and run the precalculate() routine to find the "start and stop" indices of each halo, speeding up the selection of multiple haloes from that SimSnap. This process is fundamental to the functioning of the tangos module.

Currently, this process assumes that there are exactly as many of these unique indices as there are haloes in the simulation, running from 1 to N_haloes. Problems arise, however, when a placeholder id is used to signify e.g. unbound particles. This is the case for EAGLE's implementation of SUBFIND, as an example - unbound particles are assigned the id 2^30. In this case, _boundaries is a length 2^30 array containing mostly -1's between the index of the final "real" halo in the box and the final element. Not only does this waste a lot of memory, but the "stop" index of the final halo is assumed to be the next element in _boundaries, which will be -1. This causes all (but one) of the unbound particles in the SimSnap to be assigned to the final halo, which is clearly problematic.

To resolve this, I changed the calculation of the halo boundaries to find all the unique ids in the simulation and search for their locations using numpy's searchsorted routine, returning an array exactly as long as the number of real haloes in the SimSnap. On loading a halo, the boundaries can be easily found in _boundaries by searching for the id in _unique_i.