### PR TITLE
Reading units issue solved

### DIFF
--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -563,9 +563,18 @@ class GadgetHDFSnap(SimSnap):
 
         cosmo = 'HubbleParam' in list(self._get_hdf_parameter_attrs().keys())
         if cosmo:
-            for fac in self._get_cosmo_factors(self._hdf_files[0], 'Coordinates'): dist_unit *= fac
-            for fac in self._get_cosmo_factors(self._hdf_files[0], 'Velocities'): vel_unit *= fac
-            for fac in self._get_cosmo_factors(self._hdf_files[0], 'Mass'): mass_unit *= fac
+            try:
+                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Coordinates'): dist_unit *= fac
+            except:
+                dist_unit *= units.a * units.h**-1
+            try:
+                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Velocities'): vel_unit *= fac
+            except:
+                vel_unit *= units.a**(1,2)
+            try:
+                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Mass'): mass_unit *= fac
+            except:
+                mass_unit *= units.h**-1
 
         self._file_units_system = [units.Unit(x) for x in [
             vel_unit, dist_unit, mass_unit, "K"]]

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -365,7 +365,7 @@ class GadgetHDFSnap(SimSnap):
     def _get_cosmo_factors(hdf, arr_name) :
         """Return the cosmological factors for a given array"""
         match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((s.endswith("/"+arr_name)) & ('PartType' in s))]
-        if (arr_name == 'Mass' or 'Masses') and len(match) == 0:
+        if (arr_name == 'Mass' or arr_name == 'Masses') and len(match) == 0:
             # mass stored in header. We're out in the cold on our own.
             warnings.warn("Masses are either stored in the header or have another dataset name; assuming the cosmological factor %s" % units.h**-1)
             return units.Unit('1.0'), units.h**-1

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -571,7 +571,7 @@ class GadgetHDFSnap(SimSnap):
                 vel_unit *= units.a**(1,2)
                 warnings.warn("Unable to find cosmological factors in HDF file; assuming velocity is %s" % vel_unit)
             try:
-                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Mass'): vel_unit *= fac
+                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Mass'): mass_unit *= fac
             except KeyError:
                 mass_unit *= units.h**-1
                 warnings.warn("Unable to find cosmological factors in HDF file; assuming mass is %s" % mass_unit)

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -365,9 +365,9 @@ class GadgetHDFSnap(SimSnap):
     def _get_cosmo_factors(hdf, arr_name) :
         """Return the cosmological factors for a given array"""
         match = [s for s in GadgetHDFSnap._get_hdf_allarray_keys(hdf) if ((s.endswith("/"+arr_name)) & ('PartType' in s))]
-        if arr_name == 'Mass' and len(match) == 0:
-            # mass stored in header. We're out in the cold on our own.
-            return units.Unit('1.0'), units.h**-1
+        if len(match) == 0:
+                # no match
+            return False, False
         if len(match) > 0 :
             try:
                 aexp = hdf[match[0]].attrs['aexp-scale-exponent']
@@ -380,9 +380,6 @@ class GadgetHDFSnap(SimSnap):
                 # gadget4 <sigh>
                 hexp = hdf[match[0]].attrs['h_scaling']
             return units.a**util.fractions.Fraction.from_float(float(aexp)).limit_denominator(), units.h**util.fractions.Fraction.from_float(float(hexp)).limit_denominator()
-        else :
-            return units.Unit('1.0'), units.Unit('1.0')
-
 
     def _get_units_from_hdf_attr(self, hdfattrs) :
         """Return the units based on HDF attributes VarDescription"""
@@ -565,16 +562,24 @@ class GadgetHDFSnap(SimSnap):
         if cosmo:
             try:
                 for fac in self._get_cosmo_factors(self._hdf_files[0], 'Coordinates'): dist_unit *= fac
-            except:
+            except KeyError:
                 dist_unit *= units.a * units.h**-1
+                warnings.warn("Unable to find cosmological factors in HDF file; assuming position is %s" % dist_unit)
             try:
                 for fac in self._get_cosmo_factors(self._hdf_files[0], 'Velocities'): vel_unit *= fac
-            except:
+            except KeyError:
                 vel_unit *= units.a**(1,2)
+                warnings.warn("Unable to find cosmological factors in HDF file; assuming velocity is %s" % vel_unit)
             try:
-                for fac in self._get_cosmo_factors(self._hdf_files[0], 'Mass'): mass_unit *= fac
-            except:
+                fac = self._get_cosmo_factors(self._hdf_files[0], 'Mass')
+                if not fac[0]:
+                    fac = self._get_cosmo_factors(self._hdf_files[0], 'Masses')
+                    if not fac[0]:
+                        mass_unit *= units.h**-1
+                        warnings.warn("Masses are stored in the header; assuming mass is %s" % mass_unit)
+            except KeyError:
                 mass_unit *= units.h**-1
+                warnings.warn("Unable to find cosmological factors in HDF file; assuming mass is %s" % mass_unit)
 
         self._file_units_system = [units.Unit(x) for x in [
             vel_unit, dist_unit, mass_unit, "K"]]


### PR DESCRIPTION
Cosmological factors a and h were impossible to retrieve from AREPO snapshots and the code, consequently, crashed.

In the function _get_cosmo_factors, the case where the attributes 'aexp-scale-exponent', 'aexp-scale-exponent', 'aexp-scale-exponent', and ''aexp-scale-exponent'' was not handled.

I forced gadget-like factors in this case.