### PR TITLE
Introduce method to convert a simulation array's dtype

### DIFF
--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -282,3 +282,18 @@ def test_kdtree_shared_mem(npart=1000):
     gc.collect()
     shared._ensure_shared_memory_clean()
     assert shared.get_num_shared_arrays() == n
+
+def test_kdtree_mixed_dtypes(npart=1000):
+    f = _make_test_gaussian(npart)
+    f.set_array_dtype('pos', np.float32)
+    f.set_array_dtype('mass', np.float64)
+    assert f['mass'].dtype == np.float64
+
+    with pytest.warns(RuntimeWarning, match="Converting mass array to float32"):
+        f.build_tree()
+
+    npt.assert_allclose(f['smooth'], f['smooth'], atol=1e-7)
+
+    # kdtree should have auto-converted the dtype
+    assert f['pos'].dtype == np.float32
+    assert f['mass'].dtype == np.float32

--- a/tests/simsnap_test.py
+++ b/tests/simsnap_test.py
@@ -2,6 +2,7 @@
 
 import pathlib
 
+import numpy as np
 import pytest
 
 import pynbody
@@ -14,3 +15,30 @@ def test_load_empty_folder():
     with pytest.raises(IOError) as excinfo:
         f = pynbody.load("testdata/empty_folder_0001")
     assert "Is a directory" in str(excinfo.value)
+
+@pytest.mark.parametrize("family_array", [False, True], ids=['all', 'family'])
+@pytest.mark.parametrize("dimensionality", [1, 3], ids=['1D', '3D'])
+def test_change_dtype(family_array, dimensionality):
+    f = pynbody.new(dm=50, gas=50)
+    if family_array:
+        f = f.dm
+    if dimensionality == 1:
+        f['testarray'] = np.arange(len(f), dtype=np.float64)
+    else:
+        f['testarray'] = np.arange(3*len(f), dtype=np.float64).reshape(len(f), 3)
+    assert f['testarray'].dtype == np.float64
+    f['testarray'].units="Msol"
+    f.set_array_dtype('testarray', np.float32)
+    assert f['testarray'].dtype == np.float32
+    assert f['testarray'].units == "Msol"
+    if dimensionality == 1:
+        assert np.allclose(f['testarray'], np.arange(len(f), dtype=np.float32))
+    else:
+        assert np.allclose(f['testarray'], np.arange(3*len(f), dtype=np.float32).reshape(len(f), 3))
+
+
+def test_change_dtype_nonexistent_array():
+    f = pynbody.new(dm=50, gas=50)
+    with pytest.raises(KeyError) as excinfo:
+        f.set_array_dtype('nonexistent_array', np.float32)
+    assert "nonexistent_array" in str(excinfo.value)


### PR DESCRIPTION
Make KDTree construction automatically change dtypes if needed (and warn appropriately)