### PR TITLE
EAGLE compatibility and vital fix for using tangos with EAGLE

### DIFF
--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -546,11 +546,12 @@ class GadgetHDFSnap(SimSnap):
         # Create a dictionary for the units, this will come in handy later
         unitvar = {'U_V': vel_unit, 'U_L': dist_unit, 'U_M': mass_unit,
                    'U_T': time_unit, '[K]': units.K,
-                   'SEC_PER_YEAR': units.yr, 'SOLAR_MASS': units.Msol}
-        # Last two units are to catch occasional arrays like StarFormationRate which don't
-        # follow the patter of U_ units unfortunately
+                   'SEC_PER_YEAR': units.yr, 'SOLAR_MASS': units.Msol,
+                   'solar masses / yr': units.Msol/units.yr, 'BH smoothing': dist_unit}
+        # Some arrays like StarFormationRate don't follow the patter of U_ units
         cgsvar = {'U_M': 'g', 'SOLAR_MASS': 'g', 'U_T': 's',
-                  'SEC_PER_YEAR': 's', 'U_V': 'cm s**-1', 'U_L': 'cm', '[K]': 'K'}
+                  'SEC_PER_YEAR': 's', 'U_V': 'cm s**-1', 'U_L': 'cm', '[K]': 'K',
+                  'solar masses / yr': 'g s**-1', 'BH smoothing': 'cm'}
 
         self._hdf_cgsvar = cgsvar
         self._hdf_unitvar = unitvar

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -654,7 +654,7 @@ class SubFindHDFSnap(GadgetHDFSnap) :
 
 class EagleLikeHDFSnap(GadgetHDFSnap):
     """Reads Eagle-like HDF snapshots (download at http://data.cosma.dur.ac.uk:8080/eagle-snapshots/)"""
-    _readable_hdf5_test_key = "PartType0/SubGroupNumber"
+    _readable_hdf5_test_key = "PartType1/SubGroupNumber"
 
     def halos(self, subs=None):
         """Load the Eagle FOF halos, or if subs is specified the Subhalos of the given FOF halo number.

--- a/pynbody/snapshot/snapshot_util.py
+++ b/pynbody/snapshot/snapshot_util.py
@@ -66,7 +66,7 @@ class ContainerWithPhysicalUnitsOption:
         if dims is None:
             return
 
-        if ar.units is None:
+        if ar.units is None or isinstance(ar.units,units.NoUnit):
             return
 
         new_unit = self._cached_unit_conversion(ar.units, dims, ucut=ucut)


### PR DESCRIPTION
Here are a few small changes that improve (or in one case, fix) compatibility with EAGLE.

I added a few more unit definitions into gadgethdf.py to allow for a few more fields in EAGLE snapshots to be loaded in. While the majority of fields follow the expected unit syntax (U_M, U_V etc.) some fields do not - the most important of which is the star formation rate, which is fixed here. There are many more fields that still aren't accounted for, and I'll probably fix those down the road.

Secondly, I altered the field that gadgethdf uses to identify EAGLE outputs to use PartType1 (dark matter) rather than PartType0 (gas). This allows DM-only simulations to be read as EagleLikeHDFSnap objects.

Finally and most critically, upon updating my version of pynbody to the latest version, recent changes to how units are handled (specifically, the new cached unit conversion system) have broken the method tangos uses to enumerate EAGLE haloes. On adding a simulation to the database, tangos saves a "TangosSubGroupNumber" field to your hdf5 snapshot files, but without any hdf5 attributes. This means that upon loading these back in, pynbody interprets these ids as having unit "pynbody.units.NoUnit". The new unit conversion system can only handle where a unit is None (in which case it skips doing conversion), and not NoUnit. I fixed this by simply also checking whether the unit is NoUnit, and also skipping conversion. Currently, tangos doesn't work at all with EAGLE outputs without this fix!