### PR TITLE
Cache testdata in GitHub Actions build-test workflow

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -44,11 +44,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install numpy${{ matrix.numpy-version }}
-    - name: Manually build h5py for python 3.11
-      if: ${{ matrix.python-version == '3.11' }}
-      run: |
-        sudo apt-get install libhdf5-dev
-        pip install --no-binary=h5py h5py
     - name: Build and install pynbody
       run: |
         python -m pip install -v .[tests]
@@ -61,10 +56,10 @@ jobs:
         wget -q http://star.ucl.ac.uk/~app/testdata.tar.gz
         tar --exclude="._*" -xzvf testdata.tar.gz
     - name: Run all tests
-      working-directory: tests    
+      working-directory: tests
       run: python -m pytest
     - name: Uninstall posix_ipc
       run: python -m pip uninstall -y posix_ipc
     - name: Run ramses tests without shared memory support
-      working-directory: tests    
+      working-directory: tests
       run: python -m pytest ramses_new_ptcl_format_test.py ramses_test.py

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -29,6 +29,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v3
+    - name: Cache testdata
+      uses: actions/cache@v3
+      id: cache-testdata
+      with:
+        path: tests/testdata
+        key: testdata-v1
     - name: Install gcc
       run: |
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -49,17 +55,16 @@ jobs:
         echo "[ramses]" >> ~/.pynbodyrc
         echo "parallel-read=2" >> ~/.pynbodyrc
     - name: Fetch and unpack test data
+      if: steps.cache-testdata.outputs.cache-hit != 'true'
+      working-directory: tests
       run: |
-        cd tests
         wget -q http://star.ucl.ac.uk/~app/testdata.tar.gz
         tar --exclude="._*" -xzvf testdata.tar.gz
     - name: Run all tests
-      run: |
-        cd tests
-        python -m pytest
+      working-directory: tests    
+      run: python -m pytest
     - name: Uninstall posix_ipc
       run: python -m pip uninstall -y posix_ipc
     - name: Run ramses tests without shared memory support
-      run: |
-        cd tests
-        python -m pytest ramses_new_ptcl_format_test.py ramses_test.py
+      working-directory: tests    
+      run: python -m pytest ramses_new_ptcl_format_test.py ramses_test.py


### PR DESCRIPTION
As I mentioned in https://github.com/pynbody/pynbody/pull/701#issuecomment-1401097177, caching the testdata should speed up the build-test workflow a bit. Because I just had to implement a similar directory caching in another project (and learned how easy it really is), I thought I might as well add it here too. So this PR caches the `testdata` download step. As people have pointed out elsewhere, this really just replaces downloading from the web with downloading from GitHub's servers, but it does seem to be substantially faster (~45s vs. 2.5 minutes).

I believe the testdata rarely changes? So the cache as written never expires. If you have to update it, either change the version in the cache key or just delete the cache on the Actions tab.

I'll push another commit getting rid of your source `h5py` installation for Python 3.11 to illustrate how the cache is used; ``h5py`` now has Python 3.11 wheels, so the source compilation is no longer necessary.