### PR TITLE
Update `pypi.yaml` action dependencies and add dependabot to automatically keep them up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,6 +3,11 @@ name: Push to PyPI
 on:
   push:
     tags: v*
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/pypi.yaml'
 
   workflow_dispatch:
 
@@ -43,11 +48,13 @@ jobs:
           brew install gcc@10
 
       - name: Determine version tag
+        if: github.event_name != 'pull_request'
         run: |
           echo "SETUP_VERSION=`python setup.py --version`" >> $GITHUB_ENV
           echo "VERSION_TAG=`git describe --tags | cut -c 2-`" >> $GITHUB_ENV
 
       - name: Verify version naming is consistent
+        if: github.event_name != 'pull_request'
         run: |
           if [ "${{ env.VERSION_TAG }}" == "${{ env.SETUP_VERSION }}" ]; then
               echo Git tag and python setup.py versions match: ${{ env.VERSION_TAG }}
@@ -68,6 +75,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
 
@@ -90,6 +98,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: PyPI
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -19,9 +19,9 @@ jobs:
         os: [ubuntu-20.04, macos-10.15]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -59,9 +59,9 @@ jobs:
           fi
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.12.0
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -69,9 +69,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -82,7 +82,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -91,12 +91,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: PyPI
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -25,7 +25,7 @@ jobs:
         buildplat:
         - [ubuntu-20.04, manylinux, x86_64]
         - [macos-10.15, macosx, x86_64]
-        python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
+        python: ["cp38", "cp39", "cp310", "cp311"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -14,15 +14,18 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.buildplat[0] }}
+    runs-on: ${{ matrix.buildplat[0] }}
     env:
       CC: gcc-10
       CXX: g++-10
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
-
+        # Following numpy's setup
+        buildplat:
+        - [ubuntu-20.04, manylinux, x86_64]
+        - [macos-10.15, macosx, x86_64]
+        python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
     steps:
       - uses: actions/checkout@v3
 
@@ -35,14 +38,14 @@ jobs:
         run: python -m "pip" install numpy cython
 
       - name: Install GCC (Ubuntu)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.buildplat[0] == 'ubuntu-20.04'
         shell: bash
         run: |
           sudo apt-get update -qq
           sudo apt install gcc-10 g++-10
 
       - name: Install GCC (MacOS)
-        if: matrix.os == 'macos-10.15'
+        if: matrix.buildplat[0] == 'macos-10.15'
         shell: bash
         run: |
           brew install gcc@10
@@ -67,6 +70,9 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}_${{ matrix.buildplat[2] }}
+          CIBW_ARCHS_MACOS: ${{ matrix.buildplat[2] }}
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I noticed that the action dependencies in `pypi.yaml` were out of date, which meant, for example, that you weren't building a Python 3.11 wheel (because the `cibuildwheel` action version was old). This updates the dependencies to their latest versions and additionally adds a `dependabot.yml` file that should keep them automatically up to date (I put a monthly schedule to check such that this doesn't cause too many PRs).