### PR TITLE
Fixing bug in theta velocity and adding tests on spherical derivations

### DIFF
--- a/nose/derived_arrays.py
+++ b/nose/derived_arrays.py
@@ -1,0 +1,66 @@
+import pynbody
+import numpy as np
+import weakref
+
+
+def setup():
+    global f, h
+    f = pynbody.new(dm=1000, star=500, gas=500, order='gas,dm,star')
+    f['pos'] = np.random.normal(scale=1.0, size=f['pos'].shape)
+    f['vel'] = np.random.normal(scale=1.0, size=f['vel'].shape)
+    f['mass'] = np.random.uniform(1.0, 10.0, size=f['mass'].shape)
+    f.gas['rho'] = np.ones(500, dtype=float)
+
+
+def test_spherical_coordinates_arrays():
+
+    # Spherical coordinates are derivable
+    assert 'r' in f.derivable_keys()
+    assert 'az' in f.derivable_keys()
+    assert 'theta' in f.derivable_keys()
+
+    # And their associated velocities
+    assert 'vr' in f.derivable_keys()
+    assert 'vphi' in f.derivable_keys()
+    assert 'vtheta' in f.derivable_keys()
+
+    # Derive the arrays
+    f['r'], f['az'], f['theta']
+    f['vr'], f['vphi'], f['vtheta']
+
+    # Test the range of values make sense for spherical coordinates
+
+    # Azimuth is chosen between -pi and pi
+    np.testing.assert_array_less(f['az'], np.pi * np.ones(f['az'].shape))
+    np.testing.assert_array_less(- np.pi * np.ones(f['az'].shape), f['az'])
+
+    # Polar angle is between 0 and pi
+    np.testing.assert_array_less(f['theta'], np.pi * np.ones(f['theta'].shape))
+    np.testing.assert_array_less(np.zeros(f['theta'].shape), f['theta'])
+
+    # Pynbody uses a different approach than projecting to compute spherical coordinates
+    # Check the two methods are producing the same results
+
+    # Should find that x = r cos(azimuth) cos(polar declination)
+    #                  y = r sin(azimuth) cos(polar declination)
+    #                  z = r cos(polar declination)
+    np.testing.assert_allclose(f['x'], f['r'] * np.cos(f['az']) * np.sin(f['theta']))
+    np.testing.assert_allclose(f['y'], f['r'] * np.sin(f['az']) * np.sin(f['theta']))
+    np.testing.assert_allclose(f['z'], f['r'] * np.cos(f['theta']))
+
+    # Should find vr = vx * cos(azimuth) sin(polar declination) + vy sin(azimuth) sin(polar declination)
+    # + vz cos (polar declination)
+    vr = np.sin(f['theta']) * np.cos(f['az']) * f['vx'] + np.sin(f['theta']) * np.sin(f['az']) * f['vy'] + \
+         np.cos(f['theta']) * f['vz']
+    np.testing.assert_allclose(vr, f['vr'])
+
+    # Should find vphi = - vx * sin(azimuth) + vy cos(azimuth) + 0
+    vphi = - np.sin(f['az']) * f['vx'] + np.cos(f['az']) * f['vy']
+    np.testing.assert_allclose(vphi, f['vphi'])
+
+    # Should find vtheta = vx * cos(azimuth) cos(polar declination) + vy sin(azimuth) cos(polar declination)
+    # - vz sin (polar declination)
+    vtheta = np.cos(f['theta']) * np.cos(f['az']) * f['vx'] + np.cos(f['theta']) * np.sin(f['az']) * f['vy'] - \
+             np.sin(f['theta']) * f['vz']
+    np.testing.assert_allclose(vtheta, f['vtheta'])
+

--- a/pynbody/derived.py
+++ b/pynbody/derived.py
@@ -110,7 +110,7 @@ def vtheta(self):
     """Velocity projected to polar direction"""
     return (np.cos(self['az']) * np.cos(self['theta']) * self['vx'] +
             np.sin(self['az']) * np.cos(self['theta']) * self['vy'] -
-            np.sin(self['theta']) * self['vy'])
+            np.sin(self['theta']) * self['vz'])
 
 
 _op_dict = {"mean": "mean velocity",
@@ -209,7 +209,7 @@ for band in bands_available:
 
 @SimSnap.derived_quantity
 def theta(self):
-    """Angle from the z axis, from [0:2pi]"""
+    """Angle from the z axis, from [0:pi]"""
     return np.arccos(self['z'] / self['r'])
 
 

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -345,6 +345,13 @@ class SimSnap(object):
 
         if name in list(self.keys()):
             self._dependency_tracker.touching(name)
+
+            # Ensure that any underlying dependencies on 1D positions and velocities
+            # are forwarded to 3D dependencies as well
+            nd_name = self._array_name_1D_to_ND(name)
+            if nd_name is not None:
+                self._dependency_tracker.touching(nd_name)
+
             return self._get_array(name)
         
         with self._dependency_tracker.calculating(name):


### PR DESCRIPTION
This PR partially address #636, fixing a bug in the derivation of the theta-velocity in spherical polar coordinates and adding a test for it. 