### PR TITLE
Fix bug where sometimes family arrays would return the entire simulation

### DIFF
--- a/nose/family_test.py
+++ b/nose/family_test.py
@@ -23,3 +23,10 @@ def test_family_array_null_slice():
     assert len(test[1:9:2].star['TestFamilyArray'])==0 # this always succeeded
     assert len(test[[1, 3, 5, 11,13]].star['TestFamilyArray']) == 2  # this always succeeded
     assert len(test[[1,3,5,7]].star['TestFamilyArray'])==0 # this would fail
+
+def test_family_array_sim():
+    """Test that the simulation of a family array is a family slice"""
+
+    test = pynbody.new(dm=10, star=10)
+    test.dm._create_array('mass')
+    assert test.dm['mass'].sim == test.dm

--- a/nose/ramses_test.py
+++ b/nose/ramses_test.py
@@ -225,3 +225,9 @@ def test_temperature_derivation():
     np.testing.assert_allclose(f.g['temp'][:10], [25988.332966, 27995.231272, 27995.19821, 30516.467776,
                                                   26931.794949, 29073.739294, 29177.197614, 31917.91444,
                                                   26931.790284, 29177.242923])
+
+
+def test_family_array():
+    f.dm['mass']
+    assert "mass" in f.family_keys()
+    assert f.dm['mass'].sim == f.dm

--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -293,12 +293,17 @@ class SimArray(np.ndarray):
 
     @property
     def sim(self):
+
         if hasattr(self.base, 'sim'):
-            if self.family and self.base.sim:
-                return self.base.sim[self.family]
-            else:
-                return self.base.sim
-        return self._sim()
+            base_sim = self.base.sim
+        else:
+            base_sim = self._sim()
+
+        if self.family is not None and base_sim is not None:
+            return base_sim[self.family]
+        else:
+            return base_sim
+
 
     @sim.setter
     def sim(self, s):


### PR DESCRIPTION
SimArray.sim is supposed to point either to the entire simulation, or if it is a family array,
it should point to the family to which it corresponds. In some circumstances, it was returning
the entire simulation despite being a family array which can lead to huge confusion around
indices.