### PR TITLE
Cache unit conversion (13× speedup in halo catalogue access)

### DIFF
--- a/pynbody/snapshot/snapshot_util.py
+++ b/pynbody/snapshot/snapshot_util.py
@@ -26,8 +26,7 @@ class ContainerWithPhysicalUnitsOption:
     @classmethod
     def _cached_unit_conversion(cls, from_unit, dims, ucut=3):
         key = (
-            repr(from_unit._bases),
-            repr(from_unit._powers),
+            from_unit._hash_dimensions(),
             tuple(dims),
             ucut,
         )

--- a/pynbody/snapshot/snapshot_util.py
+++ b/pynbody/snapshot/snapshot_util.py
@@ -25,15 +25,19 @@ class ContainerWithPhysicalUnitsOption:
 
     @classmethod
     def _cached_unit_conversion(cls, from_unit, dims, ucut=3):
-        from_unit_s = repr(from_unit)
-        dims_s = repr(tuple(dims))
-        key = (from_unit_s, dims_s, ucut)
+        key = (
+            repr(from_unit._bases),
+            repr(from_unit._powers),
+            tuple(dims),
+            ucut,
+        )
         if key in cls._units_conversion_cache:
             return cls._units_conversion_cache[key]
 
         try:
             d = from_unit.dimensional_project(dims)
         except units.UnitsException:
+            cls._units_conversion_cache[key] = None
             return
 
         new_unit = reduce(
@@ -63,7 +67,7 @@ class ContainerWithPhysicalUnitsOption:
         if dims is None:
             return
 
-        if ar.units is None or ar.units.is_dimensionless():
+        if ar.units is None:
             return
 
         new_unit = self._cached_unit_conversion(ar.units, dims, ucut=ucut)

--- a/pynbody/snapshot/snapshot_util.py
+++ b/pynbody/snapshot/snapshot_util.py
@@ -26,7 +26,7 @@ class ContainerWithPhysicalUnitsOption:
     @classmethod
     def _cached_unit_conversion(cls, from_unit, dims, ucut=3):
         key = (
-            from_unit._hash_dimensions(),
+            from_unit.dimensionality_as_string(),
             tuple(dims),
             ucut,
         )

--- a/pynbody/units.py
+++ b/pynbody/units.py
@@ -228,9 +228,14 @@ class UnitBase(object):
 
         return state
 
-    def _hash_dimensions(self):
+    def dimensionality_as_string(self):
         """
-        Returns a unique string identifying the dimensions of this unit, ignoring the scale.
+        Returns the dimensionality of the Unit object.
+
+        Example
+        -------
+        > pynbody.units.Unit("3e8 m s**-1 yr").dimensionality_as_string()
+        'm^1'
         """
         state = self._dimension_state()
         return " ".join(

--- a/pynbody/units.py
+++ b/pynbody/units.py
@@ -301,8 +301,9 @@ class NoUnit(UnitBase):
 
     def __init__(self):
         self._no_unit = True
-        self._bases = []
-        self._powers = []
+
+    def _dimension_state(self):
+        return {}
 
     def ratio(self, other, **substitutions):
         if isinstance(other, NoUnit):

--- a/pynbody/units.py
+++ b/pynbody/units.py
@@ -280,6 +280,8 @@ class NoUnit(UnitBase):
 
     def __init__(self):
         self._no_unit = True
+        self._bases = []
+        self._powers = []
 
     def ratio(self, other, **substitutions):
         if isinstance(other, NoUnit):
@@ -340,6 +342,8 @@ class IrreducibleUnit(UnitBase):
     def __init__(self, st):
         self._st_rep = st
         self._register_unit(st)
+        self._bases = []
+        self._powers = []
 
     def __reduce__(self):
         return (_resurrect_named_unit, (self._st_rep, None, None))
@@ -363,6 +367,8 @@ class NamedUnit(UnitBase):
 
         self._represents = represents
         self._register_unit(st)
+        self._bases = represents._bases
+        self._powers = represents._powers
 
     def __reduce__(self):
         return (_resurrect_named_unit, (self._st_rep, getattr(self, '_latex', None), self._represents))


### PR DESCRIPTION
When converting units from a halo catalogue, a *lot* of time is spent doing the `dimensional_project` operation. This PR adds support for a caching mechanism to speed things up.

| Action | Time before (s) | Time with 783033a (s) | Time with 3f4f171   (s) |
|---|--|--|--|
| `f = pynbody.load(…)`| 2 | 2 | 2 |
| `halos = f.halos(); halos.physical_units()` | 0.5 | 0.5 | 0.5 |
| `halos[1]`| 25 | 25 | 25 |
| `[h.properties for h in halos]` | ~2000 | ~300 | ~150 |