### PR TITLE
Fix neighbour list python interface

### DIFF
--- a/nose/sph_smooth_test.py
+++ b/nose/sph_smooth_test.py
@@ -132,8 +132,8 @@ def test_neighbour_list():
     assert hsml == f.g['smooth'][p_idx]
     npt.assert_allclose(hsml,np.sqrt(np.max(dist2))/2, rtol=1e-6)
     assert hsml == 128.19053649902344
-    assert neigh_list == [0, 1, 2, 37, 4, 5, 70, 38, 8, 9, 10, 69, 12, 71, 14, 15, 16,
-                          17, 67, 33, 109, 76, 96, 64, 74, 39, 65, 40, 28, 97, 30, 31]
+    assert neigh_list == [9, 11, 35, 1998, 7, 12, 22, 36, 5, 20, 34, 31, 8, 19, 37, 10, 2018,
+                          2017, 38, 52, 39, 41, 42, 33, 23, 1997, 43, 1996, 24, 40, 25, 21]
     assert dist2 == [0.0, 39369.51953125, 24460.677734375, 31658.59375, 58536.9765625, 57026.3984375, 51718.3515625,
                      47861.25390625, 59311.27734375, 34860.97265625, 36082.15234375, 65731.2578125, 16879.42578125,
                      52811.79296875, 16521.751953125, 17574.501953125, 24489.19140625, 29066.84765625, 36883.796875,
@@ -143,7 +143,9 @@ def test_neighbour_list():
     neighbour_list_all = t.all_nn(n_neigh)
     assert n == neighbour_list_all[0]
     for nl in neighbour_list_all:
-        assert len(nl[2]) == n_neigh
+        assert len(nl[2]) == n_neigh   # always find n_neigh neighbours
+        idx_self = nl[2].index(nl[0])  # index of self in the neighbour list (not necessarily the first element)
+        assert nl[3][idx_self] == 0.0  # distance to self
 
 
 if __name__=="__main__":

--- a/pynbody/sph/kdmain.cpp
+++ b/pynbody/sph/kdmain.cpp
@@ -316,12 +316,9 @@ PyObject *nn_next(PyObject *self, PyObject *args)
 
         PyList_SetItem(retList, 0, PyLong_FromLong(smx->kd->p[smx->pi].iOrder));
         if(kd->nBitDepth==32)
-            PyList_SetItem(retList, 1, PyFloat_FromDouble(
-                        (double)GET<float>(smx->kd->pNumpySmooth, smx->kd->p[smx->pi].iOrder)));
+            PyList_SetItem(retList, 1, PyFloat_FromDouble(GETSMOOTH(float,smx->pi)));
         else
-            PyList_SetItem(retList, 1, PyFloat_FromDouble(
-                        GET<double>(smx->kd->pNumpySmooth, smx->kd->p[smx->pi].iOrder)));
-
+            PyList_SetItem(retList, 1, PyFloat_FromDouble(GETSMOOTH(double,smx->pi)));
         PyList_SetItem(retList, 2, nnList);
         PyList_SetItem(retList, 3, nnDist);
 

--- a/pynbody/sph/kdmain.cpp
+++ b/pynbody/sph/kdmain.cpp
@@ -314,7 +314,7 @@ PyObject *nn_next(PyObject *self, PyObject *args)
             PyList_SetItem(nnDist, i, PyFloat_FromDouble(smx->fList[i]));
         }
 
-        PyList_SetItem(retList, 0, PyLong_FromLong(smx->pi));
+        PyList_SetItem(retList, 0, PyLong_FromLong(smx->kd->p[smx->pi].iOrder));
         if(kd->nBitDepth==32)
             PyList_SetItem(retList, 1, PyFloat_FromDouble(
                         (double)GET<float>(smx->kd->pNumpySmooth, smx->kd->p[smx->pi].iOrder)));

--- a/pynbody/sph/kdmain.cpp
+++ b/pynbody/sph/kdmain.cpp
@@ -239,7 +239,7 @@ PyObject *nn_start(PyObject *self, PyObject *args)
     float hsm;
     float period = BIGFLOAT;
 
-    PyArg_ParseTuple(args, "Oi|f", &kdobj, &nSmooth, &period);
+    PyArg_ParseTuple(args, "Oii|f", &kdobj, &nSmooth, &nProcs, &period);
     kd = (KD)PyCapsule_GetPointer(kdobj, NULL);
 
     if(period<=0)
@@ -302,7 +302,7 @@ PyObject *nn_next(PyObject *self, PyObject *args)
 
     Py_END_ALLOW_THREADS
 
-    if (nCnt != 0)
+    if (nCnt > 0)
     {
         nnList = PyList_New(nCnt); // Py_INCREF(nnList);
         nnDist = PyList_New(nCnt); // Py_INCREF(nnDist);

--- a/pynbody/sph/kdmain.cpp
+++ b/pynbody/sph/kdmain.cpp
@@ -279,7 +279,7 @@ PyObject *nn_start(PyObject *self, PyObject *args)
 /*==========================================================================*/
 PyObject *nn_next(PyObject *self, PyObject *args)
 {
-    long nCnt, i;
+    long nCnt, i, pj;
 
     KD kd;
     SMX smx;
@@ -310,7 +310,8 @@ PyObject *nn_next(PyObject *self, PyObject *args)
 
         for (i=0; i < nCnt; i++)
         {
-            PyList_SetItem(nnList, i, PyLong_FromLong(smx->pList[i]));
+            pj = smx->pList[i];
+            PyList_SetItem(nnList, i, PyLong_FromLong(smx->kd->p[pj].iOrder));
             PyList_SetItem(nnDist, i, PyFloat_FromDouble(smx->fList[i]));
         }
 

--- a/pynbody/sph/kdtree.py
+++ b/pynbody/sph/kdtree.py
@@ -39,6 +39,7 @@ class KDTree(object):
             nn = 64
 
         smx = kdmain.nn_start(self.kdtree, int(nn), 1, self.boxsize)
+        kdmain.domain_decomposition(self.kdtree,1)
 
         while True:
             nbr_list = kdmain.nn_next(self.kdtree, smx)
@@ -115,7 +116,7 @@ class KDTree(object):
         if nn is None:
             nn = 64
 
-        smx = kdmain.nn_start(self.kdtree, int(nn), self.boxsize)
+        smx = kdmain.nn_start(self.kdtree, int(nn), n_proc, self.boxsize)
 
         propid = self.smooth_operation_to_id(mode)
 

--- a/pynbody/sph/kdtree.py
+++ b/pynbody/sph/kdtree.py
@@ -72,7 +72,7 @@ class KDTree(object):
                 nbr_list[3] : list[float]
                     list of distances squared of each neighbouring particles.
 
-            The lists of particle and of the relative distance squared not sorted.
+            The lists of particle and of the relative distance squared are not sorted.
 
         """
         if nn is None:
@@ -146,14 +146,14 @@ class KDTree(object):
             raise ValueError("Unknown smoothing request %s" % name)
 
     def populate(self, mode, nn):
-        """Create the KDTree and and perform operation as specified by `mode`.
+        """Create the KDTree and perform the operation specified by `mode`.
 
         Parameters
         ----------
         mode : str (see `kdtree.smooth_operation_to_id`)
             Specify operation to perform (compute smoothing lengths, density, SPH mean, or SPH dispersion).
         nn : int
-            Number of neighbors to be considered when smoothing.
+            Number of neighbours to be considered when smoothing.
         """
         from . import _thread_map
 
@@ -210,6 +210,7 @@ class KDTree(object):
         Returns
         -------
         output : pynbody.array.SimArray
+            The SPH mean of the input array.
         """
         output = np.empty_like(array)
 
@@ -254,6 +255,7 @@ class KDTree(object):
         Returns
         -------
         output : pynbody.array.SimArray
+            The dispersion of the input array.
         """
         output = np.empty_like(array)
         if hasattr(array, "units"):


### PR DESCRIPTION
I refreshed the methods `kdtree.nn()` and `kdtree.all_nn()`.

Looking at the git blame, I think the code hasn't been updated after kdtree got multithreading support.
I had to dig into the (undocumented) cpp code to try to fix the functionality. The main changes are:

* The signature of `kdmain.nn_start` was not coherent.
* the value returned by `smSmoothStep` wasn't checked properly in `kdmain.nn_next`.
* An initialization `kdmain.domain_decomposition` step was missing.

The last two points probably are an heritage of when multithreading was not implemented.

This PR may help to answer these [two](https://groups.google.com/g/pynbody-users/c/rVuPKYwa1xY/m/suthSAyjAQAJ) [questions](https://groups.google.com/g/pynbody-users/c/yHMYYznGF0k).

