### PR TITLE
Fixed issue with number of vectors in velocity image

### DIFF
--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -111,11 +111,11 @@ def velocity_image(sim, width="10 kpc", vector_color='black', edgecolor='black',
             width = _units.Unit(width)
         width = width.in_units(sim['pos'].units, **sim.conversion_context())
 
-    width = float(width)
+    width = np.float32(width)
 
-    pixel_size = width / vector_resolution
-    X, Y = np.meshgrid(np.arange(-width / 2 + pixel_size/2, width / 2 + pixel_size/2, pixel_size ),
-                       np.arange(-width / 2 + pixel_size/2, width / 2 + pixel_size/2, pixel_size))
+    pixel_size = width / np.float32(vector_resolution)
+    X, Y = np.meshgrid(np.linspace(-width / 2 + pixel_size/2, width / 2 - pixel_size/2, vector_resolution ),
+                       np.linspace(-width / 2 + pixel_size/2, width / 2 - pixel_size/2, vector_resolution))
 
     im = image(sim, width=width, **kwargs)
 

--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -111,10 +111,10 @@ def velocity_image(sim, width="10 kpc", vector_color='black', edgecolor='black',
             width = _units.Unit(width)
         width = width.in_units(sim['pos'].units, **sim.conversion_context())
 
-    width = np.float32(width)
+    width = float(width)
 
-    pixel_size = width / np.float32(vector_resolution)
-    X, Y = np.meshgrid(np.linspace(-width / 2 + pixel_size/2, width / 2 - pixel_size/2, vector_resolution ),
+    pixel_size = width / float(vector_resolution)
+    X, Y = np.meshgrid(np.linspace(-width / 2 + pixel_size/2, width / 2 - pixel_size/2, vector_resolution),
                        np.linspace(-width / 2 + pixel_size/2, width / 2 - pixel_size/2, vector_resolution))
 
     im = image(sim, width=width, **kwargs)


### PR DESCRIPTION
Minor fix for a small bug in the velocity_image function that I came across. Currently, the coordinates of the velocity image are defined using np.arange, which could sometimes lead to the creation of an array that is 1 element too long in each dimension.

For example, by default pynbody creates a 40x40 image of the velocity field, and then combines it with X, Y (defined using np.meshgrid) to produce the arrows on the image. Using np.arange can lead to a (41,41) shape array being created, which is incompatible with the velocity image.

Using np.linspace instead means you're guaranteed to get X and Y of correct size.