### PR TITLE
Add default units to two-phase properties

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -116,6 +116,8 @@ phi: cm^2 s^-2
 accg: cm s^-2
 mass: kg
 temp: K
+Tinc: K
+tempEff: K
 rho: kg cm^-3
 den: kg cm^-3
 smooth: cm
@@ -129,7 +131,10 @@ OxMassFrac: 1
 coolontime: s
 p: Pa
 u: km^2 s^-2
+uHot: km^2 s^-2
 massform: kg
+massHot: kg
+MassHot: kg
 # ramses RT stores radiation density in flux units:
 rad_0_rho: cm^-2 s^-1
 rad_0_flux: cm^-2 s^-1


### PR DESCRIPTION
I've added some properties to `default_config.ini` for the mass and energy components in two-phase gasoline/ChaNGa runs.  This will make sure that when loaded the two-phase particles will have correct units for both the cold and hot phase. 