### PR TITLE
[BUGFIX] Dyn is a force unit, not pressure

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -288,6 +288,7 @@ m_e: 9.10938188e-31 kg
 
 # Forces
 N: kg m s^-2
+dyn: g cm s^-2
 
 # Energies
 J: N m
@@ -298,7 +299,6 @@ MeV: 1000 keV
 
 # Pressures
 Pa: J m^-3
-dyn: erg cm^-3
 
 # Redshift
 (1+z): a^-1


### PR DESCRIPTION
This fixes the following erroneous unit definition (which should raise an exception)

![image](https://user-images.githubusercontent.com/5411875/113153883-cc195180-9237-11eb-8880-f4628d3af3c1.png)
