### PR TITLE
Switch to using numpy.get_include() to get numpy header files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from os import path
 
-import numpy.distutils.misc_util
+import numpy as np
 from Cython.Build import build_ext
 from Cython.Compiler.Options import get_directive_defaults
 from setuptools import Extension, setup
@@ -89,7 +89,7 @@ if have_pthread:
 
 extra_link_args = []
 
-incdir = numpy.distutils.misc_util.get_numpy_include_dirs()
+incdir = [np.get_include()]
 
 kdmain = Extension('pynbody.sph.kdmain',
                    sources = ['pynbody/sph/kdmain.cpp', 'pynbody/sph/kd.cpp',


### PR DESCRIPTION
``numpy.distutils`` is being removed in Python 3.12, so this PR replaces its use in ``pynbody``'s ``setup.py`` with ``numpy.get_include``, which has identical functionality and has been in ``numpy`` since, I believe, version 1.6, so a long time ago.