### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+minimum_pre_commit_version: "1.15.0"
+
+ci:
+    autofix_prs: false
+
+repos:
+-   repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.20.0
+    hooks:
+    -   id: setup-cfg-fmt
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: no-commit-to-branch
+      args: [--branch, master]
+    - id: check-shebang-scripts-are-executable
+    - id: check-executables-have-shebangs
+    - id: check-yaml
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+    - id: pyupgrade
+      args: [--py37-plus]
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    -   id: rst-backticks
+- repo: https://github.com/nbQA-dev/nbQA
+  rev: 1.2.3
+  hooks:
+    - id: nbqa-pyupgrade
+      args: [--nbqa-mutate, --py37-plus]
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+      name: isort (python)
+    - id: isort
+      name: isort (cython)
+      types: [cython]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   rev: 1.2.3
   hooks:
     - id: nbqa-pyupgrade
-      args: [--nbqa-mutate, --py37-plus]
+      args: [--py37-plus]
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ pynbody
 [Pynbody](https://github.com/pynbody/pynbody) is a light-weight,
 portable, format-transparent analysis framework for N-body and
 hydrodynamic astrophysical simulations supporting PKDGRAV/Gasoline,
-Gadget, N-Chilada, and RAMSES AMR outputs. 
+Gadget, N-Chilada, and RAMSES AMR outputs.
 
 Written in Python, the core tools are accompanied by a library of
-publication-level analysis routines. For a quick tour of some of 
+publication-level analysis routines. For a quick tour of some of
 the features, have a look at this [IPython notebook](http://nbviewer.ipython.org/github/pynbody/pynbody/blob/master/examples/pynbody_demo.ipynb).
 
 *Since August 2020, pynbody supports only Python 3.5 or later*. To reflect this change, we are moving to a new semantic version numbering scheme, starting with 1.0.0.  Earlier versions of pynbody (prior to 1.0) can be installed for users who are still transitioning away from Python 2, support for which ended in January 2020.
 
 
-### Getting started 
+### Getting started
 
 If python and the standard pip package manager is installed and properly configured, you can simply do:
 
@@ -29,20 +29,18 @@ you have the package installed, try the introductory
 The full documentation can be found
 [here](http://pynbody.github.io/pynbody/).
 
-### Contributing 
+### Contributing
 
-Help us make *pynbody* better! As you develop analysis for your science with pynbody, consider making your code available for everyone else to use. You can do this by creating a [tutorial](http://pynbody.github.io/pynbody/tutorials/tutorials.html) or [cookbook](http://pynbody.github.io/pynbody/tutorials/tutorials.html#cookbook-recipes) or by adding your code to the relevant sub-module and submitting a pull request (make a fork first -- see https://help.github.com/articles/using-pull-requests). 
+Help us make *pynbody* better! As you develop analysis for your science with pynbody, consider making your code available for everyone else to use. You can do this by creating a [tutorial](http://pynbody.github.io/pynbody/tutorials/tutorials.html) or [cookbook](http://pynbody.github.io/pynbody/tutorials/tutorials.html#cookbook-recipes) or by adding your code to the relevant sub-module and submitting a pull request (make a fork first -- see https://help.github.com/articles/using-pull-requests).
 
 
 ### Acknowledging the code
 
 When using pynbody, please acknowledge it by citing the [Astrophysics Source Code Library entry](http://adsabs.harvard.edu/abs/2013ascl.soft05002P). Optionally you can also cite the Zenodo DOI for the specific version of pynbody that you are using, which may be found [here](https://doi.org/10.5281/zenodo.1297087).
 
-### Support and Contact 
+### Support and Contact
 
 If you have trouble with Pynbody or you have feature
-requests/suggestions you can [submit an issue](https://github.com/pynbody/pynbody/issues), 
+requests/suggestions you can [submit an issue](https://github.com/pynbody/pynbody/issues),
 and/or send us an email on the [Usergroup mailing
 list](https://groups.google.com/forum/?fromgroups#!forum/pynbody-users).
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,17 @@ requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython"]
 
 [tool.pytest.ini_options]
 testpaths = ['tests']
+
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+known_third_party = [
+  "IPython",
+  "numpy",
+  "matplotlib",
+  "pytest",
+]
+known_first_party = [
+  "pynbody",
+]
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]


### PR DESCRIPTION
This adds a configuration file for `pre-commit`. This applies a set of automatic fixes and formatting checks to all code committed to the repository.

# Activated checks

- setup-cfg-fmt: Make sure the setup.cfg file is properly formatted (useless for now, will become useful if we migrate to using `setup.cfg` rather than `setup.py`
- trailing-whitespace, end-of-file-fixer, no-commit-to-branch, check-shebang-scripts-are-executable, check-executables-have-shebangs and check-yaml are simple self-explanatory checks
- pyupgrade: automatically update the files using pyupgrade to support recent Python features (can be controlled using the args flag, currently set at Python 3.7)
- rst-backticks: Detect common mistake of using single backticks when writing rst
- nbqa-pyupgrade: also apply pyupgrade to ipython notebooks.
- sort: sorts the imports in all python files.

# CI-side
On the CI-side, this activates an extra check to pass for a PR to turn “green”.

Most issues can be automatically fixed by simply commenting `pre-commit.ci autofix` on the PR to be updated.

# Developer
pre-commit hooks also run on the developer side.
To that end,  one first needs to install pre-commit and activate it
```
python -m install pre-commit
# In the foloder
pre-commit install
```
Now, each time the developer wants to commit something, the hooks will all be run (exactly as on the CI). The commit will be rejected if any of the tests do not pass.