### PR TITLE
AdaptaHOP with long ints

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ jobs:
       id: cache-testdata
       with:
         path: tests/testdata
-        key: testdata-v5
+        key: testdata-v6
     - name: Install gcc
       run: |
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -16,8 +16,9 @@ snap-class-priority: RamsesSnap, GrafICSnap, NchiladaSnap, GadgetSnap, SwiftSnap
 # and the first that is able to produce a halo catalogue is used. The order can be changed
 # here or by passing sim.halos(priority=[...]) at runtime (see documentation for SimSnap.halos).
 halo-class-priority: HaloNumberCatalogue, AmigaGrpCatalogue, VelociraptorCatalogue, SubFindHDFHaloCatalogue,
-    RockstarCatalogue, AHFCatalogue, SubfindCatalogue, NewAdaptaHOPCatalogue, AdaptaHOPCatalogue, HOPCatalogue,
-    Gadget4SubfindHDFCatalogue, ArepoSubfindHDFCatalogue, TNGSubfindHDFCatalogue
+                     RockstarCatalogue, AHFCatalogue, SubfindCatalogue,
+                     NewAdaptaHOPCatalogue, NewAdaptaHOPCatalogueFullyLongInts, AdaptaHOPCatalogue, HOPCatalogue,
+                     Gadget4SubfindHDFCatalogue, ArepoSubfindHDFCatalogue, TNGSubfindHDFCatalogue
 
 centering-scheme: ssc
 

--- a/pynbody/extern/_cython_fortran_utils.pyx
+++ b/pynbody/extern/_cython_fortran_utils.pyx
@@ -238,6 +238,42 @@ cdef class FortranFile:
 
         return data
 
+    cpdef INT64_t read_int32_or_64(self) except? -1:
+        """Reads a single int32 or int64 (based on length of record) from the
+        file and return it as an int64.
+
+        Returns
+        -------
+        data : int64
+            The value.
+        """
+
+        cdef INT32_t s1, s2
+        cdef INT32_t data32
+        cdef INT64_t data64
+
+        if self._closed:
+            raise ValueError("I/O operation on closed file.")
+
+        fread(&s1, INT32_SIZE, 1, self.cfile)
+
+        if s1 == INT32_SIZE:
+            fread(&data32, INT32_SIZE, s1 // INT32_SIZE, self.cfile)
+            data64 = <INT64_t> data32
+        elif s1 == INT64_SIZE:
+            fread(&data64, INT64_SIZE, s1 // INT64_SIZE, self.cfile)
+        else:
+            raise ValueError('Size obtained (%s) does not match with the expected '
+                             'size (%s or %s) of record' % (s1, INT32_SIZE, INT64_SIZE))
+
+        fread(&s2, INT32_SIZE, 1, self.cfile)
+
+        if s1 != s2:
+            raise IOError('Sizes do not agree in the header and footer for '
+                          'this record - check header dtype')
+
+        return data64
+
 
     def read_attrs(self, object attrs):
         """This function reads from that file according to a

--- a/pynbody/halo/adaptahop.py
+++ b/pynbody/halo/adaptahop.py
@@ -208,10 +208,6 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
             if self._read_contamination:
                 Nskip += len(self._halo_attributes_contam)
 
-            # We might need a reference to both int readers later in the loop
-            default_reader = fpu.read_int64
-            backup_reader = fpu.read_int
-
             for i in range(nhalos + nsubs):
                 self._file_offsets[i] = fpu.tell()
                 if self._longint:
@@ -220,16 +216,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
                     npart = fpu.read_int()
                 self._npart[i] = npart
                 fpu.skip(1)  # skip over fortran field with ids of parts
-
-                # AdaptaHOP might use long ints for iord only, or for every
-                # int in the code. Hide this subtlety to the user with a try catch.
-                try:
-                    ipos = fpu.tell()
-                    self._halo_numbers[i] = default_reader()
-                except ValueError:
-                    fpu.seek(ipos)
-                    self._halo_numbers[i] = backup_reader()
-                    backup_reader, default_reader = default_reader, backup_reader
+                self._halo_numbers[i] = self._read_int_without_knowing_length(fpu)
                 fpu.skip(Nskip)     # skip over attributes
 
     def _get_all_particle_indices(self):
@@ -312,15 +299,7 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
                 npart = fpu.read_int()
 
             fpu.skip(1) # iord array
-
-            # Same as above -- after PR#821, AdaptaHOP catalogues can have mixed short/long int, or full long ints.
-            try:
-                ipos = fpu.tell()
-                halo_id_read = fpu.read_int64()
-            except ValueError:
-                fpu.seek(ipos)
-                halo_id_read = fpu.read_int()
-
+            halo_id_read = self._read_int_without_knowing_length(fpu)
             assert i == halo_id_read
             if self._read_contamination:
                 attrs = self._halo_attributes + self._halo_attributes_contam
@@ -383,6 +362,19 @@ class BaseAdaptaHOPCatalogue(HaloCatalogue):
             "Most likely, this class is expecting the wrong header/data blocks "
             "compared to what is stored in the halo catalogue."
         )
+
+    @classmethod
+    def _read_int_without_knowing_length(cls, fpu: FortranFile):
+        # After PR#821, AdaptaHOP catalogues can have short in headers, but long int iords,
+        # or be using long ints fully everywhere.
+        # This is a quick heuristic to enable reading of both without failing
+        try:
+            ipos = fpu.tell()
+            int_value = fpu.read_int64()
+        except ValueError:
+            fpu.seek(ipos)
+            int_value = fpu.read_int()
+        return int_value
 
     @classmethod
     def _can_load(cls, sim, filename=None, arr_name="grp", *args, **kwa):

--- a/tests/adaptahop_test.py
+++ b/tests/adaptahop_test.py
@@ -7,7 +7,7 @@ from pynbody.halo.adaptahop import (
     AdaptaHOPCatalogue,
     BaseAdaptaHOPCatalogue,
     NewAdaptaHOPCatalogue,
-    NewAdaptaHOPCatalogueFullyLongInts
+    NewAdaptaHOPCatalogueFullyLongInts,
 )
 
 

--- a/tests/adaptahop_test.py
+++ b/tests/adaptahop_test.py
@@ -7,6 +7,7 @@ from pynbody.halo.adaptahop import (
     AdaptaHOPCatalogue,
     BaseAdaptaHOPCatalogue,
     NewAdaptaHOPCatalogue,
+    NewAdaptaHOPCatalogueFullyLongInts
 )
 
 
@@ -214,6 +215,11 @@ def test_halo_particle_ids(halos):
             "testdata/EDGE_adaptahop_output/tree_bricks047_nocontam",
             NewAdaptaHOPCatalogue,
             dict(_longint=True, _read_contamination=False),
+        ),
+        (
+            "testdata/EDGE_adaptahop_output/tree_bricks100_full_long_ints",
+            NewAdaptaHOPCatalogueFullyLongInts,
+            dict(_longint=True, _read_contamination=True),
         ),
     ),
 )


### PR DESCRIPTION
Hi Andrew,

This PR adds a new AdaptaHOP class tailored for versions ran with self-consistent long ints across the code. 

I have tried to avoid duplicating code while making the new loader as backwards compatible with previous AdaptaHOP versions that (i) have iords on short ints; and (ii) have iords on long ints, but the rest of properties and headers in short int (the default previously). 

I have confirmed that this loads the data correctly on an in-house example, and maybe @cphyc can confirm that pynbody can still load older AdaptaHOP catalogues without issues?

Let me know if anything stands out
Martin
