### PR TITLE
Fix a couple of issues with unusual AHF catalogues

### DIFF
--- a/pynbody/halo/__init__.py
+++ b/pynbody/halo/__init__.py
@@ -77,7 +77,11 @@ from numpy.typing import NDArray
 from .. import array, snapshot, units, util
 from ..util import iter_subclasses
 from .details.iord_mapping import make_iord_to_offset_mapper
-from .details.number_mapping import MonotonicHaloNumberMapper, create_halo_number_mapper
+from .details.number_mapping import (
+    HaloNumberMapper,
+    MonotonicHaloNumberMapper,
+    create_halo_number_mapper,
+)
 from .details.particle_indices import HaloParticleIndices
 
 if TYPE_CHECKING:

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -230,7 +230,7 @@ class AHFCatalogue(HaloCatalogue):
                     nhalo = int(f.readline().strip())
                     assert nhalo == len(self.number_mapper)
                     for hnum in range(nhalo):
-                        npart = int(f.readline().strip())
+                        npart = int(f.readline().split()[0].strip())
                         assert npart == self._halo_properties['npart'][hnum]
                         self._fpos[hnum] = f.tell()
                         for i in range(npart):

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -122,7 +122,7 @@ class AHFCatalogue(HaloCatalogue):
 
         try:
             self._load_ahf_substructure(self._ahfBasename + 'substructure')
-        except (KeyError, ValueError, FileNotFoundError):
+        except (KeyError, ValueError, FileNotFoundError, IndexError):
             if not ignore_missing_substructure:
                 raise
             logger.error("Unable to load AHF substructure file; continuing without. To expose the underlying problem as an exception, pass ignore_missing_substructure=False to the AHFCatalogue constructor")

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -187,11 +187,12 @@ class AHFCatalogue(HaloCatalogue):
             # by saying the mask is wherever host_halo is not a valid halo number. Rather than compare every entry
             # to all the halo numbers (which would be expensive), we look for the minimum valid
 
-            mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
+            if len(host_halo) > 0:
+                mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
 
-            host_halo[mask] = self.number_mapper.index_to_number(
-                self._ahf_own_number_mapper.number_to_index(host_halo[mask])
-            )
+                host_halo[mask] = self.number_mapper.index_to_number(
+                    self._ahf_own_number_mapper.number_to_index(host_halo[mask])
+                )
 
     def _determine_format_revision_from_filename(self):
         if self._ahfBasename.split("z")[-2][-1] == ".":

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -140,7 +140,7 @@ class AHFCatalogue(HaloCatalogue):
 
     def _setup_halo_numbering(self, halo_numbers):
         has_id = 'ID' in self._halo_properties
-        if has_id:
+        if has_id and len(self._halo_properties['ID'])>0:
             self._ahf_own_number_mapper = create_halo_number_mapper(self._halo_properties['ID'])
         else:
             # if no explicit IDs, ahf implicitly numbers starting at 0 in file order

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -26,7 +26,7 @@ class AHFCatalogue(HaloCatalogue):
     """
 
     def __init__(self, sim, filename=None, make_grp=None, get_all_parts=None, use_iord=None, ahf_basename=None,
-                 dosort=None, only_stat=None, write_fpos=True, halo_numbers='file-order',
+                 dosort=None, only_stat=None, write_fpos=True, halo_numbers='ahf',
                  ignore_missing_substructure=True,
                  **kwargs):
         """Initialize an AHFCatalogue.
@@ -34,16 +34,16 @@ class AHFCatalogue(HaloCatalogue):
         Parameters
         ----------
 
-        *sim*: SimSnap
+        sim: SimSnap
           the simulation snapshot to which this catalogue refers
 
-        *filename*: str | pathlib.Path
+        filename: str | pathlib.Path
           specify a path to an AHF halo catalog. Note that AHF actually outputs multiple files; you can specify the
           path to the ``AHF_halos`` or ``AHF_particles`` file and the code will infer the other filenames from this.
           Alternatively you can specify the path up to the ``AHF_`` prefix and the code will similarly infer the full
           set of filenames.
 
-        *halo_numbers*: str
+        halo_numbers: str, optional
           specify how to number the halos. Options are:
 
           * 'ahf' (default): use the halo numbers written in the AHF halos file if present, or a zero-based indexing
@@ -52,30 +52,37 @@ class AHFCatalogue(HaloCatalogue):
           * 'length-order': sort by the number of particles in each halo, with the halo with most particles being halo 0
           * 'length-order-v1': as length-order, but indexing from halo 1, compatible with ``dosort=True`` in pynbody v1
 
-        *ignore_missing_substructure*: bool
+        ignore_missing_substructure : bool, optional
           If True (default), the code will not raise an exception if the substructure file is missing or corrupt. If
           False, it will raise an exception.
 
-        *use_iord*: bool
+        use_iord : bool, optional
           if True, the particle IDs in the Amiga catalogue are taken to refer to the iord array. If False,
           they are the particle offsets within the file. If None, the parameter defaults to True for GadgetSnap,
           False otherwise.
 
-        *ahf_basename*: str
+        write_fpos : bool, optional
+            If True (default), the code will attempt to write a file containing the starting positions of each halo's
+            particle information within the AHF_particles file. If False, it will not attempt to write this file. This
+            file is used to speed up loading of particle information for individual halos when :meth:`load_all` is not
+            called. If :meth`load_all` is called, there is no benefit to writing the file and better performance
+            is obtained by using ``write_fpos=False``.
+
+        ahf_basename : str, optional
           Deprecated way to specify the location of the catalogue
 
-        *make_grp*:
+        make_grp :
           Deprecated. If True a 'grp' array is created in the underlying snapshot specifying the lowest level halo
           that any given particle belongs to. If it is False, no such array is created; if None, the behaviour is
           determined by the configuration system.
 
-        *get_all_parts*:
+        get_all_parts :
           Deprecated; use the :meth:`load_all` method instead.
 
-        *dosort*:
+        dosort :
           Deprecated; equivalent to ``halo_numbers='length-order'``
 
-        *only_stat*:
+        only_stat :
           Deprecated; this keyword is now ignored. To obtain halo information without loading the particles,
           use the methods :meth:`get_properties_one_halo` or :meth:`get_properties_all_halos`.
 

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -180,7 +180,7 @@ class AHFCatalogue(HaloCatalogue):
             # by saying the mask is wherever host_halo is not a valid halo number. Rather than compare every entry
             # to all the halo numbers (which would be expensive), we look for the minimum valid
 
-            mask = host_halo >= np.min(self.number_mapper.all_numbers)
+            mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
 
             host_halo[mask] = self.number_mapper.index_to_number(
                 self._ahf_own_number_mapper.number_to_index(host_halo[mask])

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -170,7 +170,18 @@ class AHFCatalogue(HaloCatalogue):
 
         if 'hostHalo' in self._halo_properties:
             host_halo = self._halo_properties['hostHalo']
-            mask = host_halo != -1
+
+            # Below, we used to use:
+            #   mask = host_halo != -1
+            # but now it seems like specific runs (presumably MPI ones, where IDs are random?) use zero to indicate
+            # 'no host'.
+            #
+            # Of course, in other runs, halo 0 might be a perfectly valid host halo, so we need to deal with this
+            # by saying the mask is wherever host_halo is not a valid halo number. Rather than compare every entry
+            # to all the halo numbers (which would be expensive), we look for the minimum valid
+
+            mask = host_halo >= np.min(self.number_mapper.all_numbers)
+
             host_halo[mask] = self.number_mapper.index_to_number(
                 self._ahf_own_number_mapper.number_to_index(host_halo[mask])
             )

--- a/tests/ahf_halos_test.py
+++ b/tests/ahf_halos_test.py
@@ -141,6 +141,17 @@ def test_detecting_ahf_catalogues_with_without_trailing_slash():
         f = pynbody.load(name)
         _halos = pynbody.halo.ahf.AHFCatalogue(f)
 
+def test_ramses_ahf_load_halo_no_fpos():
+    # test that we can load AHF halos without an fpos file
+    f = pynbody.load("testdata/ramses_new_format_cosmo_with_ahf_output_00110")
+
+    # delete the fpos file, if it exists
+    fpos_path = "testdata/ramses_new_format_cosmo_with_ahf_output_00110/ramses_new_format_cosmo_with_ahf_output_00110_fullbox.tipsy.z0.031.AHF_fpos"
+    if os.path.exists(fpos_path):
+        os.remove(fpos_path)
+
+    h = f.halos()
+    h[0] # noqa - just checking there's no error
 
 def test_ramses_ahf_family_mapping_with_new_format():
     # Test Issue 691 where family mapping of AHF catalogues with Ramses new particle formats would go wrong


### PR DESCRIPTION
Where AHF catalogues are either empty or very small (with no substructure), loading them could fail