### PR TITLE
Fix use of swift simulations with black holes 

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -131,6 +131,7 @@ Coordinates: pos
 Velocities: vel
 FOFGroupIDs: grp
 Masses: mass
+SubgridMasses: mass
 Potentials: phi
 Softenings: eps
 ParticleIDs: iord

--- a/pynbody/snapshot/namemapper.py
+++ b/pynbody/snapshot/namemapper.py
@@ -16,16 +16,16 @@ def setup_name_maps(config_name, gadget_blocks=False, with_alternates=False):
     alternates = {}
     try:
         for a, b in config_parser.items(config_name):
-            if sys.version_info[0] == 2:
-                if gadget_blocks:
-                    a = a.upper().ljust(4)
-            else:
-                if gadget_blocks:
-                    a = a.upper().ljust(4).encode("utf-8")
-            if b in name_map:
-                alternates[name_map[b]] = b
+            if gadget_blocks:
+                a = a.upper().ljust(4).encode("utf-8")
+
+            b_alternates = alternates.get(b, [])
+            b_alternates.append(a)
+            alternates[b] = b_alternates
+
             rev_name_map[a] = b
             name_map[b] = a
+
     except configparser.NoOptionError:
         pass
 
@@ -51,26 +51,68 @@ def name_map_function(name_map, rev_name_map):
 class AdaptiveNameMapper:
     """A class to map between the names of arrays in different simulation codes.
 
-    This class is designed to be used in a context where the names of arrays in a simulation code may not be fully
-    known in advance. For example, we might be unsure whether pynbody's ``pos`` array corresponds to the ``Coordinates``
-    array or the ``Position`` array in a given simulation snapshot. This class allows us possible different mappings
-    to be given in the configuration, and then once one of the mappings is used, it is locked in for the duration of
-    the object's lifetime.
+    This class is designed to be used in a context where the names of arrays in a simulation code (a 'format name') may
+    not be fully known in advance. For example, we might be unsure whether pynbody's ``pos`` array corresponds to the
+    format name ``Coordinates`` or  ``Position`` in a given simulation snapshot. This class allows us possible different
+    mappings to be given in the configuration, and then once one of the mappings is used, it is locked in for the
+    duration of the object's lifetime.
+
+    One may wish to set return_all_format_names to True to just get all possible format names for a given pynbody name.
 
     """
-    def __init__(self, config_name, gadget_blocks=False):
-        self._name_map, self._rev_name_map, self._alternates = setup_name_maps(config_name, gadget_blocks,True)
+    def __init__(self, config_name, gadget_blocks=False, return_all_format_names=False):
+        """Create a new AdaptiveNameMapper object.
 
-    def _select_alternate_target(self,name):
-        self._name_map[self._alternates[name]]=name
-        self._rev_name_map[name]=self._alternates[name]
+        Parameters
+        ----------
 
-    def _select_alternate_target_if_required(self,name):
-        if name not in list(self._name_map.values()) and name in self._alternates:
-            self._select_alternate_target(name)
+        config_name : str
+            The name of the section in the configuration file to use for the mapping.
+
+        gadget_blocks : bool
+            If True, the mapping is case-insensitive and pads the names to 4 characters, as is the convention for GADGET
+            block names.
+
+        return_all_format_names : bool
+            If True, return all the possible format-specific names for a pynbody name, rather than only the most
+            recently accessed (which is the default behaviour).
+
+        Notes
+        -----
+
+        Generally, return_all_format_names = False is the obvious choice, where we don't know in advance the name of the
+        array in the simulation snapshot, but we know there will be only one such name. However, swift uses a different
+        name for the masses of its black holes (``SubgridMasses``) than for the masses of its other particles
+        (``Masses``), so in this case we need to set ``allow_ambiguous = True``. There may be other cases where this
+        is necessary.
+        """
+        self._pynbody_to_format_map, self._format_to_pynbody_map, self._pynbody_to_all_format_map = setup_name_maps(config_name, gadget_blocks, True)
+        self._return_all_format_names = return_all_format_names
+
+    def _select_alternate_target_if_required(self, name):
+        if name not in list(self._pynbody_to_format_map.values()):
+            for k, v in self._pynbody_to_all_format_map.items():
+                if name in v:
+                    self._pynbody_to_format_map[k] = name
+
 
     def __call__(self, name, reverse=False):
+        """Map a pynbody name to a format name.
+
+        If reverse=True, the mapping is done in the reverse direction (i.e. from format name to pynbody name).
+
+        If return_all_format_names=True, when reverse=False, this function returns a list of all possible format names
+        """
+
+        result_if_no_match = name
         if reverse:
             self._select_alternate_target_if_required(name)
-        current_map = self._rev_name_map if reverse else self._name_map
-        return current_map.get(name, name)
+            current_map = self._format_to_pynbody_map
+        else:
+            if self._return_all_format_names:
+                current_map = self._pynbody_to_all_format_map
+                result_if_no_match = [name]
+            else:
+                current_map = self._pynbody_to_format_map
+
+        return current_map.get(name, result_if_no_match)


### PR DESCRIPTION
The 'mass' array is named "SubgridMasses" for BHs but just "Masses" for other particle types, in the HDF5 file.

This turns out to be quite a severe headache to deal with.