### PR TITLE
Multi-file Gadget 4 and arepo HDF5 subfind outputs

### DIFF
--- a/nose/subfindhdf_gadget4_test.py
+++ b/nose/subfindhdf_gadget4_test.py
@@ -68,11 +68,10 @@ def test_halo_loading() :
     assert(len(halos_arepo[0]['iord']) == len(halos_arepo[0]) == htest_arepo.load()['halos']['GroupLenType'][0, 1])
 
 
-def test_particle_data() :
-    for htest_file, halocatalogue in [(htest, halos), (htest_arepo, halos_arepo)]:
-        hids = np.random.choice(range(len(halocatalogue)), 5)
-        for hid in hids:
-            assert(np.allclose(halocatalogue[hid].dm['iord'], htest_file[hid]['iord']))
+def test_particle_data():
+    hids = np.random.choice(range(len(halos)), 5)
+    for hid in hids:
+        assert(np.allclose(halos[hid].dm['iord'], htest[hid]['iord']))
 
 
 import six

--- a/nose/subfindhdf_gadget4_test.py
+++ b/nose/subfindhdf_gadget4_test.py
@@ -2,63 +2,77 @@ import pynbody
 
 
 def setup():
-    global snap, halos, subhalos, htest
+    global snap, halos, subhalos, htest, snap_arepo, halos_arepo, subhalos_arepo, htest_arepo
     snap = pynbody.load('testdata/testL10N64/snapshot_000.hdf5')
     halos = snap.halos()
     subhalos = snap.halos(subs=True)
     htest = Halos('testdata/testL10N64/', 0)
+    snap_arepo = pynbody.load('testdata/arepo/cosmobox_015.hdf5')
+    halos_arepo = snap_arepo.halos()
+    subhalos_arepo = snap_arepo.halos(subs=True)
+    htest_arepo = Halos('testdata/arepo/', 15)
 
 
 def teardown():
-    global snap, halos, subhalos, htest
-    del snap, halos, subhalos, htest
+    global snap, halos, subhalos, htest, snap_arepo, halos_arepo, subhalos_arepo, htest_arepo
+    del snap, halos, subhalos, htest, snap_arepo, halos_arepo, subhalos_arepo, htest_arepo
 
 
 def test_catalogue():
     _h_nogrp = snap.halos(grp_array=True)
     _subh_nogrp = snap.halos(subs=True, grp_array=True)
-    for h in [halos, subhalos, _h_nogrp, _subh_nogrp]:
+    _harepo_nogrp = snap_arepo.halos(grp_array=True)
+    _subharepo_nogrp = snap_arepo.halos(subs=True, grp_array=True)
+    for h in [halos, subhalos, _h_nogrp, _subh_nogrp, halos_arepo, subhalos_arepo, _harepo_nogrp, _subharepo_nogrp]:
         assert(isinstance(h, pynbody.halo.subfindhdf.Gadget4SubfindHDFCatalogue)), \
             "Should be a Gadget4SubfindHDFCatalogue catalogue but instead it is a " + str(type(h))
 
 
 def test_header():
     assert(halos.header == htest.loadHeader())
+    assert(halos_arepo.header == htest_arepo.loadHeader())
 
 
 def test_halo_properties():
-    r = htest.load()['halos']
-    hids = np.random.choice(range(len(halos)), 5)
-    for hid in hids:
-        for key in list(r.keys()):
-            if key in list(halos[hid].properties.keys()):
-                np.testing.assert_allclose(halos[hid].properties[key], r[key][hid])
+    for htest_file, halocatalogue in [(htest, halos), (htest_arepo, halos_arepo)]:
+        r = htest_file.load()['halos']
+        hids = np.random.choice(range(len(halocatalogue)), 5)
+        for hid in hids:
+            for key in list(r.keys()):
+                if key in list(halocatalogue[hid].properties.keys()):
+                    np.testing.assert_allclose(halocatalogue[hid].properties[key], r[key][hid])
 
 
 def test_subhalo_properties():
-    r = htest.load()['subhalos']
-    hids = np.random.choice(range(len(subhalos)), 5)
-    for hid in hids:
-        for key in list(r.keys()):
-            if key in list(subhalos[hid].properties.keys()):
-                np.testing.assert_allclose(subhalos[hid].properties[key], r[key][hid])
+    for htest_file, halocatalogue in [(htest, subhalos), (htest_arepo, subhalos_arepo)]:
+        r = htest_file.load()['subhalos']
+        hids = np.random.choice(range(len(halocatalogue)), 5)
+        for hid in hids:
+            for key in list(r.keys()):
+                if key in list(halocatalogue[hid].properties.keys()):
+                    np.testing.assert_allclose(halocatalogue[hid].properties[key], r[key][hid])
 
 
 def test_halo_loading() :
     """ Check that halo loading works """
-    h = halos
     # check that data loading for individual fof groups works
     _ = halos[0]['pos']
     _ = halos[1]['pos']
     _ = halos[0]['mass'].sum()
     _ = halos[1]['mass'].sum()
-    assert(len(halos[0]['iord']) == len(halos[0]) == htest.load()['halos']['GroupLen'][0])
+    _ = halos_arepo[0]['pos']
+    _ = halos_arepo[1]['pos']
+    _ = halos_arepo[0]['mass'].sum()
+    _ = halos_arepo[1]['mass'].sum()
+    assert(len(halos[0]['iord']) == len(halos[0]) == htest.load()['halos']['GroupLenType'][0, 1])
+    assert(len(halos_arepo[0]['iord']) == len(halos_arepo[0]) == htest_arepo.load()['halos']['GroupLenType'][0, 1])
 
 
 def test_particle_data() :
-    hids = np.random.choice(range(len(halos)), 5)
-    for hid in hids:
-        assert(np.allclose(halos[hid].dm['iord'], htest[hid]['iord']))
+    for htest_file, halocatalogue in [(htest, halos), (htest_arepo, halos_arepo)]:
+        hids = np.random.choice(range(len(halocatalogue)), 5)
+        for hid in hids:
+            assert(np.allclose(halocatalogue[hid].dm['iord'], htest_file[hid]['iord']))
 
 
 import six
@@ -112,8 +126,10 @@ class Halos:
     def loadSubhalos(self, fields=None):
         """ Load all subhalo information from the entire group catalog for one snapshot
            (optionally restrict to a subset given by fields). """
-
-        return self.loadObjects("Subhalo", "subhalos", fields)
+        try:
+            return self.loadObjects("Subhalo", "subhalos", fields)
+        except:
+            return self.loadObjects("Subhalo", "subgroups", fields)
 
     def loadHalos(self, fields=None):
         """ Load all halo information from the entire group catalog for one snapshot

--- a/pynbody/halo/subfind.py
+++ b/pynbody/halo/subfind.py
@@ -260,7 +260,14 @@ class SubfindCatalogue(HaloCatalogue):
 
     @staticmethod
     def _can_load(sim, **kwargs):
-        if os.path.exists(SubfindCatalogue._name_of_catalogue(sim)):
-            return True
+        file = SubfindCatalogue._name_of_catalogue(sim)
+        if os.path.exists(file):
+            if os.path.exists(file):
+                if file.endswith(".hdf5"):
+                    return False
+                elif os.listdir(file)[0].endswith(".hdf5"):
+                    return False
+                else:
+                    return True
         else:
             return False

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -425,7 +425,7 @@ class Gadget4SubfindHDFCatalogue(HaloCatalogue):
             length = self._halodat['GroupLenType'][i, self.ptypenum]
             offset = self.get_halo_offsets(halo_id=i)
 
-        x = Halo(i, self, self.base, np.where(np.in1d(self.base['iord'], self.ids[offset: offset + length]))[0])
+        x = Halo(i, self, self.base, np.arange(offset, offset + length))
         x._descriptor = "halo_" + str(i)
         x.properties.update(self.get_halo_properties(i))
         return x

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -499,7 +499,7 @@ class Gadget4SubfindHDFCatalogue(HaloCatalogue):
         """ Copy `file[gname]` dictionary into groupdat dictionary. """
         if groupdat:
             for key in list(groupdat.keys()):
-                groupdat[key] = np.append(groupdat[key], file[gname][key][:])
+                groupdat[key] = np.append(groupdat[key], file[gname][key][:], axis=0)
         else:
             for key in list(file[gname].keys()):
                 groupdat[key] = file[gname][key][:]

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -575,6 +575,11 @@ class Gadget4SubfindHDFCatalogue(HaloCatalogue):
         """ Check if Subfind HDF file exists. """
         file = Gadget4SubfindHDFCatalogue._name_of_catalogue(sim)
         if os.path.exists(file):
-            return True
+            if file.endswith(".hdf5"):
+                return True
+            elif os.listdir(file)[0].endswith(".hdf5"):
+                return True
+            else:
+                return False
         else:
             return False


### PR DESCRIPTION
Hi Andrew, 

I extended my subfind-gadget4 implementation to support (a) Arepo HDF5 subfind outputs and (b) multi-file outputs from either gadget-4 or Arepo. The main difference between Arepo and gadget-4 is that the former does not directly provide particle offsets so one has to compute them based on the group lengths. I also had to modify `subfind.py` to include a check of the files' format in order to load the right catalogue class. I also added some tests using an Arepo snapshot (and the corresponding SUBFIND catalogue) that you already had in your testdata. Let me know what you think!

Best,
Luisa
