### PR TITLE
More flexibility when reading particle files with RAMSES

### DIFF
--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -321,7 +321,7 @@ ramses_particle_header = (
     ('ncpu', 1, 'i'),
     ('ndim', 1, 'i'),
     ('npart', 1, 'i'),
-    ('randseed', 4, 'i'),
+    ('randseed', -1, 'i'),
     ('nstar', 1, 'i'),
     ('mstar', 1, 'd'),
     ('mstar_lost', 1, 'd'),


### PR DESCRIPTION
When using MC tracer, the local random seed is dumped together with the seed used for tracers. This causes the record 'randseed' to have a length of 8bytes instead of 4.
This fixes it by skipping the record altogether.