### PR TITLE
Support reading hydro file descriptor blocks

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -216,6 +216,8 @@ parallel-read=8
 # https://bitbucket.org/rteyssie/ramses
 ramses_utils = $HOME/ramses/utils/
 
+# Mapping from RAMSES names (as they appear in XXXX_file_descriptor.txt) to pynbody names
+name-mapping = density:rho, velocity_x:vx, velocity_y:vy, velocity_z:vz, pressure:p, metallicity:metal
 
 
 [gadget-default-output]

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -171,6 +171,15 @@ identity: iord
 levelp: level
 birth_time: tform
 
+# Mapping from RAMSES names (as they appear in XXXX_file_descriptor.txt) to pynbody names
+density:rho
+velocity_x: vx
+velocity_y: vy
+velocity_z: vz
+pressure: p
+metallicity: metal
+
+
 [ramses]
 # For RAMSES format post November 2017: map the raw particle family ID to the pynbody family type
 
@@ -215,10 +224,6 @@ parallel-read=8
 # specify the locations of RAMSES utilities -- obtain from
 # https://bitbucket.org/rteyssie/ramses
 ramses_utils = $HOME/ramses/utils/
-
-# Mapping from RAMSES names (as they appear in XXXX_file_descriptor.txt) to pynbody names
-name-mapping = density:rho, velocity_x:vx, velocity_y:vy, velocity_z:vz, pressure:p, metallicity:metal
-
 
 [gadget-default-output]
 # Gadget files have no intrinsic set of fields, so this defines a

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -171,11 +171,8 @@ identity: iord
 levelp: level
 birth_time: tform
 
-# Mapping from RAMSES names (as they appear in XXXX_file_descriptor.txt) to pynbody names
-density:rho
-velocity_x: vx
-velocity_y: vy
-velocity_z: vz
+# map the names in the XXXX_file_descriptor.txt to pynbody names
+density: rho
 pressure: p
 metallicity: metal
 

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -372,21 +372,30 @@ particle_blocks = list(map(
     str.strip, config_parser.get('ramses', "particle-blocks").split(",")))
 particle_format = [TYPE_MAP[str.strip(e)] for e in config_parser.get('ramses', "particle-format").split(",")]
 
-hydro_blocks = list(map(
-    str.strip, config_parser.get('ramses', "hydro-blocks").split(",")))
-grav_blocks = list(map(
-    str.strip, config_parser.get('ramses', "gravity-blocks").split(",")))
+hydro_blocks = [_.strip() for _ in config_parser.get('ramses', "hydro-blocks").split(",")]
+grav_blocks = [_.strip() for _ in config_parser.get('ramses', "gravity-blocks").split(",")]
+rt_blocks = [_.strip() for _ in config_parser.get('ramses', 'rt-blocks', raw=True).split(",")]
 
-rt_blocks = list(map(
-    str.strip, config_parser.get('ramses', 'rt-blocks', raw=True).split(",")
-))
-
-particle_distinguisher = list(map(
-    str.strip, config_parser.get('ramses', 'particle-distinguisher').split(",")))
-
+particle_distinguisher = [_.strip() for _ in config_parser.get('ramses', 'particle-distinguisher').split(",")]
 positive_typemap = [family.get_family(str.strip(x)) for x in config_parser.get('ramses', 'type-mapping-positive').split(",")]
 
 negative_typemap = [family.get_family(str.strip(x)) for x in config_parser.get('ramses', 'type-mapping-negative').split(",")]
+
+name_mapping = {_.strip() for (_) in config_parser.get('ramses', "name-mapping").split(",")}
+
+
+def read_descriptor(fname):
+    description = []
+    with open(fname, mode="r") as fd:
+        if fd.readline() != "# version:  1\n":
+            raise ValueError("Wrong file format")
+        fd.readline()  # ivar, variable_name, variable_type
+        for line in fd.readlines():
+            i, name, dtype = (_.strip() for _ in line.split(","))
+
+            pynbody_name = name_mapping.get(name, name)
+            description.append(pynbody_name)
+    return description
 
 
 class RamsesSnap(SimSnap):
@@ -445,6 +454,7 @@ class RamsesSnap(SimSnap):
             count+=type_map[fam]
 
         self._num_particles = count
+        self._load_fluid_descriptors()
         self._load_rt_infofile()
         self._decorate()
         self._transfer_sink_data_to_family_array()
@@ -458,6 +468,19 @@ class RamsesSnap(SimSnap):
             warnings.warn(
                 "RamsesSnap is configured to use multiple processes, but the posix_ipc module is missing. Reverting to single thread.",
                 RuntimeWarning)
+
+    def _load_fluid_descriptors(self):
+        types = ["hydro", "grav"]
+        default_blocks = [hydro_blocks, grav_blocks]
+        descriptors_fnames = [f"{ftype}_file_descriptor.txt" for ftype in types]
+
+        for desc_type, default_block, descriptor_fname in zip(types, default_blocks, descriptors_fnames):
+            try:
+                block = read_descriptor(descriptor_fname)
+            except (FileNotFoundError, ValueError):
+                block = default_block
+
+            setattr(self, f"_{desc_type}_blocks", block)
 
     def _load_rt_infofile(self):
         self._rt_blocks = []
@@ -852,7 +875,9 @@ class RamsesSnap(SimSnap):
 
         dims = []
 
-        for i in [hydro_blocks, grav_blocks, self._rt_blocks][mode]:
+        hydr
+
+        for i in [self._hydro_blocks, self._grav_blocks, self._rt_blocks][mode]:
             if i not in self.gas:
                 self.gas._create_array(i)
             if self._ndim < 3 and i[-1] == 'z':
@@ -980,7 +1005,7 @@ class RamsesSnap(SimSnap):
                     keys = set(self.loadable_keys(f0))
         else:
             if fam is family.gas:
-                keys = ['x', 'y', 'z', 'smooth'] + hydro_blocks + self._rt_blocks
+                keys = ['x', 'y', 'z', 'smooth'] + self._hydro_blocks + self._rt_blocks
             elif fam in self._iter_particle_families():
                 keys = self._particle_blocks
             elif fam is self._sink_family:
@@ -1071,9 +1096,9 @@ class RamsesSnap(SimSnap):
                 if 'smooth' not in self.gas:
                     self.gas._create_array('smooth')
                 self._load_gas_pos()
-            elif array_name == 'vel' or array_name in hydro_blocks:
+            elif array_name == 'vel' or array_name in self._hydro_blocks:
                 self._load_gas_vars()
-            elif array_name in grav_blocks:
+            elif array_name in self._grav_blocks:
                 self._load_gas_vars(1)
             elif array_name in self._rt_blocks_3d:
                 warnings.warn("Loading RT data from disk. Photon densities are stored in flux units by Ramses and need "

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -469,7 +469,7 @@ class RamsesSnap(SimSnap):
     def _load_fluid_descriptors(self):
         types = ["hydro", "grav"]
         default_blocks = [hydro_blocks, grav_blocks]
-        descriptors_fnames = [f"{ftype}_file_descriptor.txt" for ftype in types]
+        descriptors_fnames = [os.path.join(self._filename, f"{ftype}_file_descriptor.txt") for ftype in types]
 
         for desc_type, default_block, descriptor_fname in zip(types, default_blocks, descriptors_fnames):
             try:
@@ -871,8 +871,6 @@ class RamsesSnap(SimSnap):
         i1 = 0
 
         dims = []
-
-        hydr
 
         for i in [self._hydro_blocks, self._grav_blocks, self._rt_blocks][mode]:
             if i not in self.gas:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -381,11 +381,9 @@ positive_typemap = [family.get_family(str.strip(x)) for x in config_parser.get('
 
 negative_typemap = [family.get_family(str.strip(x)) for x in config_parser.get('ramses', 'type-mapping-negative').split(",")]
 
-name_mapping = {_.strip() for (_) in config_parser.get('ramses', "name-mapping").split(",")}
-
-
 def read_descriptor(fname):
     description = []
+    name_mapping = namemapper.AdaptiveNameMapper('ramses-name-mapping')
     with open(fname, mode="r") as fd:
         if fd.readline() != "# version:  1\n":
             raise ValueError("Wrong file format")
@@ -393,8 +391,7 @@ def read_descriptor(fname):
         for line in fd.readlines():
             i, name, dtype = (_.strip() for _ in line.split(","))
 
-            pynbody_name = name_mapping.get(name, name)
-            description.append(pynbody_name)
+            description.append(name_mapping(name, reverse=True))
     return description
 
 

--- a/tests/ramses_test.py
+++ b/tests/ramses_test.py
@@ -232,3 +232,13 @@ def test_family_array():
     f.dm['mass']
     assert "mass" in f.family_keys()
     assert f.dm['mass'].sim == f.dm
+
+
+def test_file_descriptor_reading():
+    f = pynbody.load("testdata/prop_time_output_00030")
+
+    expected_fields = ["rho", "vel", "metal", *(f"scalar_{i+1:02d}" for i in range(2))]
+    loadable_fields = f.g.loadable_keys()
+
+    for field in expected_fields:
+        assert field in loadable_fields


### PR DESCRIPTION
RAMSES ships with so-called `file_descriptor`s that describe what variables are written on-disk.

This adds support for reading them automatically.