### PR TITLE
Fix selecting SUBFIND haloes with precalculated indices

### DIFF
--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -296,8 +296,8 @@ class GrpCatalogue(HaloCatalogue):
         getting a single halo, however."""
         self._sorted = np.argsort(
             self.base[self._array], kind='mergesort')  # mergesort for stability
-        self._boundaries = util.find_boundaries(
-            self.base[self._array][self._sorted])
+        self._unique_i = np.unique(self.base[self._array])
+        self._boundaries = np.searchsorted(self.base[self._array][self._sorted],self._unique_i)
 
     def get_group_array(self, family=None):
         if family is not None:
@@ -317,20 +317,18 @@ class GrpCatalogue(HaloCatalogue):
             return index
         else:
             # pre-calculated
-            if i >= len(self._boundaries) or i < 0:
-                raise no_exist
-            if self._boundaries[i] < 0:
+            if not np.isin(i,self._unique_i):
                 raise no_exist
 
-            start = self._boundaries[i]
-            if start is None:
-                raise no_exist
+            match = np.where(self._unique_i==i)[0]
 
-            end = None
-            j = i + 1
-            while j < len(self._boundaries) and end is None:
-                end = self._boundaries[j]
-                j += 1
+            start = self._boundaries[match][0]
+            
+            if start == self._boundaries[-1]:
+                # This is the final halo
+                end = None
+            else:
+                end = self._boundaries[match+1][0]
 
             return self._sorted[start:end]
 


### PR DESCRIPTION
This is quite a substantial change to a very integral part of pynbody, but I think it's an important fix for those using pynbody and SUBFIND together, particularly when also using tangos. I've been using pynbody with this change in place for many months and haven't encountered an issue, but happy to iterate on it a bit. 

With pynbody, one can sort a SimSnap by the unique ids assigned by the halo finder (or by pynbody itself), and run the precalculate() routine to find the "start and stop" indices of each halo, speeding up the selection of multiple haloes from that SimSnap. This process is fundamental to the functioning of the tangos module.

Currently, this process assumes that there are exactly as many of these unique indices as there are haloes in the simulation, running from 1 to N_haloes. Problems arise, however, when a placeholder id is used to signify e.g. unbound particles. This is the case for EAGLE's implementation of SUBFIND, as an example - unbound particles are assigned the id 2^30. In this case, _boundaries is a length 2^30 array containing mostly -1's between the index of the final "real" halo in the box and the final element. Not only does this waste a lot of memory, but the "stop" index of the final halo is assumed to be the next element in _boundaries, which will be -1. This causes all (but one) of the unbound particles in the SimSnap to be assigned to the final halo, which is clearly problematic - it tends to lead to the creation of one big "super halo" in tangos made up of all the unbound particles in the simulation.

To resolve this, I switched from using "util.find_boundaries" to using a combination of np.unique and np.searchsorted to identify all the unique halo finder IDs in the simulation, and identify the boundaries of each halo. With these unique IDs (_unique_i) in hand, the boundaries of halo i can be easily found by searching for i in _unique_i.

As far as I can tell, this method is considerably faster and more memory-efficient for simulations employing subfind (my tangos runs are sped up by factors of 5-6ish), and hopefully shouldn't cause any issues for other simulations.