### PR TITLE
Ramses loader fixes

### DIFF
--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -184,3 +184,11 @@ def test_proper_time_loading():
         2.38078038, 4.3666123, 2.68693346, 3.37377901, 3.27283305,
         3.03470615, 2.4334257, 2.65158796, 2.90785361, 2.56396249],
         rtol=1e-5)
+
+
+def test_is_cosmological_without_namelist():
+    # Load a cosmo run, but without the namelist.txt file
+    f_without_namelist = pynbody.load("testdata/ramses_dmo_partial_output_00051")
+    f_without_namelist.physical_units()
+
+    assert(not f_without_namelist._not_cosmological())

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -213,3 +213,15 @@ def test_is_cosmological_without_namelist():
     with np.testing.assert_warns(UserWarning):
         assert (not f_without_namelist._not_cosmological())
 
+
+def test_temperature_derivation():
+    f.g['mu']
+    f.g['temp']
+
+    assert(f.g['mu'].min() != f.g['mu'].max())   # Check that ionized and neutral mu are now generated
+    np.testing.assert_allclose(f.g['mu'][:10], 0.59 * np.ones(10))
+    np.testing.assert_allclose(f.g['mu'].max(), 1.3)
+
+    np.testing.assert_allclose(f.g['temp'][:10], [25988.332966, 27995.231272, 27995.19821, 30516.467776,
+                                                  26931.794949, 29073.739294, 29177.197614, 31917.91444,
+                                                  26931.790284, 29177.242923])

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -87,6 +87,17 @@ def test_rt_arrays():
          1.59989054e-09,   7.61815782e-07,   7.09372161e-08,
          7.76265288e-09,   4.32642383e-09])
 
+
+def test_rt_unit_warning_for_photon_rho():
+    # Issue 542 about photon density unit.
+    # Check that warning informing user about the missing "reduced speed of light" factor is generated
+    # at load time
+    f1 = pynbody.load("testdata/ramses_rt_partial_output_00002", cpus=[1, 2, 3])
+
+    with np.testing.assert_warns(UserWarning):
+        f1.gas['rad_0_rho']
+
+
 def test_all_dm():
     f1 = pynbody.load("testdata/ramses_dmo_partial_output_00051")
     assert len(f1.families())==1

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -187,8 +187,10 @@ def test_proper_time_loading():
 
 
 def test_is_cosmological_without_namelist():
-    # Load a cosmo run, but without the namelist.txt file
+    # Load a cosmo run, but without the namelist.txt file and checks that cosmo detection works with a warning
     f_without_namelist = pynbody.load("testdata/ramses_dmo_partial_output_00051")
     f_without_namelist.physical_units()
 
-    assert(not f_without_namelist._not_cosmological())
+    with np.testing.assert_warns(UserWarning):
+        assert (not f_without_namelist._not_cosmological())
+

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -156,14 +156,22 @@ def test_metals_field_correctly_copied_from_metal():
 
 
 def test_tform_and_tform_raw():
-    # Tform is not available for test data, so test warning generation and that the array is full of -1
-    with np.testing.assert_warns(UserWarning):
-        assert len(f.st['tform']) == len(f.st['tform_raw']) == 2655
-        np.testing.assert_allclose(f.st['tform'], - np.ones((2655,), dtype=np.float64), rtol=1e-5)
+    # Standard test output is a non-cosmological run, for which tform should be read from disk,
+    # rather than transformed. Tform raw and transformed are therefore the same
+    assert len(f.st['tform']) == len(f.st['tform_raw']) == 2655
+    np.testing.assert_allclose(f.st['tform_raw'], f.st['tform'])
 
-    np.testing.assert_allclose(f.st['tform_raw'][:10], [4.58574701, 4.58100771, 4.58284129, 3.18777836, 4.55801122,
-                                                        4.50733498, 4.5100136,  4.57288808, 4.55926183, 4.52128465],
-                               rtol=1e-5)
+    # Now loads a cosmological run, for which tforms have a weird format
+    # Birth files are however not generated for this output, hence tform is filled with -1
+    # Raw tform still carry the original weird units
+    fcosmo = pynbody.load("testdata/output_00080")
+    with np.testing.assert_warns(UserWarning):
+        np.testing.assert_allclose(fcosmo.st['tform'], - np.ones((31990,), dtype=np.float64), rtol=1e-5)
+        np.testing.assert_allclose(fcosmo.st['tform_raw'][:10],
+                                   [-2.72826591, -1.8400868,  -2.35988485, -3.81799766, -2.67772371, -3.22276503,
+                                    -2.5208477,  -2.67845014, -3.17295132, -2.43044642],
+                                   rtol=1e-5)
+
 
 def test_proper_time_loading():
     f_pt = pynbody.load(

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -994,10 +994,17 @@ class RamsesSnap(SimSnap):
         return list(keys_ND)
 
     def _not_cosmological(self):
+        not_cosmological = True
+
         if "cosmo" in self._namelist and self._namelist["cosmo"]:
-            return False
-        else:
-            return True
+            not_cosmological = False
+
+        if not self._namelist:
+            warnings.warn("Namelist file either not found or unable to read" +
+                          "guessing whether run is cosmological from cosmological parameters")
+            not_cosmological = (self._info['omega_k'] == self._info['omega_l'] == 0)
+
+        return not_cosmological
 
     def _convert_tform(self):
         # Copy the existing array in weird Ramses format into a hidden raw array
@@ -1006,7 +1013,7 @@ class RamsesSnap(SimSnap):
 
         if self._is_using_proper_time:
             t0 = analysis.cosmology.age(self, z=0.0, unit="Gyr")
-            birth_time = t0 + self.s["tform_raw"].in_units("Gyr")/self.properties["a"]**2
+            birth_time = t0 + self.s["tform_raw"].in_units("Gyr") / self.properties["a"] ** 2
             birth_time[birth_time > t0] = t0 - 1e-7
             self.star['tform'] = birth_time
         else:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1007,19 +1007,23 @@ class RamsesSnap(SimSnap):
         return not_cosmological
 
     def _convert_tform(self):
-        # Copy the existing array in weird Ramses format into a hidden raw array
-        self.star['tform_raw'] = self.star['tform']
-        self.star['tform_raw'].units = self._file_units_system[1]
+        # Only convert tform for cosmological runs. The built0in tforms for isolated runs
+        # are actually meaningful (issue 554)
+        if not self._not_cosmological():
+            
+            # Copy the existing array in weird Ramses format into a hidden raw array
+            self.star['tform_raw'] = self.star['tform']
+            self.star['tform_raw'].units = self._file_units_system[1]
 
-        if self._is_using_proper_time:
-            t0 = analysis.cosmology.age(self, z=0.0, unit="Gyr")
-            birth_time = t0 + self.s["tform_raw"].in_units("Gyr") / self.properties["a"] ** 2
-            birth_time[birth_time > t0] = t0 - 1e-7
-            self.star['tform'] = birth_time
-        else:
-            from ..analysis import ramses_util
-            # Replace the tform array by its usual meaning using the birth files
-            ramses_util.get_tform(self)
+            if self._is_using_proper_time:
+                t0 = analysis.cosmology.age(self, z=0.0, unit="Gyr")
+                birth_time = t0 + self.s["tform_raw"].in_units("Gyr") / self.properties["a"] ** 2
+                birth_time[birth_time > t0] = t0 - 1e-7
+                self.star['tform'] = birth_time
+            else:
+                from ..analysis import ramses_util
+                # Replace the tform array by its usual meaning using the birth files
+                ramses_util.get_tform(self)
 
     def _read_proper_time(self):
         try:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1076,6 +1076,9 @@ class RamsesSnap(SimSnap):
             elif array_name in grav_blocks:
                 self._load_gas_vars(1)
             elif array_name in self._rt_blocks_3d:
+                warnings.warn("Loading RT data from disk. Photon densities are stored in flux units by Ramses and need "
+                              "to be multiplied by the reduced speed of light of the run to obtain a physical number. "
+                              "This is currently left to the user, see issue 542 for more discussion.")
                 self._load_gas_vars(_gv_load_rt)
                 for u_block in self._rt_blocks_3d:
                     self[fam][u_block].units = self._rt_unit

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1010,7 +1010,7 @@ class RamsesSnap(SimSnap):
         # Only convert tform for cosmological runs. The built0in tforms for isolated runs
         # are actually meaningful (issue 554)
         if not self._not_cosmological():
-            
+
             # Copy the existing array in weird Ramses format into a hidden raw array
             self.star['tform_raw'] = self.star['tform']
             self.star['tform_raw'].units = self._file_units_system[1]
@@ -1154,4 +1154,4 @@ def mass(sim):
 
 @RamsesSnap.derived_quantity
 def temp(sim):
-    return ((sim['p'] / sim['rho']) * (1.22 * units.m_p / units.k)).in_units("K")
+    return ((sim['p'] / sim['rho']) * (sim['mu'] * units.m_p / units.k)).in_units("K")

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1155,4 +1155,13 @@ def mass(sim):
 
 @RamsesSnap.derived_quantity
 def temp(sim):
-    return ((sim['p'] / sim['rho']) * (sim['mu'] * units.m_p / units.k)).in_units("K")
+    """ Gas temperature derived from pressure and density """
+    # Has to be redefined and rederived here from Ramses native variables
+    # to avoid running into circular dependencies with the traditional derived definition
+    # Now uses the self-consistent molecular weight field from pynbody (issue 598)
+    from ..derived import mu
+    mu_est = array.SimArray(np.ones(len(sim)), units="1")
+    for i in range(5):
+        temp = ((sim['p'] / sim['rho']) * (mu_est * units.m_p / units.k)).in_units("K")
+        mu_est = mu(sim, t0=temp)
+    return temp


### PR DESCRIPTION
Hi,

I believe this PR several problems with the Ramses loader that were left standing for a while:

#542: missing physical unit for photon densities in RT runs --> the loader now explicitly warns the user about this missing factor and is tested for warning generation

#554: broken tform for isolated simulations --> loader now tests whether run is cosmoligical before attempting to read the birth files and transforming the `tform` array. Isolated simulations are correctly left untouched and both use cases are tested.

#597: detecting cosmological runs --> loader reinstates the old mechanism to detect cosmological runs, which was more robust than the namelist detection.  It generating a warning when namelist cannot be read or is not found for inferring a cosmological run.

#598: inconsistent `mu` in temperature calculation --> loader now uses the pynbody `mu` field rather than the fixed 1.22. The redefinition of the temperature in the Ramses loader is in fact needed as the traditional definitions generate Circular dependencies. This fix is to wait while the implementation reading the cooling table to infer the molecular weight is ready

Any comments welcome
Martin
