### PR TITLE
Unify the Subfind implementation

### DIFF
--- a/pynbody/array.py
+++ b/pynbody/array.py
@@ -864,7 +864,7 @@ class IndexedSimArray:
 
     def _reexpress_index(self, index):
         if isinstance(index, tuple) or (isinstance(index, list) and len(index) > 0 and hasattr(index[0], '__len__')):
-            return [self._ptr[index[0]]] + list(index[1:])
+            return (self._ptr[index[0]],) + tuple(index[1:])
         else:
             return self._ptr[index]
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -67,7 +67,7 @@ approximate-fast-images: True
 
 [gadgethdf-type-mapping]
 gas: PartType0
-dm: PartType1
+dm: PartType1, PartType2, PartType3
 star: PartType4
 bh: PartType5
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -8,7 +8,7 @@
 [general]
 verbose: False
 snap-class-priority: RamsesSnap, GrafICSnap, NchiladaSnap, GadgetSnap, EagleLikeHDFSnap, GadgetHDFSnap, SubFindHDFSnap, TipsySnap, AsciiSnap
-halo-class-priority: GrpCatalogue, AmigaGrpCatalogue, RockstarIntermediateCatalogue, RockstarCatalogue, AHFCatalogue, SubfindCatalogue, NewAdaptaHOPCatalogue, AdaptaHOPCatalogue, HOPCatalogue, Gadget4SubfindHDFCatalogue
+halo-class-priority: GrpCatalogue, AmigaGrpCatalogue, RockstarIntermediateCatalogue, RockstarCatalogue, AHFCatalogue, SubfindCatalogue, NewAdaptaHOPCatalogue, AdaptaHOPCatalogue, HOPCatalogue, Gadget4SubfindHDFCatalogue, ArepoSubfindHDFCatalogue
 
 centering-scheme: ssc
 

--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -373,7 +373,7 @@ from pynbody.halo.hop import HOPCatalogue
 from pynbody.halo.legacy import RockstarIntermediateCatalogue
 from pynbody.halo.rockstar import RockstarCatalogue
 from pynbody.halo.subfind import SubfindCatalogue
-from pynbody.halo.subfindhdf import Gadget4SubfindHDFCatalogue, SubFindHDFHaloCatalogue
+from pynbody.halo.subfindhdf import Gadget4SubfindHDFCatalogue, SubFindHDFHaloCatalogue, ArepoSubfindHDFCatalogue
 
 
 def _get_halo_classes():
@@ -383,7 +383,8 @@ def _get_halo_classes():
         GrpCatalogue, AmigaGrpCatalogue, AHFCatalogue,
         RockstarCatalogue, SubfindCatalogue, SubFindHDFHaloCatalogue,
         NewAdaptaHOPCatalogue, AdaptaHOPCatalogue,
-        RockstarIntermediateCatalogue, HOPCatalogue, Gadget4SubfindHDFCatalogue
+        RockstarIntermediateCatalogue, HOPCatalogue, Gadget4SubfindHDFCatalogue,
+        ArepoSubfindHDFCatalogue
     ]
 
     return _halo_classes

--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -373,7 +373,11 @@ from pynbody.halo.hop import HOPCatalogue
 from pynbody.halo.legacy import RockstarIntermediateCatalogue
 from pynbody.halo.rockstar import RockstarCatalogue
 from pynbody.halo.subfind import SubfindCatalogue
-from pynbody.halo.subfindhdf import Gadget4SubfindHDFCatalogue, SubFindHDFHaloCatalogue, ArepoSubfindHDFCatalogue
+from pynbody.halo.subfindhdf import (
+    ArepoSubfindHDFCatalogue,
+    Gadget4SubfindHDFCatalogue,
+    SubFindHDFHaloCatalogue,
+)
 
 
 def _get_halo_classes():

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -22,15 +22,22 @@ class SubFindHDFSubhaloCatalogue(HaloCatalogue) :
 
         self._group_id = group_id
         self._group_catalogue = group_catalogue
+        self.__calc_len()
+
+    def __calc_len(self):
+        next_group_id = self._group_id + 1
+        next_first_subhalo = self._group_catalogue.nsubhalos
+        while next_group_id < len(self._group_catalogue._fof_group_first_subhalo)-1:
+            if self._group_catalogue._fof_group_first_subhalo[self._group_id + 1]!=-1:
+                next_first_subhalo = self._group_catalogue._fof_group_first_subhalo[next_group_id]
+                break
+            next_group_id+=1
 
 
+        self._len = (next_first_subhalo - self._group_catalogue._fof_group_first_subhalo[self._group_id])
 
     def __len__(self):
-        if self._group_id == (len(self._group_catalogue._fof_group_first_subhalo)-1) :
-            return self._group_catalogue.nsubhalos - self._group_catalogue._fof_group_first_subhalo[self._group_id]
-        else:
-            return (self._group_catalogue._fof_group_first_subhalo[self._group_id + 1] -
-                    self._group_catalogue._fof_group_first_subhalo[self._group_id])
+        return self._len
 
     def _get_halo(self, i):
         if self.base is None :
@@ -246,6 +253,20 @@ class SubFindHDFHaloCatalogue(HaloCatalogue) :
     def _get_halodata_array(self, hdf_file, array_name, halo_or_group, particle_type):
         # In gadget3 implementation, halo_or_group is not needed. In Gadget4 implementation (below), it is.
         return hdf_file[particle_type][array_name]
+
+    def get_halo_properties(self, i, with_unit=True):
+        if with_unit:
+            extract = units.get_item_with_unit
+        else:
+            extract = lambda array, element: array[element]
+        properties = {}
+        if self._sub_mode:
+            for key in self._sub_properties:
+                properties[key] = extract(self._sub_properties[key], i)
+        else:
+            for key in self._fof_properties:
+                properties[key] = extract(self._fof_properties[key], i)
+        return properties
 
     def _get_halo(self, i) :
         if self.base is None :

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -170,25 +170,17 @@ class SubFindHDFHaloCatalogue(HaloCatalogue) :
         return self.base._get_units_from_hdf_attr(hdf0[hdf_key][property_key].attrs)
 
     def __reshape_multidimensional_properties(self):
-        sub_properties = self._sub_properties
-        fof_properties = self._fof_properties
+        self.__reshape_multidimensional_properties_one_dictionary(self._sub_properties)
+        self.__reshape_multidimensional_properties_one_dictionary(self._fof_properties)
 
-        for key in list(sub_properties.keys()):
+    def __reshape_multidimensional_properties_one_dictionary(self, properties_dict):
+        for key in list(properties_dict.keys()):
             # Test if there are no remainders, i.e. array is multiple of halo length
             # then solve for the case where this is 1, 2 or 3 dimension
-            if len(sub_properties[key]) % self.nsubhalos == 0:
-                ndim = len(sub_properties[key]) // self.nsubhalos
+            if len(properties_dict[key]) % self.nsubhalos == 0:
+                ndim = len(properties_dict[key]) // self.nsubhalos
                 if ndim > 1:
-                    sub_properties[key] = sub_properties[key].reshape(self.nsubhalos, ndim)
-
-            try:
-                # The case fof FOF
-                if len(fof_properties[key]) % self.ngroups == 0:
-                    ndim = len(fof_properties[key]) // self.ngroups
-                    if ndim > 1:
-                        fof_properties[key] = fof_properties[key].reshape(self.ngroups, ndim)
-            except KeyError:
-                pass
+                    properties_dict[key] = properties_dict[key].reshape(self.nsubhalos, ndim)
 
     def __reassign_properties_from_sub_to_fof(self):
         reassign = []

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -170,17 +170,17 @@ class SubFindHDFHaloCatalogue(HaloCatalogue) :
         return self.base._get_units_from_hdf_attr(hdf0[hdf_key][property_key].attrs)
 
     def __reshape_multidimensional_properties(self):
-        self.__reshape_multidimensional_properties_one_dictionary(self._sub_properties)
-        self.__reshape_multidimensional_properties_one_dictionary(self._fof_properties)
+        self.__reshape_multidimensional_properties_one_dictionary(self._sub_properties, self.nsubhalos)
+        self.__reshape_multidimensional_properties_one_dictionary(self._fof_properties, self.ngroups)
 
-    def __reshape_multidimensional_properties_one_dictionary(self, properties_dict):
+    def __reshape_multidimensional_properties_one_dictionary(self, properties_dict, expected_array_length):
         for key in list(properties_dict.keys()):
             # Test if there are no remainders, i.e. array is multiple of halo length
             # then solve for the case where this is 1, 2 or 3 dimension
-            if len(properties_dict[key]) % self.nsubhalos == 0:
-                ndim = len(properties_dict[key]) // self.nsubhalos
+            if len(properties_dict[key]) % expected_array_length == 0:
+                ndim = len(properties_dict[key]) // expected_array_length
                 if ndim > 1:
-                    properties_dict[key] = properties_dict[key].reshape(self.nsubhalos, ndim)
+                    properties_dict[key] = properties_dict[key].reshape(expected_array_length, ndim)
 
     def __reassign_properties_from_sub_to_fof(self):
         reassign = []

--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -467,10 +467,10 @@ def image(sim, qty='rho', width="10 kpc", resolution=500, units=None, log=True,
 
         if ret_im:
             return p.imshow(im[::-1, :].view(np.ndarray), extent=(-width / 2, width / 2, -width / 2, width / 2),
-                            vmin=vmin, vmax=vmax, cmap=cmap, norm = norm)
+                            cmap=cmap, norm = norm)
 
         ims = p.imshow(im[::-1, :].view(np.ndarray), extent=(-width / 2, width / 2, -width / 2, width / 2),
-                       vmin=vmin, vmax=vmax, cmap=cmap, norm = norm)
+                       cmap=cmap, norm = norm)
 
         u_st = sim['pos'].units.latex()
         if not subplot:

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -114,7 +114,7 @@ def test_halo_values() :
         assert(np.allclose(halo.properties['CenterOfMass'], FoF_CoM[i], rtol=1e-3))
 
         for j, s in enumerate(halo.sub) :
-	        assert(np.allclose(s.properties['CenterOfMass'], Sub_CoM[OffsetHalo[i]+j], rtol=1e-3))
+            assert(np.allclose(s.properties['CenterOfMass'], Sub_CoM[OffsetHalo[i]+j], rtol=1e-3))
 
     ###
     # Test the Halo particle information

--- a/tests/subfindhdf_gadget4_test.py
+++ b/tests/subfindhdf_gadget4_test.py
@@ -2,6 +2,7 @@ from os.path import isfile
 
 import h5py
 import numpy as np
+
 import pynbody
 
 


### PR DESCRIPTION
The Subfind-HDF implementation for Gadget4/Arepo could only load one particle type at a time, which
is quite restrictive. Meanwhile, a more powerful Subfind-HDF implementation existed but was not
compatible with the changes made for Gadget4/Arepo. This expands the unified implementation to
work with Gadget4/Arepo.