### PR TITLE
Support tracer particles

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -178,7 +178,7 @@ birth_time: tform
 # the last family in the list is also assigned to all other positive families
 type-mapping-positive: dm, star, cloud, debris
 
-# families <0 in descending order (i.e. -1, -2,..)
+# families ≤0 in descending order (i.e. 0, -1, -2,..)
 # the last family in the list is also assigned to all other negative families
 type-mapping-negative: gas_tracer, dm_tracer, star_tracer, cloud_tracer, debris_tracer
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -41,7 +41,11 @@ gas: g
 neutrino: n, neu
 bh:
 debris:
-tracer:
+gas_tracer:
+dm_tracer:
+star_tracer:
+cloud_tracer:
+debris_tracer:
 cloud:
 
 [sph]
@@ -176,7 +180,7 @@ type-mapping-positive: dm, star, cloud, debris
 
 # families <0 in descending order (i.e. -1, -2,..)
 # the last family in the list is also assigned to all other negative families
-type-mapping-negative: tracer
+type-mapping-negative: gas_tracer, dm_tracer, star_tracer, cloud_tracer, debris_tracer
 
 # family for the additional sink.csv file
 type-sink: bh

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -639,12 +639,12 @@ class RamsesSnap(SimSnap):
         aggregate_counts_remapped = np.zeros(256, dtype=np.int64)
 
         for ramses_family_id in nonzero_families:
-            if ramses_family_id>128:
-                neg_offset = 256 - ramses_family_id
+            if ramses_family_id>128 or ramses_family_id == 0:
+                neg_offset = (256 - ramses_family_id) % 256
                 if neg_offset>len(negative_typemap):
                     pynbody_family = negative_typemap[-1]
                 else:
-                    pynbody_family = negative_typemap[neg_offset-1]
+                    pynbody_family = negative_typemap[neg_offset]
             else:
                 if ramses_family_id>len(positive_typemap):
                     pynbody_family = positive_typemap[-1]

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -321,7 +321,7 @@ ramses_particle_header = (
     ('ncpu', 1, 'i'),
     ('ndim', 1, 'i'),
     ('npart', 1, 'i'),
-    ('randseed', 4, 'i'),
+    ('randseed', -1, 'i'),
     ('nstar', 1, 'i'),
     ('mstar', 1, 'd'),
     ('mstar_lost', 1, 'd'),


### PR DESCRIPTION
This adds support for tracer particles (as introduced in https://bitbucket.org/rteyssie/ramses/pull-requests/456).

Note that it further requires #607 to be merged.