### PR TITLE
Convert conformal time

### DIFF
--- a/pynbody/analysis/_cosmology_time.pyx
+++ b/pynbody/analysis/_cosmology_time.pyx
@@ -1,0 +1,83 @@
+cimport numpy as np
+
+import numpy as np
+
+from libc.math cimport sqrt
+
+
+cdef double dadtau(double aexp_tau,double O_mat_0,double O_vac_0,double O_k_0):
+    cdef double aexp_tau3 = aexp_tau * aexp_tau * aexp_tau
+    return sqrt( aexp_tau3 * (O_mat_0 + O_vac_0*aexp_tau3 + O_k_0*aexp_tau) )
+
+cdef double dadt(double aexp_t,double O_mat_0,double O_vac_0,double O_k_0):
+    cdef double aexp_t3 = aexp_t * aexp_t * aexp_t
+    return sqrt( (1./aexp_t)*(O_mat_0 + O_vac_0*aexp_t3 + O_k_0*aexp_t) )
+
+
+cdef step_cosmo(double alpha,double tau,double aexp_tau,double t,double aexp_t,double O_mat_0,double O_vac_0,double O_k_0):
+    cdef double dtau,aexp_tau_pre,dt,aexp_t_pre
+
+    dtau = alpha * aexp_tau / dadtau(aexp_tau,O_mat_0,O_vac_0,O_k_0)
+    aexp_tau_pre = aexp_tau - dadtau(aexp_tau,O_mat_0,O_vac_0,O_k_0)*dtau/2.0
+    aexp_tau = aexp_tau - dadtau(aexp_tau_pre,O_mat_0,O_vac_0,O_k_0)*dtau
+    tau = tau - dtau
+
+    dt = alpha * aexp_t / dadt(aexp_t,O_mat_0,O_vac_0,O_k_0)
+    aexp_t_pre = aexp_t - dadt(aexp_t,O_mat_0,O_vac_0,O_k_0)*dt/2.0
+    aexp_t = aexp_t - dadt(aexp_t_pre,O_mat_0,O_vac_0,O_k_0)*dt
+    t = t - dt
+
+    return tau,aexp_tau,t,aexp_t
+
+
+cpdef friedman(double O_mat_0,double O_vac_0,double O_k_0):
+    cdef double alpha=1.e-5,aexp_min=1.e-3,aexp_tau=1.,aexp_t=1.,tau=0.,t=0.
+    cdef int nstep=0,ntable=1000,n_out
+    cdef np.ndarray[double,mode='c'] t_out=np.zeros([ntable+1]),tau_out=np.zeros([ntable+1])
+    cdef double age_tot,delta_tau,next_tau
+
+    while aexp_tau >= aexp_min or aexp_t >= aexp_min:
+       nstep = nstep + 1
+       tau,aexp_tau,t,aexp_t = step_cosmo(alpha,tau,aexp_tau,t,aexp_t,O_mat_0,O_vac_0,O_k_0)
+
+    age_tot=-t
+    if nstep < ntable :
+        ntable = nstep
+        alpha = alpha / 2.
+
+    delta_tau = 20.*tau/ntable/11.
+
+    aexp_tau = 1.
+    aexp_t = 1.
+    tau = 0.
+    t = 0.
+
+    n_out = 0
+    t_out[n_out] = t
+    tau_out[n_out] = tau
+
+    next_tau = tau + delta_tau/10.
+
+    while n_out < ntable/2 :
+        tau,aexp_tau,t,aexp_t = step_cosmo(alpha,tau,aexp_tau,t,aexp_t,O_mat_0,O_vac_0,O_k_0)
+
+        if tau < next_tau:
+            n_out = n_out + 1
+            t_out[n_out] = t
+            tau_out[n_out] = tau
+            next_tau = next_tau + delta_tau/10.
+
+    while aexp_tau >= aexp_min or aexp_t >= aexp_min:
+        tau,aexp_tau,t,aexp_t = step_cosmo(alpha,tau,aexp_tau,t,aexp_t,O_mat_0,O_vac_0,O_k_0)
+
+        if tau < next_tau:
+            n_out = n_out + 1
+            t_out[n_out] = t
+            tau_out[n_out] = tau
+            next_tau = next_tau + delta_tau
+
+    n_out = ntable
+    t_out[n_out] = t
+    tau_out[n_out] = tau
+
+    return tau_out,t_out,delta_tau,ntable,age_tot

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -37,25 +37,21 @@ very easy:
 >>> s = pynbody.load('output_00101')
 >>> pynbody.analysis.ramses_util.get_tform(s)
 
-This now generated a directory called `birth` in the parent directory
-of your output. It then calls the routine `part2birth` located in the
+By default, this will simply convert in-place the formation times.
+If you want the changes to be persistent, you can use
+
+>>> pynbody.analysis.ramses_util.get_tform(s, use_part2birth=True)
+
+This now generates for each `partXXXX.outYYYYY` file a corresponding
+`birthXXXXX.outYYYYY` file containing the formation time in physical units.
+This uses the routine `part2birth` located in the
 RAMSES utils (see the `bitbucket repository
-<https://bitbucket.org/rteyssie/ramses>`_. :func:`get_tform` also
-deletes the previous `tform` array (not from disk, just from the
-currently loaded snapshot). The next time you call :func:`get_tform`,
+<https://bitbucket.org/rteyssie/ramses>`_).
+
+:func:`get_tform` also deletes the previous `tform` array (not from disk, just 
+from the currently loaded snapshot). The next time you call :func:`get_tform`,
 the data will be loaded from the disk and `part2birth` won't need to
 be run again.
-
-Feb 2016 - RS
-Note that in this version of ramses_util I have moved the 'birth' files
-into the output directory to which they pertain. The old code wasn't
-placing them in a subdir of 'birth' in the top output and since I had
-to fix it I thought it better not to have a single directory with
-potentially 1000's of files for all RAMSES outputs. The get_tform
-routine now creates the files under the approrpiate "output_" dir
-and reads them back from there.
-
-
 """
 
 import pynbody
@@ -64,6 +60,7 @@ import numpy as np
 import os
 from pathlib import Path
 from .. units import Unit
+from ..analysis._cosmology_time import friedman
 
 from .. import config_parser
 
@@ -295,28 +292,7 @@ def write_ahf_input(sim, tipsyfile):
     f.close()
 
 
-def get_tform(sim, part2birth_path=part2birth_path):
-    """Use `part2birth` to calculate the formation time of stars in
-    Gyr and **replaces** the original `tform` array.
-
-    **Input**: 
-
-    *sim*: RAMSES snapshot
-
-    **Optional Keywords:** 
-
-    *part2birth_path:* by default, this is
-     $HOME/ramses/utils/f90/part2birth, as specified in
-     `default_config.ini` in your pynbody install directory. You can
-     override this like so -- make a file called ".pynbodyrc" in your
-     home directory, and include
-
-    [ramses]
-
-    ramses_utils = /path/to/your/ramses/utils/directory
-
-    """
-
+def get_tform_using_part2birth(sim, part2birth_path):
     from scipy.io import FortranFile
 
     if hasattr(sim, 'base'):
@@ -360,3 +336,76 @@ def get_tform(sim, part2birth_path=part2birth_path):
     top.s['tform'].units = 'Gyr'
 
     return sim.s['tform']
+
+
+def get_tform(sim, use_part2birth=False, part2birth_path=part2birth_path):
+    """
+    
+    Convert conformal times to physical times for stars and **replaces** the original
+     `tform` array.
+
+    Parameters
+    ----------
+    sim : RAMSES snapshot or subsnapshot
+    use_part2birth : boolean, optional
+        If True, use the `part2birth` tool (see notes below) to convert the formation 
+        times to physical times. If False, use a Python-based convertor.
+        Default: False.
+    part2birth_path : str, optional
+        Path to the `part2birth` util. Only used if `use_part2birth` is also True.
+        See notes for the default value.
+
+
+    Notes
+    -----
+    The default path to `part2birth` is obtained by joining the RAMSES utils
+    path (as read from configuration) and `f90/part2birth`.
+
+    For example, with the following configuration,
+
+        [ramses]
+        ramses_utils = /home/user/ramses/utils
+
+    the default path would be `/home/user/ramses/utils/f90/part2birth`.
+
+    """
+    if use_part2birth:
+        return get_tform_using_part2birth(sim, part2birth_path=part2birth_path)
+
+    if hasattr(sim, 'base'):
+        top = sim.base
+    else:
+        top = sim
+
+    conformal_ages = top.star["tform_raw"].view(np.ndarray)
+
+    cm_per_km = 1e5
+    cm_per_Mpc = 3.085677580962325e+24
+    s_per_Gyr = 3.1556926e+16
+
+    tau_frw, t_frw, dtau, n_frw, time_tot = friedman(
+        top.properties["omegaM0"],
+        top.properties["omegaL0"],
+        1.0 - top.properties["omegaM0"] - top.properties["omegaL0"],
+    )
+    h100 = top.properties["h"]
+    nOver2 = n_frw / 2
+    unit_t = top._info["unit_t"]
+    t_scale = 1.0 / (h100 * 100 * cm_per_km / cm_per_Mpc) / unit_t
+
+    # calculate index into lookup table (n_frw elements in
+    # lookup table)
+    dage = 1 + (10 * conformal_ages / dtau)
+    dage = np.minimum(dage, nOver2 + (dage - nOver2) / 10.0)
+    iage = np.array(dage, dtype=np.int32)
+
+    # linearly interpolate physical times from t_frw and tau_frw lookup
+    # tables.
+    t = t_frw[iage] * (conformal_ages - tau_frw[iage - 1]) / (tau_frw[iage] - tau_frw[iage - 1])
+    t = t + (
+        t_frw[iage - 1] * (conformal_ages - tau_frw[iage]) / (tau_frw[iage - 1] - tau_frw[iage])
+    )
+
+    top.s["tform"] = pynbody.analysis.cosmology.age(sim, z=0) + t * t_scale * unit_t / s_per_Gyr
+    top.s['tform'].units = 'Gyr'
+    return sim.s["tform"]

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -65,8 +65,9 @@ from ..analysis._cosmology_time import friedman
 from .. import config_parser
 
 ramses_utils = config_parser.get('ramses', 'ramses_utils')
+use_part2birth_by_default = config_parser.getboolean('ramses', 'use_part2birth_by_default')
 
-part2birth_path = ramses_utils + 'f90/part2birth'
+part2birth_path = os.path.join(ramses_utils, "f90", "part2birth")
 
 
 def convert_to_tipsy_simple(output, halo=0, filt=None):
@@ -338,7 +339,7 @@ def get_tform_using_part2birth(sim, part2birth_path):
     return sim.s['tform']
 
 
-def get_tform(sim, use_part2birth=False, part2birth_path=part2birth_path):
+def get_tform(sim, use_part2birth=use_part2birth_by_default, part2birth_path=part2birth_path):
     """
     
     Convert conformal times to physical times for stars and **replaces** the original
@@ -350,7 +351,7 @@ def get_tform(sim, use_part2birth=False, part2birth_path=part2birth_path):
     use_part2birth : boolean, optional
         If True, use the `part2birth` tool (see notes below) to convert the formation 
         times to physical times. If False, use a Python-based convertor.
-        Default: False.
+        See notes for the default value.
     part2birth_path : str, optional
         Path to the `part2birth` util. Only used if `use_part2birth` is also True.
         See notes for the default value.
@@ -358,6 +359,15 @@ def get_tform(sim, use_part2birth=False, part2birth_path=part2birth_path):
 
     Notes
     -----
+    The behaviour of the function can be customized in the configuration file.
+
+    The value `use_part2birth_by_default` controls whether the conversion should
+    be made using `part2birth` or in Python. It can be set as follows
+
+        [ramses]
+        use_part2birth_by_default = True  # will use part2birth to convert times
+        use_part2birth_by_default = False  # will use internal Python routine
+
     The default path to `part2birth` is obtained by joining the RAMSES utils
     path (as read from configuration) and `f90/part2birth`.
 

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -65,7 +65,6 @@ from ..analysis._cosmology_time import friedman
 from .. import config_parser
 
 ramses_utils = config_parser.get('ramses', 'ramses_utils')
-use_part2birth_by_default = config_parser.getboolean('ramses', 'use_part2birth_by_default')
 
 part2birth_path = os.path.join(ramses_utils, "f90", "part2birth")
 
@@ -339,7 +338,7 @@ def get_tform_using_part2birth(sim, part2birth_path):
     return sim.s['tform']
 
 
-def get_tform(sim, use_part2birth=use_part2birth_by_default, part2birth_path=part2birth_path):
+def get_tform(sim, use_part2birth=None, part2birth_path=part2birth_path):
     """
     
     Convert conformal times to physical times for stars and **replaces** the original
@@ -379,6 +378,9 @@ def get_tform(sim, use_part2birth=use_part2birth_by_default, part2birth_path=par
     the default path would be `/home/user/ramses/utils/f90/part2birth`.
 
     """
+    if use_part2birth is None:
+        use_part2birth = config_parser.getboolean('ramses', 'use_part2birth_by_default')
+
     if use_part2birth:
         return get_tform_using_part2birth(sim, part2birth_path=part2birth_path)
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -222,6 +222,9 @@ parallel-read=8
 # https://bitbucket.org/rteyssie/ramses
 ramses_utils = $HOME/ramses/utils/
 
+# If true, use part2birth to convert from conformal to physical time
+use_part2birth_by_default = False
+
 [gadget-default-output]
 # Gadget files have no intrinsic set of fields, so this defines a
 # default set and an ordering too (in terms of the pynbody names,

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1041,7 +1041,7 @@ class RamsesSnap(SimSnap):
             # are actually meaningful (issue 554)
             from ..analysis import ramses_util
             # Replace the tform array by its usual meaning using the birth files
-            ramses_util.get_tform(self, use_part2birth=False)
+            ramses_util.get_tform(self)
 
     def _read_proper_time(self):
         try:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -1041,7 +1041,7 @@ class RamsesSnap(SimSnap):
             # are actually meaningful (issue 554)
             from ..analysis import ramses_util
             # Replace the tform array by its usual meaning using the birth files
-            ramses_util.get_tform(self)
+            ramses_util.get_tform(self, use_part2birth=False)
 
     def _read_proper_time(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -256,6 +256,10 @@ cython_fortran_file = Extension('pynbody.extern._cython_fortran_utils',
                                 sources=['pynbody/extern/_cython_fortran_utils.pyx'],
                                 include_dirs=incdir)
 
+cosmology_time = Extension('pynbody.analysis._cosmology_time',
+                           sources=['pynbody/analysis/_cosmology_time.pyx'],
+                           include_dirs=incdir)
+
 interpolate3d_pyx = Extension('pynbody.analysis._interpolate3d',
                               sources = ['pynbody/analysis/_interpolate3d.pyx'],
                               include_dirs=incdir,
@@ -264,7 +268,7 @@ interpolate3d_pyx = Extension('pynbody.analysis._interpolate3d',
 
 
 ext_modules+=[kdmain, gravity, chunkscan, sph_render, halo_pyx, bridge_pyx, util_pyx,
-              cython_fortran_file, interpolate3d_pyx, omp_commands]
+              cython_fortran_file, cosmology_time, interpolate3d_pyx, omp_commands]
 
 if not build_cython :
     for mod in ext_modules :

--- a/tests/ramses_test.py
+++ b/tests/ramses_test.py
@@ -173,48 +173,80 @@ def test_metals_field_correctly_copied_from_metal():
     np.testing.assert_allclose(f.st['metals'][::5000], f.st['metal'][::5000], rtol=1e-5)
 
 
+def _test_tform_checker(tform_raw):
+    np.testing.assert_allclose(
+        tform_raw[:10],
+        [
+            -2.72826591,
+            -1.8400868,
+            -2.35988485,
+            -3.81799766,
+            -2.67772371,
+            -3.22276503,
+            -2.5208477,
+            -2.67845014,
+            -3.17295132,
+            -2.43044642,
+        ],
+        rtol=1e-5,
+    )
+
 def test_tform_and_tform_raw():
     # Standard test output is a non-cosmological run, for which tform should be read from disk,
     # rather than transformed. Tform raw and transformed are therefore the same
-    assert len(f.st['tform']) == len(f.st['tform_raw']) == 2655
-    np.testing.assert_allclose(f.st['tform_raw'], f.st['tform'])
+    assert len(f.st["tform"]) == len(f.st["tform_raw"]) == 2655
+    np.testing.assert_allclose(f.st["tform_raw"], f.st["tform"])
 
-    def check(tform, tform_raw):
-        np.testing.assert_allclose(tform, - np.ones((31990,), dtype=np.float64), rtol=1e-5)
-        np.testing.assert_allclose(tform_raw[:10],
-                                   [-2.72826591, -1.8400868,  -2.35988485, -3.81799766, -2.67772371, -3.22276503,
-                                    -2.5208477,  -2.67845014, -3.17295132, -2.43044642],
-                                   rtol=1e-5)
-
-    # Now loads a cosmological run, for which tforms have a weird format
-    # Birth files are however not generated for this output, hence tform is filled with -1
-    # Raw tform still carry the original weird units
-
-    # First test: use internal conversion
     fcosmo = pynbody.load("testdata/output_00080")
 
-    with pytest.warns(None) as record:
+    warn_msg = (
+        "Namelist file either not found or unable to read. Guessing whether "
+        "run is cosmological from cosmological parameters assuming flat LCDM."
+    )
+    with pytest.warns(UserWarning, match=warn_msg) as record:
         tform = fcosmo.st["tform"]
         tform_raw = fcosmo.st["tform_raw"]
+    assert len(record) == 1
 
-    # Make sure no warning was thrown
-    assert len(record) == 0
+    # Reference values have been computed with `part2birth`
+    np.testing.assert_allclose(
+        tform[:10],
+        (
+            2.7014733811298863,
+            4.067542816866577,
+            3.177232587827327,
+            1.7550122687291079,
+            2.760737434676254,
+            2.2032690196559432,
+            2.956344973463002,
+            2.7598682671833252,
+            2.2475191609123915,
+            3.077730768582204
+        ),
+        rtol=1e-2,
+    )
+    _test_tform_checker(tform_raw)
 
-    check(tform, tform_raw)
 
+def test_tform_and_tform_raw_without_sidecar_files():
     pynbody.config_parser.set("ramses", "use_part2birth_by_default", "True")
     pynbody.config_parser.set("ramses", "ramses_utils", "/this/is/an/invalid/path")
 
+    fcosmo = pynbody.load("testdata/output_00080")
+
     warn_msg = (
-        "Failed to read 'tform' from birth files at .* and "
-        "to generate them with utility at .*"
+        "Failed to read 'tform' from birth files at .* "
+        "and to generate them with utility at .*"
     )
     with pytest.warns(UserWarning, match=warn_msg):
         tform = fcosmo.st["tform"]
         tform_raw = fcosmo.st["tform_raw"]
 
-    check(tform, tform_raw)
+    np.testing.assert_allclose(tform, np.full(31990, -1))
+    _test_tform_checker(tform_raw)
 
+    pynbody.config_parser.set("ramses", "use_part2birth_by_default", "False")
+    pynbody.config_parser.set("ramses", "ramses_utils", "/this/is/an/invalid/path")
 
 def test_proper_time_loading():
     f_pt = pynbody.load(

--- a/tests/ramses_test.py
+++ b/tests/ramses_test.py
@@ -227,11 +227,20 @@ def test_tform_and_tform_raw():
     )
     _test_tform_checker(tform_raw)
 
+@pytest.fixture
+def use_part2birth_by_default():
+    use_part2birth_by_default = pynbody.config_parser.get("ramses", "use_part2birth_by_default")
+    ramses_utils = pynbody.config_parser.get("ramses", "ramses_utils")
 
-def test_tform_and_tform_raw_without_sidecar_files():
     pynbody.config_parser.set("ramses", "use_part2birth_by_default", "True")
     pynbody.config_parser.set("ramses", "ramses_utils", "/this/is/an/invalid/path")
 
+    yield
+
+    pynbody.config_parser.set("ramses", "use_part2birth_by_default", use_part2birth_by_default)
+    pynbody.config_parser.set("ramses", "ramses_utils", ramses_utils)
+
+def test_tform_and_tform_raw_without_sidecar_files(use_part2birth_by_default):
     fcosmo = pynbody.load("testdata/output_00080")
 
     warn_msg = (
@@ -244,9 +253,6 @@ def test_tform_and_tform_raw_without_sidecar_files():
 
     np.testing.assert_allclose(tform, np.full(31990, -1))
     _test_tform_checker(tform_raw)
-
-    pynbody.config_parser.set("ramses", "use_part2birth_by_default", "False")
-    pynbody.config_parser.set("ramses", "ramses_utils", "/this/is/an/invalid/path")
 
 def test_proper_time_loading():
     f_pt = pynbody.load(


### PR DESCRIPTION
RAMSES stores the formation time of objects using conformal time, which then need to be converted to physical times for analysis.

At the moment, the conversion is made using an external tool (`part2birth`, that is shipped along with RAMSES). However, this is quite brittle and requires creating a large number of sidecar files (as many as the number of processors used to run the simulation).

This PR simplifies the process by converting the conformal time to physical time directly from Python without the need for an external tool. Note that the values obtained thus may slightly differ from those obtained with `part2birth` at the percent level.

In addition, I have checked that the results agree within 1% or less in a large cosmological simulation (made of 7,143,831 stellar particles) with the following code:
```python
import pynbody

f = pynbody.load("../data/halo_000480/hydro_reference/output_00200")
f.star["tform_python"] = pynbody.analysis.ramses_util.get_tform(f.star, use_part2birth=False)
f.star["tform_ramses"] = pynbody.analysis.ramses_util.get_tform(f.star, use_part2birth=True)

np.testing.assert_allclose(
    f.star["tform_python"],
    f.star["tform_ramses"],
    rtol=5e-3,
)
```