### PR TITLE
Fix bug in get_group_array with use_index=True

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -75,6 +75,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_array
 
-__version__ = '2.0.0-beta.9'
+__version__ = '2.0.0-beta.10'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -355,7 +355,7 @@ class HaloCatalogue(snapshot.util.ContainerWithPhysicalUnitsOption,
         """Returns True if the halo catalogue contains the specified halo number."""
         return halo_number in self.number_mapper
 
-    def get_group_array(self, family=None, use_index=False):
+    def get_group_array(self, family=None, use_index=False, fill_value=-1):
         """Return an array with an integer for each particle in the simulation, indicating the halo of that particle.
 
         If there are multiple levels (i.e. subhalos), the number returned corresponds to the lowest level, i.e.
@@ -371,10 +371,14 @@ class HaloCatalogue(snapshot.util.ContainerWithPhysicalUnitsOption,
             If True, return the halo index rather than the halo number. (See the class documentation for the
             distinction between halo numbers and indices.)
 
+        fill_value : int, optional
+            The value to fill for particles not in any halo.
+
         """
         self.load_all()
         number_per_particle = self._index_lists.get_halo_number_per_particle(len(self.base),
-                                                                             None if use_index else self.number_mapper)
+                                                                             None if use_index else self.number_mapper,
+                                                                             fill_value = fill_value)
         if family is not None:
             return number_per_particle[self.base._get_family_slice(family)]
         else:

--- a/pynbody/halo/details/number_mapping.py
+++ b/pynbody/halo/details/number_mapping.py
@@ -55,7 +55,7 @@ class MonotonicHaloNumberMapper(HaloNumberMapper):
             missing_halo_numbers = halo_number[missing_halo_mask]
 
             if missing_halo_numbers.size > 0:
-                raise KeyError(f"No such halos: {missing_halo_numbers}")
+                raise KeyError(f"No such halos: {', '.join(str(i) for i in np.unique(missing_halo_numbers))}")
         else:
             if halo_index >= len(self._halo_numbers) or self._halo_numbers[halo_index] != halo_number:
                 raise KeyError(f"No such halo {halo_number}")

--- a/pynbody/halo/details/particle_indices.py
+++ b/pynbody/halo/details/particle_indices.py
@@ -44,7 +44,7 @@ class HaloParticleIndices:
         if number_mapper is not None:
             halo_numbers = number_mapper.index_to_number(ordering)
         else:
-            halo_numbers = range(len(ordering))
+            halo_numbers = ordering
 
         for halo_number, halo_index in zip(halo_numbers, ordering):
             indexing_slice = self._get_index_slice_for_halo(halo_index)

--- a/pynbody/halo/number_array.py
+++ b/pynbody/halo/number_array.py
@@ -64,16 +64,20 @@ class HaloNumberCatalogue(HaloCatalogue):
     def _no_such_halo(self, i):
         raise KeyError(f"No such halo {i}")
 
-    def get_group_array(self, family=None, use_index=False):
+    def get_group_array(self, family=None, use_index=False, fill_value=-1):
         if family is not None:
             result = self.base[family][self._array]
         else:
             result = self.base[self._array]
 
         if use_index:
-            return self.number_mapper.number_to_index(result)
-        else:
-            return result
+            result = np.copy(result)
+            ignored = result == self._ignore
+            not_ignored = ~ignored
+            result[ignored] = fill_value
+            result[not_ignored] = self.number_mapper.number_to_index(result[not_ignored])
+
+        return result
 
 
     @classmethod

--- a/pynbody/halo/subhalo_catalogue.py
+++ b/pynbody/halo/subhalo_catalogue.py
@@ -26,7 +26,7 @@ class SubhaloCatalogue(HaloCatalogue):
     def load_all(self):
         self._full_halo_catalogue.load_all()
 
-    def get_group_array(self, family=None, use_index=False):
+    def get_group_array(self, family=None, use_index=False, fill_value=-1):
         raise RuntimeError("It is not possible to retrieve the group array of a subhalo catalogue")
 
     def physical_units(self, distance='kpc', velocity='km s^-1', mass='Msol', persistent=True, convert_parent=False):

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -50,6 +50,19 @@ def test_nonmonotonic_transfer_matrix():
 
     assert (xfer==[[4,1],[0,5]]).all()
 
+def test_missing_values_transfer_matrix():
+    """Test making a transfer matrix where some particles are in no halo at all"""
+    f1 = pynbody.new(dm=10)
+    f2 = pynbody.new(dm=10)
+
+    f1['grp'] = np.array([-1,0,-1,0,0,0,1,1,1,1],dtype=np.int32)
+    f2['grp'] = np.array([0,-1,-1,0,0,1,1,1,1,1],dtype=np.int32)
+    b = pynbody.bridge.OneToOneBridge(f1,f2)
+
+    h1 = pynbody.halo.number_array.HaloNumberCatalogue(f1, ignore=-1)
+    h2 = pynbody.halo.number_array.HaloNumberCatalogue(f2, ignore=-1)
+
+    b.count_particles_in_common(h1, h2)
 
 def test_nonmonotonic_incomplete_bridge():
     # Test the non-monotonic bridge where not all the particles are shared

--- a/tests/subfind_test.py
+++ b/tests/subfind_test.py
@@ -128,3 +128,15 @@ def test_halo_particles(halos):
           264776, 558562, 362319, 591560, 706259, 348265, 249821, 231233,
           474710, 231023, 380767, 413674, 589153, 459711, 576598, 671059,
           523615])
+
+@pytest.mark.parametrize('use_index', [True, False])
+def test_halo_array(halos, use_index):
+    """Tests for a bug where the halo array was not set correctly with use_index=True"""
+    grp_array = halos.get_group_array(use_index=use_index)
+    halos.base['grp_array'] = grp_array
+    for h in halos[:100]:
+        if use_index:
+            halo_num_or_index = halos.number_mapper.number_to_index(h.properties['halo_number'])
+        else:
+            halo_num_or_index = h.properties['halo_number']
+        assert np.all(h['grp_array'] == halo_num_or_index)


### PR DESCRIPTION
There was a bug with the logic in `get_group_array` when used with `use_index=True`

This led to wrong results in some circumstances from bridge halo-matching

While fixing this, make the fact that there is a fill value in `get_group_array` explicit