### PR TITLE
Allow loading adaptahop halos even if DM is not the first particle family

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -75,6 +75,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_quantity
 
-__version__ = '2.0.0-beta.5'
+__version__ = '2.0.0-beta.6'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -120,7 +120,9 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
 
         # dm needs to be at start of family map -- technically we will assume all particles are in dm
         # but then the parent class will use the position offsets as though they refer to the whole file
-        assert self.base._get_family_slice('dm') == slice(0, len(self._base_dm))
+        dm_offset = self.base._get_family_slice('dm').start
+        if dm_offset>0:
+            self._iord_to_fpos = iord_mapping.IordOffsetModifier(self._iord_to_fpos, dm_offset)
 
         self._halos = {}
 

--- a/pynbody/halo/details/iord_mapping.py
+++ b/pynbody/halo/details/iord_mapping.py
@@ -55,6 +55,20 @@ class IordToOffsetSparse(IordToOffset):
         else:
             return result
 
+class IordOffsetModifier(IordToOffset):
+    """A wrapper around an IordToOffset which adds a constant offset to the result of the underlying mapping.
+
+    Useful if the iord values e.g. are only available for a single family; then the fpos_offset will correspond
+    to the first index of that family in the pynbody snapshot.
+    """
+    def __init__(self, iord_to_offset: IordToOffset, fpos_offset: int):
+        self._underlying = iord_to_offset
+        self._fpos_offset = fpos_offset
+
+    def map_ignoring_order(self, i: np.ndarray | int) -> np.ndarray | int:
+        result = self._underlying.map_ignoring_order(i)
+        result += self._fpos_offset
+        return result
 
 def make_iord_to_offset_mapper(iord: np.ndarray) -> IordToOffset:
     """Given an array of unique integers, iord, make an object which maps from an iord value to offset in the array.

--- a/tests/adaptahop_test.py
+++ b/tests/adaptahop_test.py
@@ -232,3 +232,20 @@ def test_halo_iteration(halos):
     assert len(h) == len(halos)
     assert h[0] is halos[1]
     assert h[-1] is halos[len(halos)]
+
+def test_dm_not_first_family(f):
+    # AdaptaHOP files only refer to DM particles, but we can't assume that DM is the first family
+    # e.g. tracer particles come first
+
+    f = pynbody.load("testdata/new_adaptahop_output_00080")
+    f_with_tracers = pynbody.new(gas_tracer=100, dm=len(f.dm), star=len(f.star), gas=len(f.gas))
+    f_with_tracers.dm['iord'] = f.dm['iord']
+    f_with_tracers.properties.update(f.properties)
+
+    halos = f.halos()
+
+    halos2 = pynbody.halo.adaptahop.NewAdaptaHOPCatalogue(f_with_tracers,
+                                 fname = "testdata/new_adaptahop_output_00080/Halos/tree_bricks080")
+
+    assert (halos2[1].dm['iord'] == halos[1].dm['iord']).all()
+    assert (halos2[2].dm['iord'] == halos[2].dm['iord']).all()


### PR DESCRIPTION
This is relevant in EDGE outputs when tracers are present