### PR TITLE
Fix warnings

### DIFF
--- a/pynbody/analysis/decomp.py
+++ b/pynbody/analysis/decomp.py
@@ -193,9 +193,9 @@ def decomp(h, aligned=False, j_disk_min=0.8, j_disk_max=1.1, E_cut=None, j_circ_
     logger.info("j_crit = %.2e" % j_crit)
 
     if j_crit > j_disk_min:
-        logger.warn(
+        logger.warning(
             "!! j_crit exceeds j_disk_min. This is usually a sign that something is going wrong (train-wreck galaxy?)")
-        logger.warn("!! j_crit will be reset to j_disk_min=%.2e" % j_disk_min)
+        logger.warning("!! j_crit will be reset to j_disk_min=%.2e" % j_disk_min)
         j_crit = j_disk_min
 
     sphere = np.where(h_star['jz_by_jzcirc'] < j_crit)

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -387,8 +387,8 @@ def halo_shape(sim, N=100, rin=None, rout=None, bins='equal'):
     almnt = lambda E: np.arccos(np.dot(np.dot(E,[1.,0.,0.]),[1.,0.,0.]))
     #-----------------------------FUNCTIONS-----------------------------
 
-    if (rout == None): rout = sim.dm['r'].max()
-    if (rin == None): rin = rout/1E3
+    if (rout is None): rout = sim.dm['r'].max()
+    if (rin is None): rin = rout/1E3
 
     posr = np.array(sim.dm['r'])[np.where(sim.dm['r'] < rout)]
     pos = np.array(sim.dm['pos'])[np.where(sim.dm['r'] < rout)]

--- a/pynbody/analysis/luminosity.py
+++ b/pynbody/analysis/luminosity.py
@@ -112,7 +112,7 @@ def calc_mags(simstars, band='v', cmd_path=None):
     try:
         vals = output_mags - 2.5 * \
             np.log10(simstars['massform'].in_units('Msol'))
-    except KeyError as ValueError:
+    except KeyError:
         vals = output_mags - 2.5 * np.log10(simstars['mass'].in_units('Msol'))
 
     vals.units = None

--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -677,7 +677,7 @@ def v_circ(p, grav_sim=None):
 
     grav_sim = grav_sim or p.sim
 
-    logger.warn(
+    logger.warning(
         "Profile v_circ -- this routine assumes the disk is in the x-y plane")
 
     # If this is a cosmological run, go up to the halo level
@@ -708,7 +708,7 @@ def pot(p):
     #from . import gravity
     import pynbody.gravity.calc as gravity
 
-    logger.warn(
+    logger.warning(
         "Profile pot -- this routine assumes the disk is in the x-y plane")
 
     grav_sim = p.sim

--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -10,6 +10,7 @@ properties.
 
 import logging
 import math
+import pickle
 import warnings
 from time import process_time
 
@@ -164,12 +165,12 @@ class Profile:
         x = self._x
 
         if load_from_file:
-            import pickle
 
             filename = self._get_unique_filepath_from_particle_list()
 
             try:
-                data = pickle.load(open(filename, 'rb'))
+                with open(filename, "rb") as f:
+                    data = pickle.load(f)
                 self._properties = data['properties']
                 self.max = data['max']
                 self.min = data['min']
@@ -509,8 +510,6 @@ class Profile:
 
         """
 
-        import pickle
-
         # record all the important data except for the snapshot itself
         # use the hash generated from the particle list for the file name
         # suffix
@@ -519,13 +518,18 @@ class Profile:
 
         logger.info("Writing profile to %s", filename)
 
-        pickle.dump({'properties': self._properties,
-                     'max': self.max,
-                     'min': self.min,
-                     'nbins': self.nbins,
-                     'profiles': self._profiles,
-                     'binind': self.binind},
-                    open(filename, 'wb'))   # Open file in binary mode to allow python 3.X writing
+        with open(filename, "wb") as f:
+            pickle.dump(
+                {
+                    'properties': self._properties,
+                    'max': self.max,
+                    'min': self.min,
+                    'nbins': self.nbins,
+                    'profiles': self._profiles,
+                    'binind': self.binind
+                },
+                f,
+            )
 
     @staticmethod
     def profile_property(fn):

--- a/pynbody/analysis/ramses_util.py
+++ b/pynbody/analysis/ramses_util.py
@@ -244,16 +244,14 @@ def write_tipsy_param(sim, tipsyfile):
     lenunit, massunit, timeunit, velunit, _ = get_tipsy_units(sim)
 
     # write the param file
-    f = open('%s.param' % tipsyfile, 'w')
-    f.write('dKpcUnit = %f\n' % lenunit)
-    f.write('dMsolUnit = %e\n' % massunit)
-    f.write('dOmega0 = %f\n' % sim.properties['omegaM0'])
-    f.write('dLambda = %f\n' % sim.properties['omegaL0'])
-    h = Unit('%f km s^-1 Mpc^-1' % (sim.properties['h'] * 100))
-    f.write('dHubble0 = %f\n' % h.in_units(velunit / lenunit))
-    f.write('bComove = 1\n')
-    f.close()
-
+    with open('%s.param' % tipsyfile, 'w') as f:
+        f.write('dKpcUnit = %f\n' % lenunit)
+        f.write('dMsolUnit = %e\n' % massunit)
+        f.write('dOmega0 = %f\n' % sim.properties['omegaM0'])
+        f.write('dLambda = %f\n' % sim.properties['omegaL0'])
+        h = Unit('%f km s^-1 Mpc^-1' % (sim.properties['h'] * 100))
+        f.write('dHubble0 = %f\n' % h.in_units(velunit / lenunit))
+        f.write('bComove = 1\n')
 
 def write_ahf_input(sim, tipsyfile):
     """Write an input file that can be used by the `Amiga Halo Finder
@@ -264,31 +262,30 @@ def write_ahf_input(sim, tipsyfile):
     # determine units
     _lenunit, massunit, _timeunit, velunit, _ = get_tipsy_units(sim)
 
-    f = open('%s.AHF.input' % tipsyfile, 'w')
-    f.write('[AHF]\n')
-    f.write('ic_filename = %s\n' % tipsyfile)
-    f.write('ic_filetype = 90\n')
-    f.write('outfile_prefix = %s\n' % tipsyfile)
-    f.write('LgridDomain = 256\n')
-    f.write('LgridMax = 2097152\n')
-    f.write('NperDomCell = 5\n')
-    f.write('NperRefCell = 5\n')
-    f.write('VescTune = 1.0\n')
-    f.write('NminPerHalo = 50\n')
-    f.write('RhoVir = 0\n')
-    f.write('Dvir = 200\n')
-    f.write('MaxGatherRad = 1.0\n')
-    f.write('[TIPSY]\n')
-    f.write('TIPSY_BOXSIZE = %e\n' % (sim.properties['boxsize'].in_units(
-        'Mpc') * sim.properties['h'] / sim.properties['a']))
-    f.write('TIPSY_MUNIT   = %e\n' % (massunit * sim.properties['h']))
-    f.write('TIPSY_OMEGA0  = %f\n' % sim.properties['omegaM0'])
-    f.write('TIPSY_LAMBDA0 = %f\n' % sim.properties['omegaL0'])
-    f.write('TIPSY_VUNIT   = %e\n' %
-            velunit.ratio('km s^-1 a', **sim.conversion_context()))
-    f.write('TIPSY_EUNIT   = %e\n' % (
-        (pynbody.units.k / pynbody.units.m_p).in_units('km^2 s^-2 K^-1') * 5. / 3.))
-    f.close()
+    with open('%s.AHF.input' % tipsyfile, 'w') as f:
+        f.write('[AHF]\n')
+        f.write('ic_filename = %s\n' % tipsyfile)
+        f.write('ic_filetype = 90\n')
+        f.write('outfile_prefix = %s\n' % tipsyfile)
+        f.write('LgridDomain = 256\n')
+        f.write('LgridMax = 2097152\n')
+        f.write('NperDomCell = 5\n')
+        f.write('NperRefCell = 5\n')
+        f.write('VescTune = 1.0\n')
+        f.write('NminPerHalo = 50\n')
+        f.write('RhoVir = 0\n')
+        f.write('Dvir = 200\n')
+        f.write('MaxGatherRad = 1.0\n')
+        f.write('[TIPSY]\n')
+        f.write('TIPSY_BOXSIZE = %e\n' % (sim.properties['boxsize'].in_units(
+            'Mpc') * sim.properties['h'] / sim.properties['a']))
+        f.write('TIPSY_MUNIT   = %e\n' % (massunit * sim.properties['h']))
+        f.write('TIPSY_OMEGA0  = %f\n' % sim.properties['omegaM0'])
+        f.write('TIPSY_LAMBDA0 = %f\n' % sim.properties['omegaL0'])
+        f.write('TIPSY_VUNIT   = %e\n' %
+                velunit.ratio('km s^-1 a', **sim.conversion_context()))
+        f.write('TIPSY_EUNIT   = %e\n' % (
+            (pynbody.units.k / pynbody.units.m_p).in_units('km^2 s^-2 K^-1') * 5. / 3.))
 
 
 def get_tform_using_part2birth(sim, part2birth_path):

--- a/pynbody/analysis/theoretical_profiles.py
+++ b/pynbody/analysis/theoretical_profiles.py
@@ -8,7 +8,6 @@ Functional forms of common profiles (NFW as an example)
 """
 
 import abc
-import sys
 
 import numpy as np
 

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -16,7 +16,7 @@ threading: True
 number_of_threads: -1
 # -1 above indicates to detect the number of processors
 
-gravity_calculation_mode: direct_omp
+gravity_calculation_mode: direct
 
 disk-fit-function: expsech
 

--- a/pynbody/halo/rockstar.py
+++ b/pynbody/halo/rockstar.py
@@ -139,10 +139,9 @@ class RockstarCatalogue(HaloCatalogue):
 
     @staticmethod
     def _can_load(sim, **kwargs):
-        for file in glob.glob(os.path.join(os.path.dirname(sim.filename), 'halos*.bin')):
-            if os.path.exists(file):
-                return True
-        return False
+        return len(
+            glob.glob(os.path.join(os.path.dirname(sim.filename), 'halos*.bin'))
+        ) > 0
 
 
 class RockstarCatalogueOneCpu(HaloCatalogue):

--- a/pynbody/halo/rockstar.py
+++ b/pynbody/halo/rockstar.py
@@ -299,7 +299,7 @@ class RockstarCatalogueOneCpu(HaloCatalogue):
             )
 
         with util.open_(self._rsFilename, 'rb') as f:
-            self._head = np.fromstring(f.read(self.head_type.itemsize),
+            self._head = np.frombuffer(f.read(self.head_type.itemsize),
                                        dtype=self.head_type)
 
             # Seek to absolute position
@@ -389,7 +389,7 @@ class RockstarCatalogueOneCpu(HaloCatalogue):
         offset = self._haloprops_offset+self.halo_type.itemsize*self._head['num_halos'][0]
 
 
-        self._halo_min = int(np.fromfile(f, dtype=self.halo_type, count=1)['id'])
+        self._halo_min = int(np.fromfile(f, dtype=self.halo_type, count=1)['id'][0])
         self._halo_max = int(self._halo_min+self._head['num_halos'][0])
 
         f.seek(self._haloprops_offset)
@@ -397,7 +397,7 @@ class RockstarCatalogueOneCpu(HaloCatalogue):
         this_id = self._halo_min
 
         for _h in range(self._head['num_halos'][0]):
-            halo_data =np.fromfile(f, dtype=self.halo_type, count=1)
+            halo_data = np.fromfile(f, dtype=self.halo_type, count=1)
             if halo_data['id'] != this_id:
                 raise RockstarFormatRevisionError(
                     "Error while reading halo catalogue. Expected "
@@ -405,9 +405,9 @@ class RockstarCatalogueOneCpu(HaloCatalogue):
                 )
             self._halo_offsets[this_id-self._halo_min] = int(offset)
             if 'num_bound' in self.halo_type.names:
-                num_ptcls = int(halo_data['num_bound'])
+                num_ptcls = int(halo_data['num_bound'][0])
             else:
-                num_ptcls = int(halo_data['num_p'])
+                num_ptcls = int(halo_data['num_p'][0])
             self._halo_lens[this_id-self._halo_min] = num_ptcls
             offset+=num_ptcls*np.dtype('int64').itemsize
             this_id+=1

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -1,8 +1,6 @@
 import os.path
 import warnings
-import weakref
 
-import h5py
 import numpy as np
 
 from .. import array, config_parser, snapshot, units

--- a/pynbody/plot/gas.py
+++ b/pynbody/plot/gas.py
@@ -12,7 +12,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 
-from ..analysis import angmom, halo, profile
+from ..analysis import angmom, profile
 from ..units import Unit
 from .generic import hist2d
 

--- a/pynbody/plot/generic.py
+++ b/pynbody/plot/generic.py
@@ -277,7 +277,6 @@ Since this function produces a density estimate, the units of the
        *scalemax*: float
          maximum value to use for the color scale
     """
-    from scipy.stats.kde import gaussian_kde
 
     from .util import fast_kde
 
@@ -437,7 +436,7 @@ def make_contour_plot(arr, xs, ys, x_range=None, y_range=None, nlevels=20,
          maximum value to use for the color scale
     """
 
-    from matplotlib import colors, ticker
+    from matplotlib import colors
 
     if not subplot:
         import matplotlib.pyplot as plt

--- a/pynbody/plot/stars.py
+++ b/pynbody/plot/stars.py
@@ -357,7 +357,7 @@ def mollview(map=None,fig=None,plot=False,filenme=None,
 	# Create the figure
 
 	if not (hold or sub):
-		if fig == None:
+		if fig is None:
 			f=plt.figure(figsize=(8.5,5.4))
 			extent = (0.02,0.05,0.96,0.9)
 		else:

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -652,21 +652,23 @@ class SimSnap(ContainerWithPhysicalUnitsOption):
         its best guess at the units.
         """
         try:
-            f = open(self.filename+".units")
+            with open(self.filename+".units") as f:
+                lines = f.readlines()
         except OSError:
             return
 
         name_mapping = {'pos': 'distance', 'vel': 'velocity'}
         units_dict = {}
 
-        for line in f:
-            if (not line.startswith("#")):
-                if ":" not in line:
-                    raise OSError("Unknown format for units file %r"%(self.filename+".units"))
-                else:
-                    t, u = list(map(str.strip,line.split(":")))
-                    t = name_mapping.get(t,t)
-                    units_dict[t] = u
+        for line in lines:
+            if line.startswith("#"):
+                continue
+            if ":" not in line:
+                raise OSError("Unknown format for units file %r"%(self.filename+".units"))
+            else:
+                t, u = list(map(str.strip,line.split(":")))
+                t = name_mapping.get(t,t)
+                units_dict[t] = u
 
         self.set_units_system(**units_dict)
 

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -901,23 +901,23 @@ class SimSnap(ContainerWithPhysicalUnitsOption):
     def rotate_x(self, angle):
         """Rotates the snapshot about the current x-axis by 'angle' degrees."""
         angle *= np.pi / 180
-        return self.transform(np.matrix([[1,      0,             0],
-                                         [0, np.cos(angle), -np.sin(angle)],
-                                         [0, np.sin(angle),  np.cos(angle)]]))
+        return self.transform(np.array([[1,      0,             0],
+                                        [0, np.cos(angle), -np.sin(angle)],
+                                        [0, np.sin(angle),  np.cos(angle)]]))
 
     def rotate_y(self, angle):
         """Rotates the snapshot about the current y-axis by 'angle' degrees."""
         angle *= np.pi / 180
-        return self.transform(np.matrix([[np.cos(angle),    0,   np.sin(angle)],
-                                         [0,                1,        0],
-                                         [-np.sin(angle),   0,   np.cos(angle)]]))
+        return self.transform(np.array([[np.cos(angle),    0,   np.sin(angle)],
+                                        [0,                1,        0],
+                                        [-np.sin(angle),   0,   np.cos(angle)]]))
 
     def rotate_z(self, angle):
         """Rotates the snapshot about the current z-axis by 'angle' degrees."""
         angle *= np.pi / 180
-        return self.transform(np.matrix([[np.cos(angle), -np.sin(angle), 0],
-                                         [np.sin(angle),  np.cos(angle), 0],
-                                         [0,             0,        1]]))
+        return self.transform(np.array([[np.cos(angle), -np.sin(angle), 0],
+                                        [np.sin(angle),  np.cos(angle), 0],
+                                        [0,             0,        1]]))
 
     def wrap(self, boxsize=None, convention='center'):
         """Wraps the positions of the particles in the box to lie between

--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -869,7 +869,7 @@ class GadgetSnap(SimSnap):
 
     def _load_array(self, name, fam=None):
         """Read in data from a Gadget file.
-        If fam != None, loads only data for that particle family"""
+        If fam is not None, loads only data for that particle family"""
         # g_name is the internal name
         g_name = _translate_array_name(name)
 
@@ -964,7 +964,7 @@ class GadgetSnap(SimSnap):
             # This code supports (limited) format conversions
             if self.__class__ is not GadgetSnap:
                 # We need a filename if we are writing to a new type
-                if filename == None:
+                if filename is None:
                     raise Exception(
                         "Please specify a filename to write a new file.")
             # Splitting the files correctly is hard; the particles need to be reordered, and
@@ -1043,7 +1043,7 @@ class GadgetSnap(SimSnap):
                 return
 
             # Write headers
-            if filename != None:
+            if filename is not None:
                 if np.size(self._files) > 1:
                     for i in np.arange(0, np.size(self._files)):
                         ffile = filename + "." + str(i)
@@ -1109,7 +1109,7 @@ class GadgetSnap(SimSnap):
                         if f_parts[i]==0:
                             continue
                         # Set up filename
-                        if filename != None:
+                        if filename is not None:
                             ffile = filename + "." + str(i)
                             if nfiles == 1:
                                 ffile = filename

--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -759,9 +759,9 @@ class GadgetSnap(SimSnap):
                 mm = nn.lower().strip()
             else:
                 mm = nn.lower().strip().decode('utf-8')
-            if not nn in _rev_name_map:
+            if nn not in _rev_name_map:
                 _rev_name_map[nn] = mm
-            if not mm in _name_map:
+            if mm not in _name_map:
                 _name_map[mm] = nn
 
         # Use translated keys only
@@ -960,7 +960,7 @@ class GadgetSnap(SimSnap):
             all_keys = set(self.loadable_keys()).union(
                 list(self.keys())).union(self.family_keys())
             all_keys = [
-                k for k in all_keys if not k in ["x", "y", "z", "vx", "vy", "vz"]]
+                k for k in all_keys if k not in ["x", "y", "z", "vx", "vy", "vz"]]
             # This code supports (limited) format conversions
             if self.__class__ is not GadgetSnap:
                 # We need a filename if we are writing to a new type

--- a/pynbody/snapshot/gadget.py
+++ b/pynbody/snapshot/gadget.py
@@ -12,15 +12,15 @@ automatically via pynbody.load.
 
 import configparser
 import copy
-import errno
 import itertools
+import os
 import struct
 import sys
 import warnings
 
 import numpy as np
 
-from .. import array, config, config_parser, family, units
+from .. import array, config_parser, family, units
 from . import SimSnap, namemapper
 
 # This is set here and not in a config file because too many things break
@@ -259,106 +259,103 @@ class GadgetFile:
         self.endian = ''
         self.format2 = True
         t_part = 0
-        fd = open(filename, "rb")
-        self.check_format(fd)
-        # If format 1, load the block definitions.
-        if not self.format2:
-            self.block_names = config_parser.get(
-                'gadget-1-blocks', "blocks").split(",")
-            self.block_names = [q.upper().ljust(4) for q in self.block_names]
-            if sys.version_info[0] > 2:
-                self.block_names = [str.encode(x, 'utf-8') for x in self.block_names]
-            # This is a counter for the fallback
-            self.extra = 0
-        while True:
-            block = GadgetBlock()
-            (name, block.length) = self.read_block_head(fd)
-            if block.length == 0:
-                break
-            # Do special things for the HEAD block
-            if name[0:4] == b"HEAD":
-                if block.length != 256:
-                    raise OSError("Mis-sized HEAD block in " + filename)
-                self.header = fd.read(256)
-                if len(self.header) != 256:
-                    raise OSError("Could not read HEAD block in " + filename)
-                self.header = _construct_gadget_header(
-                    self.header, self.endian)
+        with open(filename, "rb") as fd:
+            self.check_format(fd)
+            # If format 1, load the block definitions.
+            if not self.format2:
+                self.block_names = config_parser.get(
+                    'gadget-1-blocks', "blocks").split(",")
+                self.block_names = [q.upper().ljust(4) for q in self.block_names]
+                if sys.version_info[0] > 2:
+                    self.block_names = [str.encode(x, 'utf-8') for x in self.block_names]
+                # This is a counter for the fallback
+                self.extra = 0
+            while True:
+                block = GadgetBlock()
+                (name, block.length) = self.read_block_head(fd)
+                if block.length == 0:
+                    break
+                # Do special things for the HEAD block
+                if name[0:4] == b"HEAD":
+                    if block.length != 256:
+                        raise OSError("Mis-sized HEAD block in " + filename)
+                    self.header = fd.read(256)
+                    if len(self.header) != 256:
+                        raise OSError("Could not read HEAD block in " + filename)
+                    self.header = _construct_gadget_header(
+                        self.header, self.endian)
+                    record_size = self.read_block_foot(fd)
+                    if record_size != 256:
+                        raise OSError("Bad record size for HEAD in " + filename)
+                    t_part = self.header.npart.sum()
+                    if  ((not self.format2) and
+                        ((self.header.npart != 0) * (self.header.mass == 0)).sum()==0):
+                        # The "Spec" says that if all the existing particle masses
+                        # are in the header, we shouldn't have a MASS block
+                        self.block_names.remove(b"MASS")
+                    continue
+                # Set the partlen, using our amazing heuristics
+                success = False
+                if name[0:4] == b"POS " or name[0:4] == b"VEL ":
+                    if block.length == t_part * 24:
+                        block.partlen = 24
+                        block.data_type = np.float64
+                    else:
+                        block.partlen = 12
+                        block.data_type = np.float32
+                    block.p_types = self.header.npart != 0
+                    success = True
+                elif name[0:4] == b"ID  ":
+                    # Heuristic for long (64-bit) IDs
+                    if block.length == t_part * 4:
+                        block.partlen = 4
+                        block.data_type = np.int32
+                    else:
+                        block.partlen = 8
+                        block.data_type = np.int64
+                    block.p_types = self.header.npart != 0
+                    success = True
+
+                block.start = fd.tell()
+                # Check for the case where the record size overflows an int.
+                # If this is true, we can't get record size from the length and we just have to guess
+                # At least the record sizes at either end should be consistently wrong.
+                # Better hope this only happens for blocks where all particles are
+                # present.
+                extra_len = int(t_part) * block.partlen
+                if extra_len >= 2 ** 32:
+                    fd.seek(extra_len, 1)
+                else:
+                    fd.seek(block.length, 1)
                 record_size = self.read_block_foot(fd)
-                if record_size != 256:
-                    raise OSError("Bad record size for HEAD in " + filename)
-                t_part = self.header.npart.sum()
-                if  ((not self.format2) and
-                	((self.header.npart != 0) * (self.header.mass == 0)).sum()==0):
-                    # The "Spec" says that if all the existing particle masses
-                    # are in the header, we shouldn't have a MASS block
-                    self.block_names.remove(b"MASS")
-                continue
-            # Set the partlen, using our amazing heuristics
-            success = False
-            if name[0:4] == b"POS " or name[0:4] == b"VEL ":
-                if block.length == t_part * 24:
-                    block.partlen = 24
-                    block.data_type = np.float64
+                if record_size != block.length:
+                    raise OSError("Corrupt record in " +
+                                filename + " footer for block " + name + "dtype" + str(block.data_type))
+                if extra_len >= 2 ** 32:
+                    block.length = extra_len
+
+                if not success:
+                    # Figure out what particles are here and what types
+                    # they have. This also is a heuristic, which assumes
+                    # that blocks are either fully present or not for a
+                    # given particle. It also has to try all
+                    # possibilities of dimensions of array and data type.
+                    for dim, tp in (1, np.float32), (1, np.float64), (3, np.float32), (3, np.float64), (11, np.float32):
+                        try:
+                            block.data_type = tp
+                            block.partlen = np.dtype(tp).itemsize * dim
+                            block.p_types = self.get_block_types(
+                                block, self.header.npart)
+                            success = True
+                            break
+                        except ValueError:
+                            continue
+
+                if not success:
+                    warnings.warn("Encountered a gadget block %r which could not be interpreted - is it a strange length or data type (length=%d)?" %
+                                (name, block.length), RuntimeWarning)
                 else:
-                    block.partlen = 12
-                    block.data_type = np.float32
-                block.p_types = self.header.npart != 0
-                success = True
-            elif name[0:4] == b"ID  ":
-                # Heuristic for long (64-bit) IDs
-                if block.length == t_part * 4:
-                    block.partlen = 4
-                    block.data_type = np.int32
-                else:
-                    block.partlen = 8
-                    block.data_type = np.int64
-                block.p_types = self.header.npart != 0
-                success = True
-
-            block.start = fd.tell()
-            # Check for the case where the record size overflows an int.
-            # If this is true, we can't get record size from the length and we just have to guess
-            # At least the record sizes at either end should be consistently wrong.
-            # Better hope this only happens for blocks where all particles are
-            # present.
-            extra_len = int(t_part) * block.partlen
-            if extra_len >= 2 ** 32:
-                fd.seek(extra_len, 1)
-            else:
-                fd.seek(block.length, 1)
-            record_size = self.read_block_foot(fd)
-            if record_size != block.length:
-                raise OSError("Corrupt record in " +
-                              filename + " footer for block " + name + "dtype" + str(block.data_type))
-            if extra_len >= 2 ** 32:
-                block.length = extra_len
-
-            if not success:
-                # Figure out what particles are here and what types
-                # they have. This also is a heuristic, which assumes
-                # that blocks are either fully present or not for a
-                # given particle. It also has to try all
-                # possibilities of dimensions of array and data type.
-                for dim, tp in (1, np.float32), (1, np.float64), (3, np.float32), (3, np.float64), (11, np.float32):
-                    try:
-                        block.data_type = tp
-                        block.partlen = np.dtype(tp).itemsize * dim
-                        block.p_types = self.get_block_types(
-                            block, self.header.npart)
-                        success = True
-                        break
-                    except ValueError:
-                        continue
-
-            if not success:
-                warnings.warn("Encountered a gadget block %r which could not be interpreted - is it a strange length or data type (length=%d)?" %
-                              (name, block.length), RuntimeWarning)
-            else:
-                self.blocks[name[0:4]] = block
-
-        # and we're done.
-        fd.close()
+                    self.blocks[name[0:4]] = block
 
         # Make a mass block if one isn't found.
         if b'MASS' not in self.blocks:
@@ -471,14 +468,14 @@ class GadgetFile:
         p_start = self.get_start_part(name, p_type)
         if p_toread > parts:
             p_toread = parts
-        fd = open(self._filename, 'rb')
-        fd.seek(cur_block.start + int(cur_block.partlen * p_start), 0)
-        # This is just so that we can get a size for the type
-        dt = np.dtype(cur_block.data_type)
-        n_type = p_toread * cur_block.partlen // dt.itemsize
-        data = np.fromfile(
-            fd, dtype=cur_block.data_type, count=n_type, sep='')
-        fd.close()
+        with open(self._filename, 'rb') as fd:
+            fd.seek(cur_block.start + int(cur_block.partlen * p_start), 0)
+            # This is just so that we can get a size for the type
+            dt = np.dtype(cur_block.data_type)
+            n_type = p_toread * cur_block.partlen // dt.itemsize
+            data = np.fromfile(
+                fd, dtype=cur_block.data_type, count=n_type, sep='')
+
         if self.endian != '=':
             data = data.byteswap(True)
         return (p_toread, data)
@@ -538,33 +535,30 @@ class GadgetFile:
         if bt.kind != dt.kind:
             raise ValueError("Data of incorrect type passed to write_block")
         # Open the file
-        if filename == None:
-            fd = open(self._filename, "r+b")
-        else:
-            fd = open(filename, "r+b")
-        # Seek to the start of the block
-        fd.seek(cur_block.start + cur_block.partlen * p_start, 0)
-        # Add the block header if we are at the start of a block
-        if p_type == MinType or p_type < 0:
-            data = self.write_block_header(name, cur_block.length)
-            # Better seek back a bit first.
-            fd.seek(-len(data), 1)
-            fd.write(data)
+        fn = self._filename if filename is None else filename
 
-        if self.endian != '=':
-            big_data = big_data.byteswap(False)
+        with open(fn, 'r+b') as fd:
+            # Seek to the start of the block
+            fd.seek(cur_block.start + cur_block.partlen * p_start, 0)
+            # Add the block header if we are at the start of a block
+            if p_type == MinType or p_type < 0:
+                data = self.write_block_header(name, cur_block.length)
+                # Better seek back a bit first.
+                fd.seek(-len(data), 1)
+                fd.write(data)
 
-        # Actually write the data
-        # Make sure to ravel it, otherwise the wrong amount will be written,
-        # because it will also write nulls every time the first array dimension
-        # changes.
-        d = np.ravel(big_data.astype(dt)).tostring()
-        fd.write(d)
-        if p_type == MaxType or p_type < 0:
-            data = self.write_block_footer(name, cur_block.length)
-            fd.write(data)
+            if self.endian != '=':
+                big_data = big_data.byteswap(False)
 
-        fd.close()
+            # Actually write the data
+            # Make sure to ravel it, otherwise the wrong amount will be written,
+            # because it will also write nulls every time the first array dimension
+            # changes.
+            d = np.ravel(big_data.astype(dt)).tobytes()
+            fd.write(d)
+            if p_type == MaxType or p_type < 0:
+                data = self.write_block_footer(name, cur_block.length)
+                fd.write(data)
 
     def add_file_block(self, name, blocksize, partlen=4, dtype=np.float32, p_types=None):
         """Add a block to the block table at the end of the file. Do not actually write anything"""
@@ -618,31 +612,18 @@ class GadgetFile:
         head.npart = np.array(self.header.npart)
         data = self.write_block_header(b"HEAD", 256)
         data += head.serialize()
-        if filename == None:
+        if filename is None:
             filename = self._filename
         # a mode will ignore the file position, and w truncates the file.
-        try:
-            fd = open(filename, "r+b")
-        except OSError as xxx_todo_changeme:
-            # If we couldn't open it because it doesn't exist open it for
-            # writing.
-            (err, strerror) = xxx_todo_changeme.args
-            # If we couldn't open it because it doesn't exist open it for
-            # writing.
-            if err == errno.ENOENT:
-                fd = open(filename, "w+b")
-            # If we couldn't open it for any other reason, reraise exception
-            else:
-                raise OSError(err, strerror)
-        fd.seek(0)  # Header always at start of file
-        # Write header
-        fd.write(data)
-        # Seek 48 bytes forward, to skip the padding (which may contain extra
-        # data)
-        fd.seek(48, 1)
-        data = self.write_block_footer(b"HEAD", 256)
-        fd.write(data)
-        fd.close()
+        with open(filename, "ab") as fd:
+            fd.seek(0)  # Header always at start of file
+            # Write header
+            fd.write(data)
+            # Seek 48 bytes forward, to skip the padding (which may contain extra
+            # data)
+            fd.seek(48, 1)
+            data = self.write_block_footer(b"HEAD", 256)
+            fd.write(data)
 
 
 class GadgetWriteFile (GadgetFile):
@@ -707,15 +688,12 @@ class GadgetSnap(SimSnap):
         self._ignore_cosmo = ignore_cosmo
         npart = np.empty(N_TYPE)
         # Check whether the file exists, and get the ".0" right
-        try:
-            fd = open(filename, 'rb')
+        if os.path.exists(filename):
             files = [filename]
-        except OSError:
-            fd = open(filename + ".0", 'rb')
-            # The second time if there is an exception we let it go through
+        elif os.path.exists(filename + ".0"):
             filename = filename + ".0"
             files = None
-        fd.close()
+
         if filename[-2:] == ".0":
             self._filename = filename[:-2]
         # Read the first file and use it to get an idea of how many files we
@@ -956,19 +934,18 @@ class GadgetSnap(SimSnap):
     def _can_load(f):
         """Check whether we can load the file as Gadget format by reading
         the first 4 bytes"""
-        try:
-            fd = open(f, 'rb')
-        except OSError:
-            try:
-                fd = open(f + ".0", 'rb')
-            except Exception:
+        fname = f
+        if not os.path.exists(f):
+            if not os.path.exists(f + ".0"):
                 return False
-                # If we can't open the file, we certainly can't load it...
-        (r,) = struct.unpack('=I', fd.read(4))
-        fd.close()
+            fname = f + ".0"
+
+        with open(fname, "br") as fd:
+            r, = struct.unpack('=I', fd.read(4))
+
         # First int32 is 8 for a Gadget 2 file, or 256 for Gadget 1, or the
         # byte swapped equivalent.
-        if r == 8 or r == 134217728 or r == 65536 or r == 256:
+        if r in (8, 134217728, 65536, 256):
             return True
         else:
             return False

--- a/pynbody/snapshot/nchilada.py
+++ b/pynbody/snapshot/nchilada.py
@@ -70,8 +70,8 @@ class NchiladaSnap(SimSnap):
         # set up a logical map of particles on disk
         for f in sorted(self._loadable_keys_registry.keys()):
             ars = self._loadable_keys_registry[f]
-            tf = open(list(ars.values())[0], 'rb')
-            header_time, nbod, _, _ = self._load_header(tf)
+            with open(list(ars.values())[0], 'rb') as tf:
+                header_time, nbod, _, _ = self._load_header(tf)
             disk_family_slice[f] = slice(i, i + nbod)
             i += nbod
             self.properties['a'] = header_time
@@ -132,7 +132,8 @@ class NchiladaSnap(SimSnap):
             return
         for fam in fams:
             # this will raise an IOError propagating upwards if any family doesn't have the appropriate array
-            _, nbod, ndim, dtype = self._load_header(self._open_file_for_array(fam, array_name))
+            with self._open_file_for_array(fam, array_name) as f:
+                _, nbod, ndim, dtype = self._load_header(f)
             if universal_dtype is not None:
                 if ndim!=universal_ndim:
                     raise OSError("Mismatching dimensions for array")
@@ -180,6 +181,7 @@ class NchiladaSnap(SimSnap):
 
             if mem_index is not None:
                 r[mem_index] = b[buf_index]
+        f.close()
 
     """
     def _write_array(self, array_name, fam=None) :

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -514,11 +514,12 @@ class RamsesSnap(SimSnap):
         self._rt_blocks = []
         self._rt_blocks_3d = set()
         try:
-            f = open(os.path.join(self._filename, f"info_rt_{self._timestep_id}.txt"))
+            with open(os.path.join(self._filename, f"info_rt_{self._timestep_id}.txt")) as f:
+                lines = f.readlines()
         except OSError:
             return
 
-        self._load_info_from_specified_file(f)
+        self._load_info_from_specified_file(lines)
 
         for group in range(self._info['nGroups']):
             for block in rt_blocks:
@@ -529,8 +530,8 @@ class RamsesSnap(SimSnap):
         for block in self._rt_blocks:
             self._rt_blocks_3d.add(self._array_name_1D_to_ND(block) or block)
 
-    def _load_info_from_specified_file(self, f):
-        for line in f:
+    def _load_info_from_specified_file(self, lines):
+        for line in lines:
             if '=' in line:
                 name, val = list(map(str.strip, line.split('=')))
                 try:

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -582,11 +582,11 @@ class RamsesSnap(SimSnap):
         namelist_file = os.path.join(self._filename, "namelist.txt")
 
         if os.path.exists(namelist_file):
-            f = open(namelist_file)
-            try:
-                self._load_namelist_from_specified_file(f)
-            except ValueError:
-                warnings.warn("Namelist found but unable to read.")
+            with open(namelist_file) as f:
+                try:
+                    self._load_namelist_from_specified_file(f)
+                except ValueError:
+                    warnings.warn("Namelist found but unable to read.")
 
         else:
             warnings.warn("No namelist file found.")

--- a/pynbody/snapshot/ramses.py
+++ b/pynbody/snapshot/ramses.py
@@ -543,16 +543,17 @@ class RamsesSnap(SimSnap):
 
     def _load_infofile(self):
         self._info = {}
-        f = open(os.path.join(self._filename, f"info_{self._timestep_id}.txt"))
-
-        self._load_info_from_specified_file(f)
+        info_fname = os.path.join(self._filename, f"info_{self._timestep_id}.txt")
+        header_fname = os.path.join(self._filename, f"header_{self._timestep_id}.txt")
+        with open(info_fname) as f:
+            self._load_info_from_specified_file(f)
         try:
-            f = open(os.path.join(self._filename, f"header_{self._timestep_id}.txt"))
             # most of this file is unhelpful, but depending on the ramses
             # version, there may be information on the particle fields present
-            for line in f:
-                if "level" in line:
-                    self._info['particle-blocks'] = line.split()
+            with open(header_fname) as f:
+                for line in f:
+                    if "level" in line:
+                        self._info['particle-blocks'] = line.split()
         except OSError:
             warnings.warn(
                 "No header file found -- no particle block information available")

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -337,10 +337,10 @@ class TipsySnap(SimSnap):
 
                     # Read in the block
                     if(self._byteswap):
-                        g = np.fromstring(
+                        g = np.frombuffer(
                             fin.read(len(st) * n_block * 4), 'f').byteswap().reshape((n_block, len(st)))
                     else:
-                        g = np.fromstring(
+                        g = np.frombuffer(
                             fin.read(len(st) * n_block * 4), 'f').reshape((n_block, len(st)))
 
                     if fam in fam_out:
@@ -1230,10 +1230,10 @@ class StarLog(SimSnap):
                 # no moleculuarH with big iOrders.  Attempt to distinguish here
                 if(iSize == file_structure.itemsize):
                     if(self._byteswap):
-                        testread = np.fromstring(
+                        testread = np.frombuffer(
                             f.read(iSize), dtype=file_structure).byteswap()
                     else:
-                        testread = np.fromstring(f.read(iSize), dtype=file_structure)
+                        testread = np.frombuffer(f.read(iSize), dtype=file_structure)
                     # All star iorders are greater than any gas iorder
                     # so this indicates a bad format. (N.B. there is the
                     # possibility of a false negative)
@@ -1284,10 +1284,10 @@ class StarLog(SimSnap):
 
         logger.info("Reading starlog file %s", filename)
         if(self._byteswap):
-            g = np.fromstring(
+            g = np.frombuffer(
                 f.read(datasize), dtype=file_structure).byteswap()
         else:
-            g = np.fromstring(f.read(datasize), dtype=file_structure)
+            g = np.frombuffer(f.read(datasize), dtype=file_structure)
 
         # hoping to provide backward compatibility for np.unique by
         # copying relavent part of current numpy source:

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1289,6 +1289,7 @@ class StarLog(SimSnap):
         else:
             g = np.frombuffer(f.read(datasize), dtype=file_structure)
 
+        f.close()
         # hoping to provide backward compatibility for np.unique by
         # copying relavent part of current numpy source:
         # numpy/lib/arraysetops.py:192 (on 22nd March 2011)

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1469,6 +1469,7 @@ def load_paramfile(sim):
         if len(sim._paramfile) > 1:
             sim._paramfile["filename"] = filename
 
+    f.close()
 
 @TipsySnap.decorator
 @StarLog.decorator

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -1270,7 +1270,7 @@ class StarLog(SimSnap):
                         str(file_structure.itemsize))
                 else:
                     bigstarlog = True
-            if molecH == True: print("h2 information found in StarLog!")
+            if molecH is True: print("h2 information found in StarLog!")
 
         datasize = os.path.getsize(filename) - f.tell()
 
@@ -1484,7 +1484,7 @@ def param2units(sim):
             pass
 
         if munit is None or dunit is None:
-            if hub != None:
+            if hub is not None:
                 sim.properties['h'] = hub
             return
 
@@ -1693,7 +1693,7 @@ def slparam2units(sim):
         timeunit_st = ("%.5g" % timeunit) + " Gyr"
 
 
-        if hub != None:
+        if hub is not None:
             # append dependence on 'a' for cosmological runs
             dunit_st += " aform"
 

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -946,7 +946,7 @@ class TipsySnap(SimSnap):
         try:
             check = TipsySnap(f, verbose=False)
             del check
-        except Exception as e:
+        except Exception:
             return False
 
         return True
@@ -1315,7 +1315,7 @@ class StarLog(SimSnap):
         self._create_arrays(["iord"], dtype='int32')
         self._create_arrays(
             ["iorderGas", "massform", "rhoform", "tempform", "metals", "tform"])
-        if molecH==True:
+        if molecH:
             self._create_arrays(["h2form"])
         if bigstarlog:
             self._create_arrays(["phiform", "nsmooth"])

--- a/pynbody/sph/__init__.py
+++ b/pynbody/sph/__init__.py
@@ -47,7 +47,7 @@ _approximate_image = config_parser.getboolean('sph', 'approximate-fast-images')
 def _exception_catcher(call_fn, exception_list, *args):
     try:
         call_fn(*args)
-    except Exception as e:
+    except Exception:
         exception_list.append(sys.exc_info())
 
 def _thread_map(func, *args):

--- a/pynbody/sph/__init__.py
+++ b/pynbody/sph/__init__.py
@@ -440,7 +440,7 @@ def _interpolated_renderer(fn, levels):
             kwargs['res_downgrade'] = sub
             new_im = fn(*args, **kwargs)
             zoom = [float(x)/y for x,y in zip(base.shape, new_im.shape)]
-            base += scipy.ndimage.interpolation.zoom(new_im, zoom, order=1)
+            base += scipy.ndimage.zoom(new_im, zoom, order=1)
         return base
     return render_fn
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ filterwarnings = [
     # Ignore Warnings thrown by RAMSES when namelist cannot be read
     'ignore:No header file found -- no particle block information available:UserWarning',
     'ignore:No namelist file found\.:UserWarning',
+    'ignore:Namelist found but unable to read\.:UserWarning',
     'ignore:Namelist file either not found or unable to read.*assuming flat LCDM:UserWarning',
     'ignore:Conjoining derived and non-derived arrays.*:RuntimeWarning',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython"]
 
 [tool.pytest.ini_options]
 testpaths = ['tests']
+filterwarnings = [
+    "error",
+    # Ignore Warnings thrown by RAMSES when namelist cannot be read
+    'ignore:No header file found -- no particle block information available:UserWarning',
+    'ignore:No namelist file found\.:UserWarning',
+    'ignore:Namelist file either not found or unable to read.*assuming flat LCDM:UserWarning',
+]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ filterwarnings = [
     'ignore:Namelist found but unable to read\.:UserWarning',
     'ignore:Namelist file either not found or unable to read.*assuming flat LCDM:UserWarning',
     'ignore:Conjoining derived and non-derived arrays.*:RuntimeWarning',
+    'ignore:invalid value encountered in multiply:RuntimeWarning',
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ filterwarnings = [
     'ignore:No header file found -- no particle block information available:UserWarning',
     'ignore:No namelist file found\.:UserWarning',
     'ignore:Namelist file either not found or unable to read.*assuming flat LCDM:UserWarning',
+    'ignore:Conjoining derived and non-derived arrays.*:RuntimeWarning',
 ]
 
 [tool.isort]

--- a/tests/ahf_halos_test.py
+++ b/tests/ahf_halos_test.py
@@ -4,7 +4,8 @@ import shutil
 import stat
 import subprocess
 
-import numpy as np
+import numpy.testing as npt
+import pytest
 
 import pynbody
 
@@ -30,7 +31,8 @@ def test_ahf_properties():
     assert h[1].properties['fstart']==23
 
 
-def _setup_unwritable_ahf_situation():
+@pytest.fixture
+def setup_unwritable_ahf_situation():
     if os.path.exists("testdata/test_unwritable"):
         os.chmod("testdata/test_unwritable", stat.S_IRUSR | stat.S_IXUSR | stat.S_IWUSR)
         shutil.rmtree("testdata/test_unwritable")
@@ -41,18 +43,21 @@ def _setup_unwritable_ahf_situation():
     os.chmod("testdata/test_unwritable", stat.S_IRUSR | stat.S_IXUSR)
 
 
-def test_ahf_unwritable():
-    _setup_unwritable_ahf_situation()
+def test_ahf_unwritable(setup_unwritable_ahf_situation):
     f = pynbody.load("testdata/test_unwritable/g15784.lr.01024")
-    h = f.halos()
+    with pytest.warns(UserWarning, match="Unable to write AHF_fpos file;.*"):
+         h = f.halos()
     assert len(h)==1411
 
 
 def test_detecting_ahf_catalogues_with_without_trailing_slash():
     # Test small fixes in #688 to detect AHF catalogues with and wihtout trailing slashes in directories
-    for name in ["testdata/ramses_new_format_cosmo_with_ahf_output_00110", "testdata/ramses_new_format_cosmo_with_ahf_output_00110/"]:
+    for name in (
+        "testdata/ramses_new_format_cosmo_with_ahf_output_00110",
+        "testdata/ramses_new_format_cosmo_with_ahf_output_00110/"
+    ):
         f = pynbody.load(name)
-        halos = pynbody.halo.AHFCatalogue(f)
+        _halos = pynbody.halo.AHFCatalogue(f)
 
 
 def test_ramses_ahf_family_mapping_with_new_format():
@@ -73,17 +78,16 @@ def test_ramses_ahf_family_mapping_with_new_format():
 
         # Check we now have the same number of particles assigned to the halo
         # than its AHF header, family by family
-        assert(halo.properties['npart'] == len(halo))
-        assert(halo.properties['n_star'] == len(halo.st))
-        assert(halo.properties['n_gas'] == len(halo.g))
+        assert halo.properties['npart'] == len(halo)
+        assert halo.properties['n_star'] == len(halo.st)
+        assert halo.properties['n_gas'] == len(halo.g)
         ndm = halo.properties['npart'] - halo.properties['n_star'] - halo.properties['n_gas']
-        assert(ndm == len(halo.d))
+        assert ndm == len(halo.d)
 
         # Derive some masses to check that we are identifying the right particles, in addition to their right numbers
         dm_mass = halo.properties['Mhalo'] - halo.properties['M_star'] - halo.properties['M_gas']
         gas_mass = halo.properties['M_gas']
 
-        import numpy.testing as npt
         rtol = 1e-2 # We are not precise to per cent level with unit conversion through the different steps
         hubble = f.properties['h']      # AHF internal units are Msol/h and need to be manually corrected, which has not been done on this test output
         npt.assert_allclose(dm_mass / hubble, halo.d['mass'].sum().in_units("Msol"), rtol=rtol)

--- a/tests/cosmology_test.py
+++ b/tests/cosmology_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 import pynbody
 
@@ -10,7 +11,8 @@ def test_a_to_t():
     ipoints = pynbody.analysis.cosmology._interp_points
     interp_a = np.linspace(0.005, 1.0, ipoints+1) # enough values to force interpolation rather than direct calculation
     interp_z = 1./interp_a - 1.
-    interp_t = pynbody.analysis.cosmology.age(f, z=interp_z)
+    with pytest.warns(RuntimeWarning, match=r"Assuming default value for property.*"):
+        interp_t = pynbody.analysis.cosmology.age(f, z=interp_z)
     direct_aform = interp_a[::100]
     z = 1./direct_aform-1.
     direct_tform = pynbody.analysis.cosmology.age(f,z)
@@ -21,7 +23,8 @@ def test_aform_saturation():
     ipoints = pynbody.analysis.cosmology._interp_points
     f = pynbody.new(ipoints + 1)
     f['aform'] = np.linspace(0.0,1.1,ipoints+1)-0.05
-    tf = f['tform'][::100]
+    with pytest.warns(RuntimeWarning, match=r"Assuming default value for property.*"):
+        tf = f['tform'][::100]
     assert tf[0]!=tf[0] # nan outside range
     assert tf[-1]!=tf[-1] # nan outside range
     assert (tf[1:-1]==tf[1:-1]).all() # no nans inside range

--- a/tests/family_test.py
+++ b/tests/family_test.py
@@ -11,7 +11,7 @@ def test_pickle():
 def test_family_array_dtype() :
     # test for issue #186
     f = pynbody.load('testdata/g15784.lr.01024.gz')
-    f.g['rho'] = np.zeros(len(f.g),dtype=np.float32)
+    f.g['rho'] = np.zeros(len(f.g), dtype=np.float32)
     f.s['rho']
 
 def test_family_array_null_slice():

--- a/tests/gadget_test.py
+++ b/tests/gadget_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 import pynbody
@@ -112,10 +113,10 @@ def test_write():
     and the written and the read are the same."""
     snap.write(filename='testdata/test_gadget_write')
     snap3 = pynbody.load('testdata/test_gadget_write')
-    assert(set(snap.loadable_keys()) == set(snap3.loadable_keys()))
-    assert((snap3["pos"].view(np.ndarray) == snap["pos"]).all())
-    assert((snap3.gas["rho"].view(np.ndarray) == snap.gas["rho"]).all())
-    assert(snap3.check_headers(snap.header, snap3.header))
+    assert set(snap.loadable_keys()) == set(snap3.loadable_keys())
+    npt.assert_equal(snap3["pos"].view(np.ndarray), snap["pos"])
+    npt.assert_equal(snap3.gas["rho"].view(np.ndarray), snap.gas["rho"])
+    assert snap3.check_headers(snap.header, snap3.header)
 
 
 def test_conversion():

--- a/tests/gadget_test.py
+++ b/tests/gadget_test.py
@@ -105,7 +105,8 @@ def test_header():
 
 def test_g1_load():
     """Check we can load gadget-1 files also"""
-    snap2 = pynbody.load("testdata/gadget1.snap")
+    with pytest.warns(RuntimeWarning, match=r"Run out of block names in the config file. Using fallbacks: UNK\*"):
+        snap2 = pynbody.load("testdata/gadget1.snap")
 
 
 def test_write():

--- a/tests/gadget_test.py
+++ b/tests/gadget_test.py
@@ -16,13 +16,13 @@ def teardown_module():
 
 def test_construct():
     """Check the basic properties of the snapshot"""
-    assert (np.size(snap._files) == 2)
-    assert(snap.header.num_files == 2)
-    assert (snap.filename == "testdata/test_g2_snap")
-    assert(snap._num_particles == 8192)
+    assert np.size(snap._files) == 2
+    assert snap.header.num_files == 2
+    assert snap.filename == "testdata/test_g2_snap")
+    assert snap._num_particles == 8192
     for f in snap._files:
-        assert(f.format2 == True)
-        assert(f.endian == "=")
+        assert f.format2
+        assert f.endian == "="
 
 def test_properties():
     assert "time" in snap.properties

--- a/tests/gadget_test.py
+++ b/tests/gadget_test.py
@@ -18,7 +18,7 @@ def test_construct():
     """Check the basic properties of the snapshot"""
     assert np.size(snap._files) == 2
     assert snap.header.num_files == 2
-    assert snap.filename == "testdata/test_g2_snap")
+    assert snap.filename == "testdata/test_g2_snap"
     assert snap._num_particles == 8192
     for f in snap._files:
         assert f.format2

--- a/tests/halotools_test.py
+++ b/tests/halotools_test.py
@@ -59,13 +59,16 @@ def test_binning_hmf():
     h = subfind.halos()
     assert len(h) == 4226
 
-    center, means, err = pynbody.analysis.hmf.simulation_halo_mass_function(subfind,
-                                                                            log_M_min=8,
-                                                                            log_M_max=14,
-                                                                            delta_log_M=0.5,
-                                                                            subsample_catalogue=100)
+    with pytest.warns(UserWarning, match=r"Halo finder masses not provided\. Calculating them.*"):
+        center, means, err = pynbody.analysis.hmf.simulation_halo_mass_function(
+            subfind,
+            log_M_min=8,
+            log_M_max=14,
+            delta_log_M=0.5,
+            subsample_catalogue=100
+        )
 
-    assert(len(means) == len(center) == len(err) == 12)
+    assert len(means) == len(center) == len(err) == 12
 
     np.testing.assert_allclose(center, [2.08113883e+08,   6.58113883e+08,   2.08113883e+09,   6.58113883e+09,
                                         2.08113883e+10,   6.58113883e+10,   2.08113883e+11,   6.58113883e+11,

--- a/tests/pyread_gadget_hdf5.py
+++ b/tests/pyread_gadget_hdf5.py
@@ -169,11 +169,11 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 ##
 #########################################################
 
-    if cgsunits != None and physunits != None:
+    if cgsunits is not None and physunits is not None:
         print("[ERROR] Can't convert units to both CGS and PHYS, as CGS includes PHYS, assuming CGS ")
-        physunits == None
+        physunits is None
 
-    if silent == None:
+    if silent is None:
         print("User gave "+filename)
 
     ## Determine the file type, i.e. SubFind, Snapshot or old FOF.
@@ -186,7 +186,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
     elif filename.rfind('/snap') >= 0:
         inputtype = 'Snapshot' ## Define File type
         inputname = 'snap'
-    if silent == None:
+    if silent is None:
         print("This is a "+inputtype+" output filetype")
 
     ## Check that the file given and the ptype used makes sense
@@ -198,7 +198,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
         return -1
 
     if ptype < 6:
-        if inputtype == 'SubFind' and sub_dir == None:
+        if inputtype == 'SubFind' and sub_dir is None:
             print('[ERROR] ptype = '+str(ptype)+' is not allowed without specifying sub_dir flag')
             return -2
 
@@ -211,10 +211,10 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
     snapnum_index = filename[:folder_index-1].rfind('_')
     snapnum = int(filename[snapnum_index+1:folder_index-1])
     numfile = len(fnmatch.filter(os.listdir(filename[:folder_index]), '*.hdf5'))
-    if noloop != None:
+    if noloop is not None:
         numfile = 1 ## Force the code to only consider the input file
 
-    if silent == None:
+    if silent is None:
         print("Considering "+str(numfile)+" subfiles")
 #########################################################
 ##
@@ -239,13 +239,13 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 ##  Read in unit conversion
 ##
 #########################################################
-        if cgsunits != None or physunits != None:
+        if cgsunits is not None or physunits is not None:
             gamma = fin['Constants'].attrs['GAMMA']
             solar_mass = fin['Constants'].attrs['SOLAR_MASS'] ## [g]
             boltzmann = fin['Constants'].attrs['BOLTZMANN'] ## [erg/K]
             protonmass = fin['Constants'].attrs['PROTONMASS'] ## [g]
             sec_per_year = fin['Constants'].attrs['SEC_PER_YEAR']
-        if silent == None:
+        if silent is None:
             print("Note h="+("%.3f" % hubble)+" in this simulation"+\
             " and snapshot is at a="+("%.3f" % aexp)+\
             " (z="+("%.3f" % (1./aexp-1.))+")")
@@ -256,10 +256,10 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 ##
 #########################################################
         e = 'Parameters/ChemicalElements' in fin
-        if e == True:
+        if e is True:
             nelements = fin['Parameters/ChemicalElements'].attrs['BG_NELEMENTS']
             elementnames = fin['Parameters/ChemicalElements'].attrs['ElementNames']
-            if silent == None:
+            if silent is None:
                 print("Number of Elements Tracked "+str(nelements)+", they are")
                 for elementtype in elementnames:
                     print(elementtype)
@@ -281,7 +281,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
     if numpart_total[0] > 0 or numpart_total[4] > 0 or numpart_total[5] > 0:
         if var_name in elementnames:
             var_name = 'ElementAbundance/'+var_name
-        if smooth != None:
+        if smooth is not None:
             var_name = 'Smoothed'+var_name
     if ptype < 6:
         global_var_name = '/'+'PartType'+str(ptype)+'/'+var_name+'/'
@@ -294,10 +294,10 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
     elif ptype == 13:
         global_var_name = '/Stars/'+var_name+'/'
 
-    if sub_dir != None:
+    if sub_dir is not None:
         global_var_name = sub_dir.upper()+global_var_name
 
-    if silent == None:
+    if silent is None:
         print("Now select the requested variable "+global_var_name)
 
 #########################################################
@@ -307,17 +307,17 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 #########################################################
     prefix_index = filename.rfind('.hdf5') ## First HDF5
     for ifile in range(0,numfile):
-        if noloop != None:
+        if noloop is not None:
             newinfile = filename
         else:
             newinfile = filename[0:folder_index] + inputname +'_'+str(snapnum).zfill(3)+'.'+str(ifile)+filename[prefix_index:]
-        if silent == None:
+        if silent is None:
             print("Reading from "+newinfile)
 
         with h5py.File(newinfile, "r") as fin:
 ## If the dataset is present in the file then read it into tmpset, and if dataset exists concatenate them
             e = global_var_name in fin
-            if e == True:
+            if e is True:
                 tmpset = pd.DataFrame(fin[global_var_name][()]) ## Let HDF5 metadata dictate array format
 
                 try:
@@ -325,7 +325,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
                 except NameError:
                     dataset = tmpset
                     ## Grab the conversion factors while we find this dataset for the first time
-                    if cgsunits != None or physunits != None:
+                    if cgsunits is not None or physunits is not None:
                         cgsconvfactor = fin[global_var_name].attrs['CGSConversionFactor']
                         aexpscaleexponent = fin[global_var_name].attrs['aexp-scale-exponent']
                         hscaleexponent = fin[global_var_name].attrs['h-scale-exponent']
@@ -340,7 +340,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
             ## Have to hardwire in the case for collisionless particles, which all have the same mass,
             ## as given by the masstable, and a number of particles given by Header numppart_total
             ## Assume that the standard Gadget units are used.
-                if cgsunits != None or physunits != None:
+                if cgsunits is not None or physunits is not None:
                     cgsconvfactor=1.989e43
                     aexpscaleexponent=0.0
                     hscaleexponent=-1.0
@@ -358,7 +358,7 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 ##  Horribe Bug in the Code which has the FOF CoM wrong scaling
 ##
 #########################################################
-        if cgsunits != None or physunits != None:
+        if cgsunits is not None or physunits is not None:
             if global_var_name == 'FOF/CenterOfMassVelocity/' and abs(aexpscaleexponent-0.5) < 0.01:
                 print("OWLS SubFind had a bug which stated FoF CenterOfMassVelocity had aexp of 0.5, in reality it was -1.0 ")
                 aexpscaleexponent = -1.0
@@ -369,14 +369,14 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
 ##  for 'a' and 'h' dependencies, else output in code units
 ##
 #########################################################
-    if cgsunits != None:
-        if leaveh != None:
+    if cgsunits is not None:
+        if leaveh is not None:
             convfactor = aexp**aexpscaleexponent * cgsconvfactor
         else:
             convfactor = aexp**aexpscaleexponent * hubble**hscaleexponent * cgsconvfactor
 
-    if physunits != None:
-        if leaveh != None:
+    if physunits is not None:
+        if leaveh is not None:
             convfactor = aexp**aexpscaleexponent
         else:
             convfactor = aexp**aexpscaleexponent * hubble**hscaleexponent
@@ -392,22 +392,22 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
         if  var_name == 'MaximumEntropy':
             convfactor *= cgsconvfactor*protonmass**gamma / boltzmann
 
-    if cgsunits != None or physunits != None:
+    if cgsunits is not None or physunits is not None:
         dataset *= convfactor
-        if silent == None:
-            if cgsunits != None:
+        if silent is None:
+            if cgsunits is not None:
                 print("Converting units to CGS")
-            if physunits != None:
+            if physunits is not None:
                 print("Converting units to Proper Normalised Units ")
             print("Scale Factor dependency "+str(aexpscaleexponent))
-            if leaveh != None:
+            if leaveh is not None:
                 print("User asked to leave little h unchanged! ")
             else:
                 print("little h dependency "+str(hscaleexponent))
 
             print("Overall conversion factor "+str(convfactor))
     else:
-        if silent == None:
+        if silent is None:
             print("No conversion - still in Code units")
 
 #########################################################
@@ -432,14 +432,14 @@ def pyread_gadget_hdf5(filename, ptype, var_name, sub_dir=None,\
         nadded = len(dataset.index) // ncols
         dataset = pd.DataFrame(dataset.values.reshape((nadded,ncols)))
 
-    if floatunits != None:
+    if floatunits is not None:
         dataset = dataset.astype('f4')## Make the units float32
 
-    if silent == None:
+    if silent is None:
         print("Done ")
 
     ## User wants to change from Dataframe to numpy format
-    if nopanda != None:
+    if nopanda is not None:
         dataset = numpy.ascontiguousarray(dataset)
 
     return dataset

--- a/tests/ramses_new_ptcl_format_test.py
+++ b/tests/ramses_new_ptcl_format_test.py
@@ -125,7 +125,7 @@ def test_load_no_ptcls():
     assert len(f.gas) == 196232
 
 def test_loaded_namelist():
-    assert f._namelist['cosmo'] == False
-    assert f._namelist['hydro'] == True
+    assert f._namelist['cosmo'] is False
+    assert f._namelist['hydro'] is True
     assert f._namelist['z_ave'] == 0.1
-    assert f._namelist.get("non_existent_key") == None
+    assert f._namelist.get("non_existent_key") is None

--- a/tests/ramses_new_ptcl_format_test.py
+++ b/tests/ramses_new_ptcl_format_test.py
@@ -1,15 +1,14 @@
 import glob
 import os
-import warnings
 
 import numpy as np
+import pytest
 
 import pynbody
 
 sink_filename = "testdata/ramses_new_format_partial_output_00001/sink_00001.csv"
 sink_filename_moved = sink_filename+".temporarily_moved"
 
-import pytest
 
 
 def setup_module():
@@ -34,44 +33,41 @@ def test_sink_variables():
     assert str(f.bh['pos'].units)=="3.09e+21 cm"
     assert (f.bh['id']==np.array([1,2])).all()
 
-def _unexpected_format_warning_was_issued(warnings):
-    return any(["unexpected format" in str(w_i).lower() for w_i in warnings])
 
 def _no_bh_family_present(f):
     return (len(f.bh)==0) and (pynbody.family.bh not in f.families())
 
-def test_no_sink_file():
+@pytest.fixture
+def backup_sinkfile():
     try:
         os.rename(sink_filename, sink_filename_moved)
-        with warnings.catch_warnings(record=True) as w:
-            f_no_sink = pynbody.load("testdata/ramses_new_format_partial_output_00001")
-        assert not _unexpected_format_warning_was_issued(w)
-        assert _no_bh_family_present(f_no_sink)
+        yield sink_filename
     finally:
         os.rename(sink_filename_moved, sink_filename)
 
-def test_garbled_sink_file():
-    try:
-        os.rename(sink_filename, sink_filename_moved)
-        with open(sink_filename,"w") as tfile:
+
+def test_no_sink_file(backup_sinkfile):
+    # No warning should be raised
+    f_no_sink = pynbody.load("testdata/ramses_new_format_partial_output_00001")
+    assert _no_bh_family_present(f_no_sink)
+
+def test_garbled_sink_file(backup_sinkfile):
+    with open(sink_filename, "w") as tfile:
+        tfile.write("1,2,3\r\n")
+
+    warn_str = r"Unexpected format in file .*\.csv -- sink data has not been loaded"
+    with pytest.warns(UserWarning, match=warn_str):
+        f_garbled_sink = pynbody.load("testdata/ramses_new_format_partial_output_00001")
+    assert _no_bh_family_present(f_garbled_sink)
+
+    with open(sink_filename,"w") as tfile:
+        for i in range(4):
             tfile.write("1,2,3\r\n")
 
-        with warnings.catch_warnings(record=True) as w:
-            f_garbled_sink = pynbody.load("testdata/ramses_new_format_partial_output_00001")
-        assert _unexpected_format_warning_was_issued(w)
-        assert _no_bh_family_present(f_garbled_sink)
-
-        with open(sink_filename,"w") as tfile:
-            for i in range(4):
-                tfile.write("1,2,3\r\n")
-
+    with pytest.warns(UserWarning, match=warn_str):
         f_garbled_sink = pynbody.load("testdata/ramses_new_format_partial_output_00001")
-        # Would be nice to test the warning is also raised here, but need to figure out how to get python to
-        # re-raise it despite the fact it was already triggered above.
 
-        assert _no_bh_family_present(f_garbled_sink)
-    finally:
-        os.rename(sink_filename_moved, sink_filename)
+    assert _no_bh_family_present(f_garbled_sink)
 
 def test_load_pos():
     loaded_vals = f.dm['pos'][::5001]

--- a/tests/ramses_test.py
+++ b/tests/ramses_test.py
@@ -22,9 +22,9 @@ def test_properties():
     np.testing.assert_almost_equal(f.properties['h'], 0.01)
     np.testing.assert_almost_equal(f.properties['omegaM0'], 1.0)
 
+@pytest.mark.filterwarnings(r"ignore:More hydro variables \(\d*\).*:RuntimeWarning")
 def test_particle_arrays():
-    with pytest.warns(RuntimeWarning, match="More hydro variables.*"):
-        f['pos']
+    f['pos']
     f['vel']
     np.testing.assert_allclose(f.star['pos'][50], [ 29.93861623,  29.29166795,  29.77920022])
     np.testing.assert_allclose(f.dm['pos'][50], [ 23.76016295,  21.64945726,   7.70719058])
@@ -34,6 +34,7 @@ def test_particle_arrays():
        144166,  26147])
     np.testing.assert_allclose(f.dm['vel'][50], [ 0.32088361, -0.82660566, -0.32874243])
 
+@pytest.mark.filterwarnings(r"ignore:More hydro variables \(\d*\).*:RuntimeWarning")
 def test_array_unit_sanity():
     """Picks up on problems with converting arrays as they
     get promoted from family to simulation level"""
@@ -113,9 +114,9 @@ def test_rt_unit_warning_for_photon_rho():
         f1.gas['rad_0_rho']
 
 
+@pytest.mark.filterwarnings(r"ignore:Using field at offset \d to distinguish.*:UserWarning")
 def test_all_dm():
-    with pytest.warns(UserWarning, match=r"Using field at offset \d to distinguish.*"):
-        f1 = pynbody.load("testdata/ramses_dmo_partial_output_00051")
+    f1 = pynbody.load("testdata/ramses_dmo_partial_output_00051")
 
     assert len(f1.families())==1
     assert len(f1.dm)==274004
@@ -133,9 +134,9 @@ def test_all_dm():
                                rtol=1e-5
                                )
 
+@pytest.mark.filterwarnings(r"ignore:Using field at offset \d to distinguish.*:UserWarning")
 def test_forcegas_dmo():
-    with pytest.warns(UserWarning, match=r"Using field at offset \d to distinguish.*"):
-        f_dmo = pynbody.load("testdata/ramses_dmo_partial_output_00051", cpus=[1], force_gas=True)
+    f_dmo = pynbody.load("testdata/ramses_dmo_partial_output_00051", cpus=[1], force_gas=True)
     assert len(f_dmo.families())==2
     assert len(f_dmo.dm)==274004
     assert len(f_dmo.g)==907818
@@ -350,10 +351,10 @@ def test_proper_time_loading():
         )
 
 
+@pytest.mark.filterwarnings(r"ignore:Using field at offset \d to distinguish.*:UserWarning")
 def test_is_cosmological_without_namelist():
     # Load a cosmo run, but without the namelist.txt file and checks that cosmo detection works with a warning
-    with pytest.warns(UserWarning, match=r"Using field at offset \d to distinguish.*"):
-        f_without_namelist = pynbody.load("testdata/ramses_dmo_partial_output_00051")
+    f_without_namelist = pynbody.load("testdata/ramses_dmo_partial_output_00051")
     f_without_namelist.physical_units()
 
     warn_msg = (
@@ -364,9 +365,10 @@ def test_is_cosmological_without_namelist():
         assert f_without_namelist.is_cosmological
 
 
+@pytest.mark.filterwarnings("ignore:No ionization fractions found, assuming.*:UserWarning")
+@pytest.mark.filterwarnings(r"ignore:More hydro variables \(\d*\).*:RuntimeWarning")
 def test_temperature_derivation():
-    with pytest.warns(UserWarning, match="No ionization fractions found, assuming.*"):
-        f.g['mu']
+    f.g['mu']
     f.g['temp']
 
     assert(f.g['mu'].min() != f.g['mu'].max())   # Check that ionized and neutral mu are now generated
@@ -394,10 +396,10 @@ def test_file_descriptor_reading():
         assert field in loadable_fields
 
 
+@pytest.mark.filterwarnings(r"ignore:Using field at offset \d to distinguish.*:UserWarning")
 def test_tform_and_metals_do_not_break_loading_when_not_present_in_particle_blocks():
     # DMO snapshot would not have tform or metals in the header or defined on disc
-    with pytest.warns(UserWarning, match=r"Using field at offset \d to distinguish.*"):
-        f_dmo = pynbody.load("testdata/ramses_dmo_partial_output_00051", force_gas=True)
+    f_dmo = pynbody.load("testdata/ramses_dmo_partial_output_00051", force_gas=True)
 
     # This should break the loading with a Key Error that the array cannot be found
     # Previous to the fix of #689, it would break with
@@ -462,10 +464,10 @@ def array_by_array_test_tipsy_converter(ramses_snap, tipsy_snap):
         npt.assert_allclose(ramses_snap.g['mass'], tipsy_snap.g['mass'], rtol=rtol)
 
 
+@pytest.mark.filterwarnings(r"ignore:Using field at offset \d to distinguish.*:UserWarning")
 def test_tipsy_conversion_for_dmo():
     path = "testdata/ramses_dmo_partial_output_00051"
-    with pytest.warns(UserWarning, match=r"Using field at offset \d to distinguish.*"):
-        f_dmo = pynbody.load(path)
+    f_dmo = pynbody.load(path)
 
     with pytest.warns(UserWarning, match=r"This routine currently makes the assumption that the ramses snapshot is cosmological.*"):
         pynbody.analysis.ramses_util.convert_to_tipsy_fullbox(f_dmo, write_param=True)

--- a/tests/rockstar_test.py
+++ b/tests/rockstar_test.py
@@ -12,7 +12,8 @@ def setup_module():
     f['iord'] = np.arange(2097152)
     f.properties['z']=1.6591479493605812
     f._filename = "testdata/rockstar/snapshot_015"
-    h = f.halos()
+    with pytest.warns(RuntimeWarning, match=r"No iord array available; assuming.*"):
+        h = f.halos()
 
 
 def test_load_rockstar():

--- a/tests/sph_image_test.py
+++ b/tests/sph_image_test.py
@@ -1,9 +1,7 @@
-import pickle
 from pathlib import Path
 
 import numpy as np
 import numpy.testing as npt
-import pylab as p
 import pytest
 
 import pynbody
@@ -121,7 +119,8 @@ def test_denoise_projected_image_throws():
 
 def test_render_stars(stars_2d):
     global f
-    im = pynbody.plot.stars.render(f, width=10.0, resolution=100, ret_im=True, plot=False)
+    with pytest.warns(UserWarning, match=r"No log file found; reverting to guess-and-check"):
+        im = pynbody.plot.stars.render(f, width=10.0, resolution=100, ret_im=True, plot=False)
 
     # np.save("test_stars_2d.npy", im[40:60])
 
@@ -132,6 +131,9 @@ def test_render_stars(stars_2d):
 def intentional_circular_reference(sim):
     return sim['intentional_circular_reference']
 
+# Note: we ignore all warnings here, since pytest will otherwise
+# trigger a warning internally because of the exception propagation
+@pytest.mark.filterwarnings("ignore:.*")
 def test_exception_propagation():
     with pytest.raises(RuntimeError):
         pynbody.plot.sph.image(f.gas, qty='intentional_circular_reference')

--- a/tests/subfindhdf_gadget4_test.py
+++ b/tests/subfindhdf_gadget4_test.py
@@ -2,17 +2,21 @@ from os.path import isfile
 
 import h5py
 import numpy as np
+import pytest
 
 import pynbody
 
 
 def setup_module():
     global snap, halos, subhalos, htest, snap_arepo, halos_arepo, subhalos_arepo, htest_arepo
-    snap = pynbody.load('testdata/testL10N64/snapshot_000.hdf5')
+    with pytest.warns(UserWarning, match="Masses are either stored in the header or have another dataset .*"):
+        snap = pynbody.load('testdata/testL10N64/snapshot_000.hdf5')
+        snap_arepo = pynbody.load('testdata/arepo/cosmobox_015.hdf5')
+
     halos = pynbody.halo.Gadget4SubfindHDFCatalogue(snap)
     subhalos = pynbody.halo.Gadget4SubfindHDFCatalogue(snap, subs=True)
     htest = Halos('testdata/testL10N64/', 0)
-    snap_arepo = pynbody.load('testdata/arepo/cosmobox_015.hdf5')
+
     halos_arepo = pynbody.halo.ArepoSubfindHDFCatalogue(snap_arepo)
     subhalos_arepo = pynbody.halo.ArepoSubfindHDFCatalogue(snap_arepo, subs=True)
     htest_arepo = Halos('testdata/arepo/', 15)
@@ -60,7 +64,7 @@ def test_subhalo_properties():
         _test_halo_or_subhalo_properties(htest_file.load()['subhalos'], halocatalogue)
 
 
-
+@pytest.mark.filterwarnings("ignore:Unable to infer units from HDF attributes")
 def test_halo_loading() :
     """ Check that halo loading works """
     # check that data loading for individual fof groups works
@@ -77,6 +81,7 @@ def test_halo_loading() :
     assert(len(halos_arepo[0]['iord']) == len(halos_arepo[0]) == np.sum(arepo_halos['GroupLenType'][0, :], axis=-1))
 
 
+@pytest.mark.filterwarnings("ignore:Unable to infer units from HDF attributes")
 def test_particle_data():
     hids = np.random.choice(range(len(halos)), 5)
     for hid in hids:

--- a/tests/tipsy_test.py
+++ b/tests/tipsy_test.py
@@ -157,6 +157,7 @@ def test_array_write():
     assert all(np.abs(f['array_write_test'] - f['array_read_test']) < 1.e-5)
 
 
+@pytest.mark.filterwarnings("ignore:Paramfile suggests time is cosmological.*:RuntimeWarning")
 def test_isolated_read():
     s = pynbody.load('testdata/isolated_ics.std')
 
@@ -290,6 +291,7 @@ def test_unit_persistence():
     assert f1['pos'].units != 'kpc'
 
 
+@pytest.mark.filterwarnings("ignore:No log file found; reverting to guess-and-check:UserWarning")
 def test_3d_interpolation():
     # this is the result using scipy.interpolate.interp
     ref3d = np.array([0.07527991,  0.06456315,  0.08380653,  0.15143689,  0.15568259,
@@ -372,6 +374,7 @@ def test_issue_313():
 def test_issue_315():
     assert np.allclose(f.g['cs'][:3], [ 319.46246429,  359.4923197,   300.13751002])
 
+@pytest.mark.filterwarnings("ignore:No log file found; reverting to guess-and-check:UserWarning")
 def test_read_starlog_no_log():
     rhoform = f.s['rhoform'].in_units('Msol kpc**-3')[:1000:100]
     correct = np.array([ 2472533.42024787,  5336799.91228041, 64992197.77874849,


### PR DESCRIPTION
There used to be a very large number of warnings being thrown in the test suite.

Most of them are related to unclosed file descriptors.

In this PR, I either catch or I fixed the closing of the files.