### PR TITLE
Fixed bugs in the Kennicutt-Schmidt law plotting function

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
        - mkdir $READTHEDOCS_OUTPUT/html/tutorials/plots/
        - cp -r docs/*.png $READTHEDOCS_OUTPUT/html/tutorials/plots/
        # totally unclear why the above should be necessary - in my own setup, sphinx puts everything in sensible places
-       - find $READTHEDOCS_OUTPUT/html  # for debugging 
+       - find $READTHEDOCS_OUTPUT/html  # for debugging
        - find docs/ # for debugging
 
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
        - mkdir $READTHEDOCS_OUTPUT/html/tutorials/plots/
        - cp -r docs/*.png $READTHEDOCS_OUTPUT/html/tutorials/plots/
        # totally unclear why the above should be necessary - in my own setup, sphinx puts everything in sensible places
-       - find $READTHEDOCS_OUTPUT/html  # for debugging
+       - find $READTHEDOCS_OUTPUT/html  # for debugging 
        - find docs/ # for debugging
 
 sphinx:

--- a/pynbody/plot/stars.py
+++ b/pynbody/plot/stars.py
@@ -813,8 +813,8 @@ def schmidtlaw(sim, center=True, filename=None, pretime='50 Myr',
 
 	# calculate surface densities
 	if radial:
-		ps = profile.Profile(diskstars[youngstars], nbins=bins)
-		pg = profile.Profile(diskgas, nbins=bins)
+		ps = profile.Profile(diskstars[youngstars], nbins=bins, rmin=0, rmax=units.Unit(rmax))
+		pg = profile.Profile(diskgas, nbins=bins, rmin=0, rmax=units.Unit(rmax))
 	else:
 		# make bins 2 kpc
 		nbins = rmax * 2 / binsize
@@ -829,9 +829,9 @@ def schmidtlaw(sim, center=True, filename=None, pretime='50 Myr',
 	if clear:
 		plt.clf()
 
-	plt.loglog(pg['density'].in_units('Msol pc^-2'),
-			   ps['density'].in_units('Msol kpc^-2') / pretime / 1e6, "+",
-			   **kwargs)
+    plt.loglog(pg['density'].in_units('Msol pc^-2'),
+               (ps['density']/pretime).in_units('Msol kpc**-2 yr**-1'), "+",
+               **kwargs)
 
 	if compare:
 		xsigma = np.logspace(np.log10(pg['density'].in_units('Msol pc^-2')).min(),

--- a/pynbody/plot/stars.py
+++ b/pynbody/plot/stars.py
@@ -813,8 +813,8 @@ def schmidtlaw(sim, center=True, filename=None, pretime='50 Myr',
 
 	# calculate surface densities
 	if radial:
-		ps = profile.Profile(diskstars[youngstars], nbins=bins, rmin=0, rmax=units.Unit(rmax))
-		pg = profile.Profile(diskgas, nbins=bins, rmin=0, rmax=units.Unit(rmax))
+		ps = profile.Profile(diskstars[youngstars], nbins=bins, rmin=0, rmax=rmax)
+		pg = profile.Profile(diskgas, nbins=bins, rmin=0, rmax=rmax)
 	else:
 		# make bins 2 kpc
 		nbins = rmax * 2 / binsize
@@ -852,6 +852,7 @@ def schmidtlaw(sim, center=True, filename=None, pretime='50 Myr',
 	if (filename):
 		logger.info("Saving %s", filename)
 		plt.savefig(filename)
+	return pg['density'].in_units('Msol pc^-2'), (ps['density']/pretime).in_units('Msol kpc**-2 yr**-1')
 
 
 def oneschmidtlawpoint(sim, center=True, pretime='50 Myr',

--- a/pynbody/plot/stars.py
+++ b/pynbody/plot/stars.py
@@ -829,9 +829,9 @@ def schmidtlaw(sim, center=True, filename=None, pretime='50 Myr',
 	if clear:
 		plt.clf()
 
-    plt.loglog(pg['density'].in_units('Msol pc^-2'),
-               (ps['density']/pretime).in_units('Msol kpc**-2 yr**-1'), "+",
-               **kwargs)
+	plt.loglog(pg['density'].in_units('Msol pc^-2'),
+			   (ps['density']/pretime).in_units('Msol kpc**-2 yr**-1'), "+",
+			   **kwargs)
 
 	if compare:
 		xsigma = np.logspace(np.log10(pg['density'].in_units('Msol pc^-2')).min(),

--- a/pynbody/test_utils/make_disc.py
+++ b/pynbody/test_utils/make_disc.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+import pynbody as pyn
+
+
+# Generate a fake little slab with a gas fraction of 0.5.  Size should be power of 8.
+# The inner 10 kpc has stars that are 10 Myr old, and the outer 10 kpc has stars that are 90 Myr old.
+def make_disc(size=8**5):
+    size = int(size)
+    s = pyn.new(dm=0, g=size, s=size)
+    s.properties['time'] = pyn.units.Unit('100 Myr')
+    prange = np.linspace(-1,1,int(np.round(size**(1/3))))
+    s.s['mass'] = np.ones(size)
+    s.g['mass'] = np.ones(size)
+    s.g['x'], s.g['y'], s.g['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
+    s.s['x'], s.s['y'], s.s['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
+    s['pos'].units = 'kpc'
+    s['mass'].units = 'Msol'
+
+    # Set stellar ages
+    s.s['tform'] = 90*np.ones(size)
+    s.s['tform'][s.s['r'] > 0.5 ] /= 9
+    s.s['tform'].units = 'Myr'
+
+    # Scale disk
+    s['x'] *= 20
+    s['y'] *= 20
+    s['z'] *= 3
+
+    return s

--- a/tests/schmidtlaw_test.py
+++ b/tests/schmidtlaw_test.py
@@ -27,7 +27,7 @@ def make_disc(size=8**5):
     s.s['tform'] = 90*np.ones(size)
     s.s['tform'][s.s['r'] > 0.5 ] /= 9
     s.s['tform'].units = 'Myr'
-    
+
     # Scale disk
     s['x'] *= 20
     s['y'] *= 20

--- a/tests/schmidtlaw_test.py
+++ b/tests/schmidtlaw_test.py
@@ -1,39 +1,11 @@
-import copy
-import gc
-
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 import pynbody
 from pynbody.plot.stars import schmidtlaw
+from pynbody.test_utils.make_disc import make_disc
 
-
-# Generate a fake little slab with a gas fraction of 0.5.  Size should be power of 8.
-# The inner 10 kpc has stars that are 10 Myr old, and the outer 10 kpc has stars that are 90 Myr old.
-def make_disc(size=8**5):
-    size = int(size)
-    s = pynbody.new(dm=0, g=size, s=size)
-    s.properties['time'] = pynbody.units.Unit('100 Myr')
-    prange = np.linspace(-1,1,int(np.round(size**(1/3))))
-    s.s['mass'] = np.ones(size)
-    s.g['mass'] = np.ones(size)
-    s.g['x'], s.g['y'], s.g['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
-    s.s['x'], s.s['y'], s.s['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
-    s['pos'].units = 'kpc'
-    s['mass'].units = 'Msol'
-
-    # Set stellar ages
-    s.s['tform'] = 90*np.ones(size)
-    s.s['tform'][s.s['r'] > 0.5 ] /= 9
-    s.s['tform'].units = 'Myr'
-
-    # Scale disk
-    s['x'] *= 20
-    s['y'] *= 20
-    s['z'] *= 3
-
-    return s
 
 # These should give identical surface densities if we count all stars.
 def test_full_disc():

--- a/tests/schmidtlaw_test.py
+++ b/tests/schmidtlaw_test.py
@@ -1,0 +1,49 @@
+import copy
+import gc
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pynbody
+from pynbody.plot.stars import schmidtlaw
+
+
+# Generate a fake little slab with a gas fraction of 0.5.  Size should be power of 8.
+# The inner 10 kpc has stars that are 10 Myr old, and the outer 10 kpc has stars that are 90 Myr old.
+def make_disc(size=8**5):
+    size = int(size)
+    s = pynbody.new(dm=0, g=size, s=size)
+    s.properties['time'] = pynbody.units.Unit('100 Myr')
+    prange = np.linspace(-1,1,int(np.round(size**(1/3))))
+    s.s['mass'] = np.ones(size)
+    s.g['mass'] = np.ones(size)
+    s.g['x'], s.g['y'], s.g['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
+    s.s['x'], s.s['y'], s.s['z'] = map(np.ravel, np.meshgrid(prange,prange,0.1*prange)) # 1x1x0.1 slab
+    s['pos'].units = 'kpc'
+    s['mass'].units = 'Msol'
+
+    # Set stellar ages
+    s.s['tform'] = 90*np.ones(size)
+    s.s['tform'][s.s['r'] > 0.5 ] /= 9
+    s.s['tform'].units = 'Myr'
+    
+    # Scale disk
+    s['x'] *= 20
+    s['y'] *= 20
+    s['z'] *= 3
+
+    return s
+
+# These should give identical surface densities if we count all stars.
+def test_full_disc():
+    s = make_disc()
+    pg, ps = schmidtlaw(s, pretime='100 Myr')
+    npt.assert_allclose(pg.in_units('Msol pc^-2'), (ps*pynbody.units.Unit('100 Myr')).in_units('Msol pc^-2'))
+
+# These should give identical surface densities in the inner 10 kpc, and 0 for the stars in the outer 10 kpc
+def test_truncated_disc():
+    s = make_disc()
+    pg, ps = schmidtlaw(s, pretime='50 Myr')
+    npt.assert_allclose(pg.in_units('Msol pc^-2')[:4], (ps*pynbody.units.Unit('50 Myr')).in_units('Msol pc^-2')[:4])
+    npt.assert_allclose(0*pg.in_units('Msol pc^-2')[5:], (ps*pynbody.units.Unit('50 Myr')).in_units('Msol pc^-2')[5:])


### PR DESCRIPTION
The plot.stars.schmidtlaw function has two bugs.  

The first is in the radial binning.  Because rmax and rmin are not explicitly passed to profile.Profile, if the young stars do not cover the same radial range as the gas particles, two profiles with very different bin positions will be created, and the gas surface density will not be calculated at the same radial position as the star formation rate surface density.

The second bug is in the calculation of the star formation rate surface density: it is presumed that the units for pretime will be in Myr, and then this value is divided by 1e6, rather than using the robust unit-conversion framework already in pynbody.  I have switched to using this rather than hand-coding unit conversions.