### PR TITLE
Change default AHF halo numbering

### DIFF
--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -37,12 +37,14 @@ class AHFCatalogue(HaloCatalogue):
                         basename to load the catalog data.
 
         *halo_numbers*: specify how to number the halos. Options are:
-                            'file-order': use the order of the halos in the
-                            file, starting at 1 (default, compatible with
-                            older versions of pynbody); 'ahf': use the halo
-                            numbers written in the AHF halos file;
-                            'length-order': sort by the number of particles in each
-                            halo, with the halo with most particles being halo 1
+                             'ahf' (default): use the halo numbers written in the AHF halos file,
+                                              or a zero-based indexing if none is present
+                             'file-order': zero-based indexing of the halos
+                             'v1': one-based indexing of the halos, compatible with pynbody v1.x
+                             'length-order': sort by the number of particles in each halo, with the
+                                             halo with most particles being halo 0
+                             'length-order-v1': as length-order, but indexing from halo 1,
+                                                compatible with dosort=True in pynbody v1
 
         *ignore_missing_substructure*: if True (default), the code will not
                             raise an exception if the substructure file is
@@ -134,12 +136,17 @@ class AHFCatalogue(HaloCatalogue):
             # if no explicit IDs, ahf implicitly numbers starting at 0 in file order
             self._ahf_own_number_mapper = SimpleHaloNumberMapper(0, len(self._halo_properties))
 
-        if halo_numbers == 'file-order':
+        if halo_numbers == 'v1':
             number_mapper = SimpleHaloNumberMapper(1, len(self._halo_properties))
-        elif halo_numbers == 'length-order':
+        elif halo_numbers == 'file-order':
+            number_mapper = SimpleHaloNumberMapper(0, len(self._halo_properties))
+        elif halo_numbers == 'length-order' or halo_numbers == 'length-order-v1':
             npart = np.array([properties['npart'] for properties in self._halo_properties])
             osort = np.argsort(-npart)  # this is better than argsort(npart)[::-1], because it's stable
-            number_mapper = create_halo_number_mapper(osort+1)
+            if halo_numbers.endswith('v1'):
+                number_mapper = create_halo_number_mapper(osort+1)
+            else:
+                number_mapper = create_halo_number_mapper(osort)
         elif halo_numbers == 'ahf':
             number_mapper = self._ahf_own_number_mapper
         else:

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -95,11 +95,9 @@ class AHFCatalogue(HaloCatalogue):
         logger.info("AHFCatalogue loading halo properties")
         self._load_ahf_halo_properties(self._ahfBasename + 'halos')
 
-        # Now we know what halos we have, we can initialise the base class
-        # TODO - here is where dosort should be implemented, and also where AHF's own halo numbering could be used
         if dosort:
-            warnings.warn(DeprecationWarning("dosort keyword is deprecated; instead pass halo_numbers='length-order'"))
-            halo_numbers = 'length-order'
+            warnings.warn(DeprecationWarning("dosort keyword is deprecated; instead pass halo_numbers='length-order-v1'"))
+            halo_numbers = 'length-order-v1'
 
         number_mapper = self._setup_halo_numbering(halo_numbers)
 

--- a/tests/ahf_halos_test.py
+++ b/tests/ahf_halos_test.py
@@ -242,3 +242,12 @@ def test_ahf_non_sequential_ids(snap_with_non_sequential_halos,
 
     assert len(h[halo_ids[1]])==3272
     assert(h[halo_ids[1]]['iord'][::1000] == [232964, 341019, 752354, 793468]).all()
+
+def test_ahf_dosort_kwarg(snap_with_non_sequential_halos):
+    # checks for compatibility with v1 behaviour
+    f = snap_with_non_sequential_halos
+    with pytest.warns(DeprecationWarning):
+        h = pynbody.halo.ahf.AHFCatalogue(f, dosort=True)
+    assert len(h)==1411
+    assert len(h[1])==502300
+    assert len(h[20])==3272

--- a/tests/ahf_halos_test.py
+++ b/tests/ahf_halos_test.py
@@ -33,15 +33,15 @@ def test_ahf_particles(do_load_all, cleanup_fpos_file):
     if do_load_all:
         h.load_all()
 
-    assert len(h[1])==502300
-    assert (h[1]['iord'][::10000]==[57, 27875, 54094, 82969, 112002, 140143, 173567, 205840, 264606,
+    assert len(h[0])==502300
+    assert (h[0]['iord'][::10000]==[57, 27875, 54094, 82969, 112002, 140143, 173567, 205840, 264606,
            301694, 333383, 358730, 374767, 402300, 430180, 456015, 479885, 496606,
            519824, 539971, 555195, 575204, 596047, 617669, 652724, 1533992, 1544021,
            1554045, 1564080, 1574107, 1584130, 1594158, 1604204, 1614257, 1624308, 1634376,
            1644485, 1654580, 1664698, 1674831, 1685054, 1695252, 1705513, 1715722, 1725900,
            1736070, 1746235, 1756400, 1766584, 1776754, 1786886]).all()
-    assert len(h[20])==3272
-    assert(h[20]['iord'][::1000] == [232964, 341019, 752354, 793468]).all()
+    assert len(h[19])==3272
+    assert(h[19]['iord'][::1000] == [232964, 341019, 752354, 793468]).all()
 
 
 @pytest.mark.parametrize("do_load_all", [True, False])
@@ -62,9 +62,9 @@ def test_load_ahf_catalogue_non_gzipped(do_load_all):
 def test_ahf_properties():
     f = pynbody.load("testdata/g15784.lr.01024")
     h = pynbody.halo.ahf.AHFCatalogue(f)
-    assert np.allclose(h[1].properties['Mvir'], 1.69639e+12)
-    assert np.allclose(h[2].properties['Ekin'],6.4911e+17)
-    assert np.allclose(h[2].properties['Mvir'], 1.19684e+13)
+    assert np.allclose(h[0].properties['Mvir'], 1.69639e+12)
+    assert np.allclose(h[1].properties['Ekin'],6.4911e+17)
+    assert np.allclose(h[1].properties['Mvir'], 1.19684e+13)
 
 
 @pytest.fixture
@@ -118,8 +118,8 @@ def test_ramses_ahf_family_mapping_with_new_format():
     assert len(halos) == 149    # 150 lines in AHF halos file
 
     # Load halos and check that stars, DM and gas are correctly mapped by pynbody
-    # Halo 1 is the main halo and has all three families, while other are random picks
-    halo_numbers = [1, 10, 15]
+    # Halo 0 is the main halo and has all three families, while other are random picks
+    halo_numbers = [0, 9, 14]
     for halo_number in halo_numbers:
         halo = halos[halo_number]
 
@@ -157,8 +157,8 @@ def test_ahf_substructure():
     halos = pynbody.halo.ahf.AHFCatalogue(f)
     halos.load_all()
 
-    check_parents = [1,2]
-    check_children = [[73, 75, 139, 90], [116, 125,  21,  97]]
+    check_parents = [0,1]
+    check_children = [[72, 74, 138, 89], [115, 124,  20,  96]]
 
     for parent, children in zip(check_parents, check_children):
         halo = halos[parent]
@@ -218,8 +218,10 @@ def snap_with_non_sequential_halos():
 
 @pytest.mark.parametrize("halo_numbering_mode, halo_ids",
                          [('ahf', (157105, 608171)),
-                          ('file-order', (20, 1)),
-                          ('length-order', (1,20))])
+                          ('v1', (20, 1)),
+                          ('file-order', (19, 0)),
+                          ('length-order-v1', (1,20)),
+                          ('length-order', (0, 19))])
 def test_ahf_non_sequential_ids(snap_with_non_sequential_halos,
                                 halo_numbering_mode,
                                 halo_ids):

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -90,7 +90,7 @@ def test_bridging_with_more_families():
     # Test that we can create a group array for snapshots that have a complex family structure,
     # and bridge only with one family (DM). This is necessary for e.g. Tangos linking
     f1 = pynbody.load("testdata/ramses_new_format_cosmo_with_ahf_output_00110")
-    g1 = pynbody.halo.ahf.AHFCatalogue(f1)
+    g1 = pynbody.halo.ahf.AHFCatalogue(f1, halo_numbers='v1')
     g1.load_all()
     # Work only on one family and create a useless bridge which is enough to break the code
     f1 = f1.dm

--- a/tests/gravity_test.py
+++ b/tests/gravity_test.py
@@ -7,9 +7,9 @@ import pynbody
 def test_gravity():
     f = pynbody.load("testdata/g15784.lr.01024")
     h = f.halos()
-    pynbody.analysis.angmom.faceon(h[1])
+    pynbody.analysis.angmom.faceon(h[0])
     pro = pynbody.analysis.profile.Profile(
-        h[1], type='equaln', nbins=50, rmin='100 pc', rmax='50 kpc')
+        h[0], type='equaln', nbins=50, rmin='100 pc', rmax='50 kpc')
 
     v_circ_correct = np.array([  57.19634349,  103.04331454,  132.12411594,  155.65275799,
         175.52850379,  193.26102536,  209.52418648,  224.3799979 ,

--- a/tests/halotools_test.py
+++ b/tests/halotools_test.py
@@ -21,14 +21,14 @@ def teardown_module():
 
 def test_center():
     global f, h
-    with pynbody.analysis.halo.center(h[1]):
+    with pynbody.analysis.halo.center(h[0]):
         np.testing.assert_allclose(
             f['pos'][0], [-0.0137471,  -0.00208458, -0.04392379], atol=1e-4)
 
 
 def test_align():
     global f, h
-    with pynbody.analysis.angmom.faceon(h[1]):
+    with pynbody.analysis.angmom.faceon(h[0]):
         np.testing.assert_allclose(f['pos'][:2], [[-0.010718, -0.001504, -0.044783],
                                                   [-0.010026,  0.002441, -0.04465 ]], atol=1e-5)
 
@@ -38,7 +38,7 @@ def test_align():
 
 def test_virialradius():
     global f, h
-    with pynbody.analysis.halo.center(h[1]):
+    with pynbody.analysis.halo.center(h[0]):
         start = time.time()
         vrad = pynbody.analysis.halo.virial_radius(f)
         print ("time=",time.time()-start)


### PR DESCRIPTION
Unlike all other halo catalogue readers, pynbody indexes AHF halos starting at 1 for historical reasons.

I am proposing to fix this in pynbody v2, as a breaking change, with the option to obtain the old behaviour via `halo_numbers='v1'`