### PR TITLE
Patch-up: don't use editable installs on CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,4 +48,6 @@ jobs:
     - name: Uninstall posix_ipc
       run: python -m pip uninstall -y posix_ipc
     - name: Run ramses tests without shared memory support
-      run: python -m pytest tests/ramses_new_ptcl_format_test.py tests/ramses_test.py
+      run: |
+        cd tests
+        python -m pytest tests/ramses_new_ptcl_format_test.py tests/ramses_test.py

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,9 +27,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install gcc
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update -qq
-        sudo apt install gcc-10 g++-10
+        sudo apt install -y gcc-10 g++-10
     - name: Build and install pynbody
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -38,10 +38,13 @@ jobs:
         echo "parallel-read=2" >> ~/.pynbodyrc
     - name: Fetch and unpack test data
       run: |
+        cd tests
         wget -q http://star.ucl.ac.uk/~app/testdata.tar.gz
         tar --exclude="._*" -xzvf testdata.tar.gz
     - name: Run all tests
-      run: python -m pytest
+      run: |
+        cd tests
+        python -m pytest
     - name: Uninstall posix_ipc
       run: python -m pip uninstall -y posix_ipc
     - name: Run ramses tests without shared memory support

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Build and install pynbody
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install .[tests]
+        python -m pip install -v .[tests]
         echo "[ramses]" >> ~/.pynbodyrc
         echo "parallel-read=2" >> ~/.pynbodyrc
     - name: Fetch and unpack test data

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,4 +50,4 @@ jobs:
     - name: Run ramses tests without shared memory support
       run: |
         cd tests
-        python -m pytest tests/ramses_new_ptcl_format_test.py tests/ramses_test.py
+        python -m pytest ramses_new_ptcl_format_test.py ramses_test.py

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Build and install pynbody
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -e .[tests]
+        python -m pip install .[tests]
         echo "[ramses]" >> ~/.pynbodyrc
         echo "parallel-read=2" >> ~/.pynbodyrc
     - name: Fetch and unpack test data

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -437,7 +437,7 @@ class AHFCatalogue(HaloCatalogue):
         while line:
             try:
                 haloid, _nsubhalos = (int(x) for x in line.split())
-                halo_index = ID2index[haloid + 1]
+                halo_index = ID2index[haloid]
                 children = [
                     ID2index[int(x)] for x in f.readline().split()
                 ]


### PR DESCRIPTION
Recent versions of pip/setuptools seem to break editable installs of pynbody

This is potentially something to do with PEP660 https://peps.python.org/pep-0660/
but I haven't managed to really work out what's going on or pin it down to a
particular version.

For now, use quick fix of removing editable mode in CI tests