### PR TITLE
Fix a bug with reading gadget4-subfind-hdf tree information

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ jobs:
       id: cache-testdata
       with:
         path: tests/testdata
-        key: testdata-v2
+        key: testdata-v3
     - name: Install gcc
       run: |
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/docs/pitfalls.rst
+++ b/docs/pitfalls.rst
@@ -16,7 +16,7 @@ they're trying to be smart about using sensible units but the
 information just isn't available. The simplest way to avoid this
 situation is to make sure ``pynbody`` can work out the units for itself.
 
-In particular, *for gasoline/PKD/tipsy users, make sure you have a
+In particular, *for gasoline_ahf/PKD/tipsy users, make sure you have a
 param file in the directory where you are analyzing a tipsy file, and
 make sure that it defines dKpcUnit and dMsolUnit.*
 

--- a/docs/reference/derived.rst
+++ b/docs/reference/derived.rst
@@ -25,7 +25,7 @@ pynbody will calculate it:
 
    In [3]: import pynbody
 
-   In [4]: s = pynbody.load('testdata/g15784.lr.01024.gz')
+   In [4]: s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 
    In [5]: s['ke']
 

--- a/docs/tutorials/data_access.rst
+++ b/docs/tutorials/data_access.rst
@@ -41,7 +41,7 @@ functions we'll make use of later.
 
  In [1]: import numpy as np
 
- In [2]: f = pynbody.load("testdata/test_g2_snap")
+ In [2]: f = pynbody.load("testdata/gadget2/test_g2_snap")
 
 Here we've loaded a sample gadget file. Not much seems to have
 happened when you called :func:`pynbody.load`, but the variable ``f``
@@ -59,10 +59,10 @@ framework.
 
 .. note:: If you look inside the ``testdata`` folder, you'll notice that
  our test snapshot is actually an example of a *spanned* gadget
- snapshot. There is not actually a file called ``test_g2_snap``, but
- rather two files from two CPUs, ``test_g2_snap.0`` and
- ``test_g2_snap.1``. ``pynbody`` knows to load both of these if you ask
- for ``test_g2_snap``; if you ask for ``test_g2_snap.1`` (for instance),
+ snapshot. There is not actually a file called ``gadget2/test_g2_snap``, but
+ rather two files from two CPUs, ``gadget2/test_g2_snap.0`` and
+ ``gadget2/test_g2_snap.1``. ``pynbody`` knows to load both of these if you ask
+ for ``gadget2/test_g2_snap``; if you ask for ``gadget2/test_g2_snap.1`` (for instance),
  it'll load only that particular file.
 
 The ``SimSnap`` object that's returned is currently a fairly empty

--- a/docs/tutorials/example_code/density_integrated.py
+++ b/docs/tutorials/example_code/density_integrated.py
@@ -4,7 +4,7 @@ import pynbody
 import pynbody.plot.sph as sph
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 s.physical_units()
 
 # load the halos

--- a/docs/tutorials/example_code/density_profile.py
+++ b/docs/tutorials/example_code/density_profile.py
@@ -3,7 +3,7 @@ import matplotlib.pylab as plt
 import pynbody
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 
 # load the halos
 h = s.halos()

--- a/docs/tutorials/example_code/density_slice.py
+++ b/docs/tutorials/example_code/density_slice.py
@@ -4,7 +4,7 @@ import pynbody
 import pynbody.plot.sph as sph
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 s.physical_units()
 
 # load the halos

--- a/docs/tutorials/example_code/rotcurve.py
+++ b/docs/tutorials/example_code/rotcurve.py
@@ -5,7 +5,7 @@ import matplotlib.pylab as plt
 import pynbody
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 
 # load the halos
 h = s.halos()

--- a/docs/tutorials/example_code/star_render.py
+++ b/docs/tutorials/example_code/star_render.py
@@ -3,7 +3,7 @@ import matplotlib.pylab as plt
 import pynbody
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 s.physical_units()
 
 # load the halos

--- a/docs/tutorials/example_code/temperature_slice.py
+++ b/docs/tutorials/example_code/temperature_slice.py
@@ -4,7 +4,7 @@ import pynbody
 import pynbody.plot.sph as sph
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 s.physical_units()
 
 # load the halos

--- a/docs/tutorials/example_code/velocity_vectors.py
+++ b/docs/tutorials/example_code/velocity_vectors.py
@@ -4,7 +4,7 @@ import pynbody
 import pynbody.plot.sph as sph
 
 # load the snapshot and set to physical units
-s = pynbody.load('testdata/g15784.lr.01024.gz')
+s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 s.physical_units()
 
 # load the halos

--- a/docs/tutorials/halos.rst
+++ b/docs/tutorials/halos.rst
@@ -98,7 +98,7 @@ halo / subhalo structure is handled later.
 
  In [1]: import pynbody, matplotlib.pylab as plt
 
- In [2]: s = pynbody.load('testdata/g15784.lr.01024.gz')
+ In [2]: s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 
  In [3]: s.physical_units()
 
@@ -190,7 +190,7 @@ Consider the following example.
 
 .. ipython::
 
- In [2]: f = pynbody.load("testdata/g15784.lr.01024")
+ In [2]: f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
  In [3]: h = f.halos()
 
@@ -269,7 +269,7 @@ One major change is that the halo catalogue is a separate file to the snapshot.
 
  In [1]: import pynbody, matplotlib.pylab as plt
 
- In [2]: s = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5')
+ In [2]: s = pynbody.load('testdata/gadget3/data/snapshot_103/snap_103.hdf5')
 
  In [3]: s.physical_units()
 
@@ -279,7 +279,7 @@ to load the halo catalogue we have to access the subfind output directly:
 
 .. ipython::
 
- In [3]: s = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103')
+ In [3]: s = pynbody.load('testdata/gadget3/data/subhalos_103/subhalo_103')
 
  In [2]: s.physical_units()
 

--- a/docs/tutorials/profile.rst
+++ b/docs/tutorials/profile.rst
@@ -39,7 +39,7 @@ Let's quickly load a snapshot:
 
   In [1]: import pynbody; from pynbody.analysis import profile; import matplotlib.pylab as plt
 
-  In [1]: s = pynbody.load('testdata/g15784.lr.01024'); s.physical_units()
+  In [1]: s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024'); s.physical_units()
 
   In [2]: h = s.halos()
 

--- a/docs/tutorials/snapshot_manipulation.rst
+++ b/docs/tutorials/snapshot_manipulation.rst
@@ -57,7 +57,7 @@ halo) to analyze its contents.
 
  In [1]: import pylab
 
- In [2]: s = pynbody.load('testdata/g15784.lr.01024.gz')
+ In [2]: s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
 
 This loads the snapshot ``s`` (make sure you use the correct path to
 the ``testdata`` directory). Now we load the halos and center on the
@@ -173,7 +173,7 @@ to illustrate this:
 
 .. ipython::
 
- In [2]: s = pynbody.load('testdata/g15784.lr.01024.gz'); h1 = s.halos()[1];
+ In [2]: s = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz'); h1 = s.halos()[1];
 
  In [4]: cen_hyb = pynbody.analysis.halo.center(h1,mode='hyb',retcen=True)
 

--- a/examples/pynbody_demo.ipynb
+++ b/examples/pynbody_demo.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "import pynbody\n",
     "\n",
-    "s = pynbody.load('../nose/testdata/g15784.lr.01024.gz')"
+    "s = pynbody.load('../nose/testdata/gasoline_ahf/g15784.lr.01024.gz')"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "<SimSnap \"../nose/testdata/g15784.lr.01024\" len=1717156>"
+      "text/plain": "<SimSnap \"../nose/testdata/gasoline_ahf/g15784.lr.01024\" len=1717156>"
      },
      "execution_count": 3,
      "metadata": {},
@@ -510,7 +510,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "<SimSnap \"../nose/testdata/g15784.lr.01024:halo_1\" len=502300>"
+      "text/plain": "<SimSnap \"../nose/testdata/gasoline_ahf/g15784.lr.01024:halo_1\" len=502300>"
      },
      "execution_count": 18,
      "metadata": {},
@@ -1049,7 +1049,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "<SimSnap \"../nose/testdata/g15784.lr.01024:halo_1:sphere::star\" len=242858>"
+      "text/plain": "<SimSnap \"../nose/testdata/gasoline_ahf/g15784.lr.01024:halo_1:sphere::star\" len=242858>"
      },
      "execution_count": 32,
      "metadata": {},

--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -75,6 +75,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_quantity
 
-__version__ = '2.0.0-beta.2'
+__version__ = '2.0.0-beta.3'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/halo/subfindhdf.py
+++ b/pynbody/halo/subfindhdf.py
@@ -141,7 +141,8 @@ class SubFindHDFHaloCatalogue(HaloCatalogue) :
 
     def __inherit_data(self, parent):
         attrs_to_share = ["_fof_properties", "_sub_properties", "_fof_group_offsets", "_fof_group_lengths",
-                         "_subfind_halo_offsets", "_subfind_halo_lengths"]
+                         "_subfind_halo_offsets", "_subfind_halo_lengths",
+                          "fof_ignore", "sub_ignore"]
         for attr in attrs_to_share:
             setattr(self, attr, getattr(parent, attr))
 

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -55,7 +55,6 @@ class TipsySnap(SimSnap):
 
         must_have_paramfile = kwargs.get('must_have_paramfile', False)
         take = kwargs.get('take', None)
-        verbose = kwargs.get('verbose', config['verbose'])
 
         self.partial_load = take is not None
 
@@ -941,9 +940,11 @@ class TipsySnap(SimSnap):
     @classmethod
     def _can_load(cls, f):
         try:
-            check = TipsySnap(f, verbose=False)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                check = TipsySnap(f)
             del check
-        except Exception:
+        except Exception as e:
             return False
 
         return True

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -156,7 +156,7 @@ def test_dimensionful_comparison():
     assert not (y['b'] > y['a']).any()
 
 def test_issue_485_1():
-    s = pynbody.load("testdata/test_g2_snap.1")
+    s = pynbody.load("testdata/gadget2/test_g2_snap.1")
     stars = s.s
     indexed_arr = stars[1,2]
     np.testing.assert_almost_equal(np.sum(indexed_arr['vz'].in_units('km s^-1')), -20.13701057434082031250)
@@ -164,7 +164,7 @@ def test_issue_485_1():
 
 def test_issue_485_2():
     # Adaptation of examples/vdisp.py
-    s = pynbody.load("testdata/test_g2_snap.1")
+    s = pynbody.load("testdata/gadget2/test_g2_snap.1")
 
     stars = s.s
     rxyhist, rxybins = np.histogram(stars['rxy'], bins=20)

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -17,8 +17,8 @@ def test_order_bridge():
 
 
 def test_bridge_factory():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
-    f2 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
+    f2 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     b = pynbody.bridge.bridge_factory(f1, f2)
 
     assert isinstance(b, pynbody.bridge.OrderBridge)

--- a/tests/copy_on_access_test.py
+++ b/tests/copy_on_access_test.py
@@ -117,13 +117,13 @@ def test_properties():
     assert f.properties['test_property'] == 101
 
 def test_repr():
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     f_c = f.get_copy_on_access_simsnap()
 
-    assert repr(f_c) == '<SimSnap "testdata/g15784.lr.01024:copied_on_access" len=1717156>'
+    assert repr(f_c) == '<SimSnap "testdata/gasoline_ahf/g15784.lr.01024:copied_on_access" len=1717156>'
 
 def test_loadable_keys():
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     f['pos'] # noqa
     f.dm['new_array'] = np.empty(len(f.dm))
 
@@ -140,7 +140,7 @@ def test_loadable_keys():
     assert 'new_array' in f_c.dm.loadable_keys()
 
 def test_all_keys():
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     f_c = f.get_copy_on_access_simsnap()
     assert 'pos' in f_c.all_keys()
 

--- a/tests/family_test.py
+++ b/tests/family_test.py
@@ -10,7 +10,7 @@ def test_pickle():
 
 def test_family_array_dtype() :
     # test for issue #186
-    f = pynbody.load('testdata/g15784.lr.01024.gz')
+    f = pynbody.load('testdata/gasoline_ahf/g15784.lr.01024.gz')
     f.g['rho'] = np.zeros(len(f.g), dtype=np.float32)
     f.s['rho']
 

--- a/tests/gadget_test.py
+++ b/tests/gadget_test.py
@@ -7,7 +7,7 @@ import pynbody
 
 def setup_module():
     global snap
-    snap = pynbody.load("testdata/test_g2_snap")
+    snap = pynbody.load("testdata/gadget2/test_g2_snap")
 
 
 def teardown_module():
@@ -19,7 +19,7 @@ def test_construct():
     """Check the basic properties of the snapshot"""
     assert np.size(snap._files) == 2
     assert snap.header.num_files == 2
-    assert snap.filename == "testdata/test_g2_snap"
+    assert snap.filename == "testdata/gadget2/test_g2_snap"
     assert snap._num_particles == 8192
     for f in snap._files:
         assert f.format2
@@ -71,8 +71,8 @@ def test_array_sizes():
 
 def test_fam_sim():
     """Check that an array loaded as families is the same as one loaded as a simulation array"""
-    snap2 = pynbody.load("testdata/test_g2_snap")
-    snap3 = pynbody.load("testdata/test_g2_snap")
+    snap2 = pynbody.load("testdata/gadget2/test_g2_snap")
+    snap3 = pynbody.load("testdata/gadget2/test_g2_snap")
     snap3.gas["pos"]
     snap3.dm["pos"]
     snap3.star["pos"]
@@ -122,7 +122,7 @@ def test_write():
 
 def test_conversion():
     """Check that we can convert a file from tipsy format and load it again"""
-    snap4 = pynbody.load("testdata/g15784.lr.01024")
+    snap4 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     snap4.write(fmt=pynbody.snapshot.gadget.GadgetSnap,
                 filename="testdata/test_conversion.gadget")
     snap5 = pynbody.load("testdata/test_conversion.gadget")
@@ -131,7 +131,7 @@ def test_conversion():
 def test_write_single_array():
     """Check that we can write a single array and read it back"""
     snap["pos"].write(overwrite=True)
-    snap6 = pynbody.load("testdata/test_g2_snap")
+    snap6 = pynbody.load("testdata/gadget2/test_g2_snap")
     assert((snap6["pos"] == snap["pos"]).all())
 
 
@@ -141,11 +141,11 @@ def test_no_mass_block():
 
 
 def test_unit_persistence():
-    f = pynbody.load("testdata/test_g2_snap")
+    f = pynbody.load("testdata/gadget2/test_g2_snap")
 
     # f2 is the comparison case - just load the whole
     # position array and convert it, simple
-    f2 = pynbody.load("testdata/test_g2_snap")
+    f2 = pynbody.load("testdata/gadget2/test_g2_snap")
     f2['pos']
     f2.physical_units()
 
@@ -178,8 +178,8 @@ def test_per_particle_loading():
     subtelties in the gadget handler that could mess this up by loading
     the wrong data."""
 
-    f_all = pynbody.load("testdata/test_g2_snap")
-    f_part = pynbody.load("testdata/test_g2_snap")
+    f_all = pynbody.load("testdata/gadget2/test_g2_snap")
+    f_part = pynbody.load("testdata/gadget2/test_g2_snap")
 
     f_part.dm['pos']
     f_part.star['pos']
@@ -197,21 +197,21 @@ def test_issue321():
 
 
 def test_units_override():
-    f = pynbody.load("testdata/test_g2_snap.0")
-    assert f.filename == "testdata/test_g2_snap"
+    f = pynbody.load("testdata/gadget2/test_g2_snap.0")
+    assert f.filename == "testdata/gadget2/test_g2_snap"
     assert f['pos'].units == "kpc a h^-1"
 
     # In this case the unit override system is not effective because
     # the final ".1" is not stripped away in the filename:
-    # the file `test_g2_snap.units` is not used
-    f_no_unit_override = pynbody.load("testdata/test_g2_snap.1")
-    assert f_no_unit_override.filename == "testdata/test_g2_snap.1"
+    # the file `gadget2/test_g2_snap.units` is not used
+    f_no_unit_override = pynbody.load("testdata/gadget2/test_g2_snap.1")
+    assert f_no_unit_override.filename == "testdata/gadget2/test_g2_snap.1"
     assert f_no_unit_override['pos'].units == "Mpc a h^-1"  # from default_config.ini
 
 
 def test_ignore_cosmology():
-    f = pynbody.load("testdata/test_g2_snap.1")
+    f = pynbody.load("testdata/gadget2/test_g2_snap.1")
     f.physical_units()
     np.testing.assert_allclose(f.properties['time'].in_units('Gyr'), 2.5769525238964737)
-    f_no_cosmo = pynbody.load("testdata/test_g2_snap.1", ignore_cosmo=True)
+    f_no_cosmo = pynbody.load("testdata/gadget2/test_g2_snap.1", ignore_cosmo=True)
     np.testing.assert_allclose(f_no_cosmo.properties['time'].in_units('Gyr'), 271.6149884391969)

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -11,8 +11,8 @@ from pynbody import units
 
 def setup_module() :
     global snap,subfind
-    snap = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5')
-    subfind = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103')
+    snap = pynbody.load('testdata/gadget3/data/snapshot_103/snap_103.hdf5')
+    subfind = pynbody.load('testdata/gadget3/data/subhalos_103/subhalo_103')
 
 def teardown_module() :
     global snap,subfind
@@ -49,10 +49,10 @@ def _h5py_copy_with_key_rename(src,dest):
 
 
 def test_alt_names():
-    _h5py_copy_with_key_rename('testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5',
-                'testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103_altnames.hdf5')
+    _h5py_copy_with_key_rename('testdata/gadget3/data/snapshot_103/snap_103.hdf5',
+                'testdata/gadget3/data/snapshot_103/snap_103_altnames.hdf5')
 
-    snap_alt = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103_altnames.hdf5')
+    snap_alt = pynbody.load('testdata/gadget3/data/snapshot_103/snap_103_altnames.hdf5')
     assert 'mass' in snap_alt.loadable_keys()
     assert all(snap_alt['mass']==snap['mass'])
 
@@ -68,7 +68,7 @@ def test_write():
     ar_name = 'test_array'
     snap[ar_name] = np.random.uniform(0,1,len(snap))
     snap[ar_name].write()
-    snap2 = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5')
+    snap2 = pynbody.load('testdata/gadget3/data/snapshot_103/snap_103.hdf5')
     v = snap[ar_name]
     with pytest.warns(UserWarning, match="Unable to infer units from HDF attributes"):
         v2 = snap2[ar_name]
@@ -114,7 +114,7 @@ def test_mass_in_header():
     assert np.allclose(f.dm['mass'][0], 3981879.2046075417)
 
 def test_gadgethdf_style_units():
-    f = pynbody.load("testdata/Test_NOSN_NOZCOOL_L010N0128/data/snapshot_103/snap_103.hdf5")
+    f = pynbody.load("testdata/gadget3/data/snapshot_103/snap_103.hdf5")
     npt.assert_allclose(f.st['InitialMass'].units.in_units("1.989e43 g h^-1"), 1.0,
                         rtol=1e-3)
 

--- a/tests/gravity_test.py
+++ b/tests/gravity_test.py
@@ -5,7 +5,7 @@ import pynbody
 
 
 def test_gravity():
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     h = f.halos()
     pynbody.analysis.angmom.faceon(h[0])
     pro = pynbody.analysis.profile.Profile(
@@ -42,7 +42,7 @@ def test_gravity_float():
 
 
 def test_eps_retrieval_str():
-    f = pynbody.load("testdata/test_g2_snap.0")
+    f = pynbody.load("testdata/gadget2/test_g2_snap.0")
     f.properties['eps'] = "0.3 kpc"
     pynbody.gravity.calc.all_direct(f)
     true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
@@ -52,7 +52,7 @@ def test_eps_retrieval_str():
 
 
 def test_eps_retrieval_unit():
-    f = pynbody.load("testdata/test_g2_snap.0")
+    f = pynbody.load("testdata/gadget2/test_g2_snap.0")
     f.properties['eps'] = 0.3 * pynbody.units.kpc
     pynbody.gravity.calc.all_direct(f)
     true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,
@@ -62,7 +62,7 @@ def test_eps_retrieval_unit():
 
 
 def test_eps_retrieval_number():
-    f = pynbody.load("testdata/test_g2_snap.0")
+    f = pynbody.load("testdata/gadget2/test_g2_snap.0")
     f.properties['eps'] = 0.3
     pynbody.gravity.calc.all_direct(f)
     true_phi_10 = np.array([-0.06696571, -0.07087147, -0.07049192,

--- a/tests/halotools_test.py
+++ b/tests/halotools_test.py
@@ -10,7 +10,7 @@ import pynbody
 
 def setup_module():
     global f, h
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     h = f.halos()
 
 
@@ -46,7 +46,7 @@ def test_virialradius():
 
 
 def test_ssc_bighalo():
-    s = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103')
+    s = pynbody.load('testdata/gadget3/data/subhalos_103/subhalo_103')
     s.physical_units()
     h = s.halos()
     pynbody.analysis.halo.center(h[1])
@@ -54,7 +54,7 @@ def test_ssc_bighalo():
 
 
 def test_binning_hmf():
-    subfind = pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103')
+    subfind = pynbody.load('testdata/gadget3/data/subhalos_103/subhalo_103')
 
     h = subfind.halos()
     assert len(h) == 4226

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -12,7 +12,7 @@ from pynbody.array import shared
 
 def setup_module():
     global f
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     # for compatibility with original results, pretend the box
     # is not periodic
@@ -96,7 +96,7 @@ def test_smooth_WendlandC2(rho_W):
     """
     pynbody.config['Kernel'] = 'WendlandC2'
 
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     npt.assert_allclose(f.g['rho'][::100],
                         rho_W,rtol=1e-5)
@@ -122,7 +122,7 @@ def test_kd_issue_88() :
 
 @pytest.mark.filterwarnings(r"ignore:overflow.*:RuntimeWarning")
 def test_float_kd():
-    f = pynbody.load("testdata/test_g2_snap")
+    f = pynbody.load("testdata/gadget2/test_g2_snap")
     del f.properties['boxsize']
 
     assert f.dm['mass'].dtype==f.dm['pos'].dtype==np.float32
@@ -158,7 +158,7 @@ def test_float_kd():
     npt.assert_allclose(double_double,float_float,rtol=1e-4)
 
 def test_periodic_smoothing(rho_periodic, smooth_periodic):
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     """
     np.save('test_rho_periodic.npy', f.dm['rho'][::100])
@@ -172,7 +172,7 @@ def test_periodic_smoothing(rho_periodic, smooth_periodic):
 
 @pytest.mark.filterwarnings("ignore:overflow encountered in cast:RuntimeWarning")
 def test_neighbour_list():
-    f = pynbody.load("testdata/test_g2_snap")
+    f = pynbody.load("testdata/gadget2/test_g2_snap")
     pynbody.sph._get_smooth_array_ensuring_compatibility(f.g)  # actual smoothing
     t = f.g.kdtree
     n_neigh = 32
@@ -206,7 +206,7 @@ def test_neighbour_list():
         assert nl[3][idx_self] == 0.0  # distance to self
 
 def test_div_curl_smoothing(div_curl):
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     """
     np.savez('test_div_curl', curl=f.g['v_curl'][::100], div=f.g['v_div'][::100])

--- a/tests/partial_tipsy_test.py
+++ b/tests/partial_tipsy_test.py
@@ -5,20 +5,20 @@ import pynbody
 
 
 def test_indexing():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     np.random.seed(1)
     for test_len in [100, 10000, 20000]:
         for i in range(5):
             subindex = np.random.permutation(np.arange(0, len(f1)))[:test_len]
             subindex.sort()
-            f2 = pynbody.load("testdata/g15784.lr.01024", take=subindex)
+            f2 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024", take=subindex)
 
             assert (f2['x'] == f1[subindex]['x']).all()
             assert (f2['iord'] == f1[subindex]['iord']).all()
 
 def test_load_copy():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     subview = f1[::5]
 
@@ -35,7 +35,7 @@ def test_load_copy():
         f_subview[:5].load_copy()
 
 def test_grp_load_copy():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     h = f1.halos()
     h1_copy = h[1].load_copy()
     assert (h1_copy['x']==h[1]['x']).all()

--- a/tests/snapshot_test.py
+++ b/tests/snapshot_test.py
@@ -253,6 +253,6 @@ def test_nd_array_slicing():
     assert not f._array_name_implies_ND_slice('rho_x')
 
 def test_index_list():
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     h = f.halos()
     index_list = h[1].get_index_list(f)

--- a/tests/sph_image_test.py
+++ b/tests/sph_image_test.py
@@ -10,7 +10,7 @@ test_folder = Path(__file__).parent
 
 def setup_module():
     global f
-    f = pynbody.load("testdata/g15784.lr.01024")
+    f = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     h = f.halos()
     # hard-code the centre so we're not implicitly testing the centering routine too:
     cen = [0.024456279579533, -0.034112552174141, -0.122436359962132]

--- a/tests/subfindhdf_gadget4_test.py
+++ b/tests/subfindhdf_gadget4_test.py
@@ -8,12 +8,12 @@ from pynbody.test_utils.gadget4_subfind_reader import Halos
 def setup_module():
     global snap, halos, subhalos, htest, snap_arepo, halos_arepo, subhalos_arepo, htest_arepo
     with pytest.warns(UserWarning, match="Masses are either stored in the header or have another dataset .*"):
-        snap = pynbody.load('testdata/testL10N64/snapshot_000.hdf5')
+        snap = pynbody.load('testdata/gadget4_subfind/snapshot_000.hdf5')
         snap_arepo = pynbody.load('testdata/arepo/cosmobox_015.hdf5')
 
     halos = pynbody.halo.subfindhdf.Gadget4SubfindHDFCatalogue(snap)
     subhalos = pynbody.halo.subfindhdf.Gadget4SubfindHDFCatalogue(snap, subs=True)
-    htest = Halos('testdata/testL10N64/', 0)
+    htest = Halos('testdata/gadget4_subfind/', 0)
 
     halos_arepo = pynbody.halo.subfindhdf.ArepoSubfindHDFCatalogue(snap_arepo)
     subhalos_arepo = pynbody.halo.subfindhdf.ArepoSubfindHDFCatalogue(snap_arepo, subs=True)
@@ -92,3 +92,29 @@ def test_particle_data():
     hids = np.random.choice(range(len(halos)), 5)
     for hid in hids:
         assert(np.allclose(halos[hid].dm['iord'], htest[hid]['iord']))
+
+@pytest.mark.filterwarnings("ignore:Masses are either stored")
+def test_progenitors_and_descendants():
+    f = pynbody.load("testdata/gadget4_subfind_with_progdesc/snapshot_033.hdf5")
+    h = f.halos()
+    p = h[0].subhalos[0].properties
+    match = {'FirstProgSubhaloNr': 0,
+             'NextDescSubhaloNr': 50,
+             'ProgSubhaloNr': 0,
+             'SubhaloNr': 0,
+             'DescSubhaloNr': 0,
+             'FirstDescSubhaloNr': 0,
+             'NextProgSubhaloNr': 53}
+    for k, v in match.items():
+        assert p[k] == v
+
+    p = h[3].subhalos[1].properties
+    match = {'FirstProgSubhaloNr': 162,
+             'NextDescSubhaloNr': -1,
+             'ProgSubhaloNr': 162,
+             'SubhaloNr': 153,
+             'DescSubhaloNr': 12,
+             'FirstDescSubhaloNr': 12,
+             'NextProgSubhaloNr': -1}
+    for k, v in match.items():
+        assert p[k] == v

--- a/tests/subfindhdf_test.py
+++ b/tests/subfindhdf_test.py
@@ -9,7 +9,7 @@ import pynbody
 
 @pytest.fixture
 def snap():
-    return pynbody.load('testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103')
+    return pynbody.load('testdata/gadget3/data/subhalos_103/subhalo_103')
 
 @pytest.mark.parametrize('load_all', (True, False))
 def test_halo_loading(snap, load_all) :
@@ -101,7 +101,7 @@ def test_fof_vs_sub_assignment(snap):
 def test_halo_values(snap) :
     """ Check that halo values (and sizes) agree with pyread_gadget_hdf5 """
 
-    filesub = 'testdata/Test_NOSN_NOZCOOL_L010N0128/data/subhalos_103/subhalo_103'
+    filesub = 'testdata/gadget3/data/subhalos_103/subhalo_103'
 
     # load Alan Duffy's module from https://bitbucket.org/astroduff/pyreadgadget
     from pynbody.test_utils.pyread_gadget_hdf5 import pyread_gadget_hdf5

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -63,7 +63,7 @@ def test_potential_profile_fp32():
 
 
 def test_unique_hash_generation():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
     p1 = pynbody.analysis.profile.Profile(f1, nbins=50)
     p2 = pynbody.analysis.profile.Profile(f1[:1000], nbins=50)
 
@@ -76,7 +76,7 @@ def test_unique_hash_generation():
 
 
 def test_write_profile():
-    f1 = pynbody.load("testdata/g15784.lr.01024")
+    f1 = pynbody.load("testdata/gasoline_ahf/g15784.lr.01024")
 
     p = pynbody.analysis.profile.Profile(f1[:1000], nbins=50)
     p['rbins'], p['density']


### PR DESCRIPTION
This necessitates extra testdata, and has triggered a reorganisation of the testdata archive