### PR TITLE
Also test on Python 3.10

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
This activates CI tests on Python 3.10 (upcoming stable version).

Keeping this in "work in progress" because at the moment all dependencies have to be compiled (numpy, matplotlib, ...), and that makes the tests extremely slow. If you don't think this is a problem, I'd be happy to merge it as is.