### PR TITLE
BUGFIX: Correctly iterate one-indexed halo catalogues

### DIFF
--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -155,17 +155,20 @@ class HaloCatalogue(snapshot.ContainerWithPhysicalUnitsOption):
 
     def _halo_generator(self, i_start=None, i_stop=None) :
         if len(self) == 0 : return
-        if i_start is None :
-            try :
+        if i_start is None or i_stop is None:
+            try:
                 self[0]
-                i = 0
+                one_indexed = False
             except KeyError :
-                i = 1
+                one_indexed = True
+
+        if i_start is None:
+            i = 1 if one_indexed else 0
         else :
             i = i_start
 
-        if i_stop is None :
-            i_stop = len(self)
+        if i_stop is None:
+            i_stop = len(self) + 1 if one_indexed else len(self)
 
         while True:
             try:

--- a/tests/adaptahop_test.py
+++ b/tests/adaptahop_test.py
@@ -190,3 +190,10 @@ def test_longint_contamination_autodetection(f, fname, Halo_T, ans):
     halos = Halo_T(f, fname=fname)
     assert halos._longint == ans["_longint"]
     assert halos._read_contamination == ans["_read_contamination"]
+
+def test_halo_iteration(halos):
+    h = list(halos)
+
+    assert len(h) == len(halos)
+    assert h[0] is halos[1]
+    assert h[-1] is halos[len(halos)]


### PR DESCRIPTION
This fixes a bug where the last halo in a halo catalogue would not be listed when doing
```python
halos = f.halos()
list(halos)  # is missing the last halo
```
This only happens with one-indexed halo catalogues (e.g. AdaptaHOP).