### PR TITLE
Ensuring HOP catalogues have correct lengths

### DIFF
--- a/pynbody/halo/hop.py
+++ b/pynbody/halo/hop.py
@@ -23,7 +23,7 @@ class HOPCatalogue(GrpCatalogue):
                 raise RuntimeError("Unable to find HOP .tag file in simulation directory")
 
         sim._create_array('hop_grp', dtype=np.int32)
-        sim['hop_grp'] -= 1
+        sim['hop_grp'] = -1
         with open(fname, "rb") as f:
             num_part, = struct.unpack('i', f.read(4))
             if num_part == 8:

--- a/pynbody/halo/hop.py
+++ b/pynbody/halo/hop.py
@@ -38,6 +38,9 @@ class HOPCatalogue(GrpCatalogue):
             sim.dm['hop_grp'] = np.fromfile(f, np.int32, len(sim.dm))
         GrpCatalogue.__init__(self,sim,array="hop_grp")
 
+    def __len__(self):
+        return len(self._halos)
+
     @staticmethod
     def _can_load(sim, arr_name='grp'):
         # Hop output must be in output directory or in output_*/hop directory


### PR DESCRIPTION
Ensures that the HOP halo catalogue returns a consistent length compared to its index structure (issue #530). This ensures that cycling from 0 to __len__ does not miss the last halo in the catalogue (https://github.com/pynbody/tangos/issues/108) 

I verified the behaviour is correct manually, but I cannot find a HOP catalogue to test on in the testdata. Is there one I am missing somewhere?

Martin