### PR TITLE
Phase diagram plot that handles gasoline and ChaNGa superbubble outputs automatically

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
        - mkdir $READTHEDOCS_OUTPUT/html/tutorials/plots/
        - cp -r docs/*.png $READTHEDOCS_OUTPUT/html/tutorials/plots/
        # totally unclear why the above should be necessary - in my own setup, sphinx puts everything in sensible places
-       - find $READTHEDOCS_OUTPUT/html  # for debugging 
+       - find $READTHEDOCS_OUTPUT/html  # for debugging
        - find docs/ # for debugging
 
 sphinx:

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -196,6 +196,10 @@ rad_0_flux: cm^-2 s^-1
 # point.
 binary-int-arrays: iord, igasorder, grp
 
+[tipsy-name-mapping]
+tempEff: Tinc
+massHot: MassHot
+
 [gadget-type-mapping]
 # For non-HDF (i.e. old-style) gadget files, specifies the mapping from the gadget particle
 # type (0->5) to pynbody families
@@ -220,6 +224,8 @@ smoothlength: smooth2
 temperature: temp
 GasDensity: rho
 timeform: tform
+tempEff: Tinc
+massHot: MassHot
 
 [ramses-name-mapping]
 # For RAMSES format post November 2017: map the names in the part_file_descriptor.txt to pynbody names

--- a/pynbody/plot/gas.py
+++ b/pynbody/plot/gas.py
@@ -76,7 +76,7 @@ def rho_T(sim, rho_units=None, rho_range=None, t_range=None, two_phase='split', 
     if ('tempEff' in sim.loadable_keys() and 'massHot' in sim.loadable_keys() and
         'uHot' in sim.loadable_keys()):
         changa_two_phase = True
-        temp_key = 'temp_eff'
+        temp_key = 'tempEff'
         mass_hot_key = 'massHot'
 
     if (gasoline_two_phase or changa_two_phase) and two_phase == 'merge':
@@ -85,10 +85,10 @@ def rho_T(sim, rho_units=None, rho_range=None, t_range=None, two_phase='split', 
                       ylabel=ylabel, **kwargs)
 
     if (gasoline_two_phase or changa_two_phase) and two_phase == 'split':
-        E = sim.g['uHot']*sim.g['MassHot']+sim.g['u']*(sim.g['mass']-sim.g[mass_hot_key])
-        rho = np.concatenate((sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u']),
-            sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot'])))
-        temp = np.concatenate((sim.g['temp'], sim.g['temp']/sim.g['u']*sim.g['uHot']))
+        E = sim.g['uHot']*sim.g[mass_hot_key]+sim.g['u']*(sim.g['mass']-sim.g[mass_hot_key])
+        rho = np.concatenate(((sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u'])).flat,
+            (sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot'])).flat))
+        temp = np.concatenate((sim.g['temp'].flat, (sim.g['temp']/sim.g['u']*sim.g['uHot']).flat))
         temp = temp[np.where(np.isfinite(rho))]
         rho = rho[np.where(np.isfinite(rho))]
         return hist2d(rho, temp, xlogrange=True,ylogrange=True,xlabel=xlabel,

--- a/pynbody/plot/gas.py
+++ b/pynbody/plot/gas.py
@@ -86,9 +86,9 @@ def rho_T(sim, rho_units=None, rho_range=None, t_range=None, two_phase='split', 
 
     if (gasoline_two_phase or changa_two_phase) and two_phase == 'split':
         E = sim.g['uHot']*sim.g[mass_hot_key]+sim.g['u']*(sim.g['mass']-sim.g[mass_hot_key])
-        rho = np.concatenate(((sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u'])).flat,
-            (sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot'])).flat))
-        temp = np.concatenate((sim.g['temp'].flat, (sim.g['temp']/sim.g['u']*sim.g['uHot']).flat))
+        rho = np.concatenate((np.array(sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u'])),
+            np.array(sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot']))))
+        temp = np.concatenate((np.array(sim.g['temp']), np.array(sim.g['temp']/sim.g['u']*sim.g['uHot'])))
         temp = temp[np.where(np.isfinite(rho))]
         rho = rho[np.where(np.isfinite(rho))]
         return hist2d(rho, temp, xlogrange=True,ylogrange=True,xlabel=xlabel,

--- a/pynbody/plot/gas.py
+++ b/pynbody/plot/gas.py
@@ -64,13 +64,28 @@ def rho_T(sim, rho_units=None, rho_range=None, t_range=None, two_phase='split', 
     else:
         ylabel = r'log$_{10}$(T/$' + sim.gas['temp'].units.latex() + '$)'
 
-    if 'Tinc' in sim.loadable_keys() and two_phase == 'merge':
-        return hist2d(sim.gas['rho'].in_units(rho_units),sim.gas['Tinc'],
+    gasoline_two_phase = False
+    changa_two_phase = False
+
+    if ('Tinc' in sim.loadable_keys() and 'MassHot' in sim.loadable_keys() and
+        'uHot' in sim.loadable_keys()):
+        gasoline_two_phase = True
+        temp_key = 'Tinc'
+        mass_hot_key = 'MassHot'
+
+    if ('tempEff' in sim.loadable_keys() and 'massHot' in sim.loadable_keys() and
+        'uHot' in sim.loadable_keys()):
+        changa_two_phase = True
+        temp_key = 'temp_eff'
+        mass_hot_key = 'massHot'
+
+    if (gasoline_two_phase or changa_two_phase) and two_phase == 'merge':
+        return hist2d(sim.gas['rho'].in_units(rho_units),sim.gas[temp_key],
                       xlogrange=True,ylogrange=True,xlabel=xlabel,
                       ylabel=ylabel, **kwargs)
 
-    if 'uHot' in sim.loadable_keys() and 'MassHot' in sim.loadable_keys() and two_phase == 'split':
-        E = sim.g['uHot']*sim.g['MassHot']+sim.g['u']*(sim.g['mass']-sim.g['MassHot'])
+    if (gasoline_two_phase or changa_two_phase) and two_phase == 'split':
+        E = sim.g['uHot']*sim.g['MassHot']+sim.g['u']*(sim.g['mass']-sim.g[mass_hot_key])
         rho = np.concatenate((sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u']),
             sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot'])))
         temp = np.concatenate((sim.g['temp'], sim.g['temp']/sim.g['u']*sim.g['uHot']))

--- a/pynbody/plot/gas.py
+++ b/pynbody/plot/gas.py
@@ -64,28 +64,13 @@ def rho_T(sim, rho_units=None, rho_range=None, t_range=None, two_phase='split', 
     else:
         ylabel = r'log$_{10}$(T/$' + sim.gas['temp'].units.latex() + '$)'
 
-    gasoline_two_phase = False
-    changa_two_phase = False
-
-    if ('Tinc' in sim.loadable_keys() and 'MassHot' in sim.loadable_keys() and
-        'uHot' in sim.loadable_keys()):
-        gasoline_two_phase = True
-        temp_key = 'Tinc'
-        mass_hot_key = 'MassHot'
-
-    if ('tempEff' in sim.loadable_keys() and 'massHot' in sim.loadable_keys() and
-        'uHot' in sim.loadable_keys()):
-        changa_two_phase = True
-        temp_key = 'tempEff'
-        mass_hot_key = 'massHot'
-
-    if (gasoline_two_phase or changa_two_phase) and two_phase == 'merge':
-        return hist2d(sim.gas['rho'].in_units(rho_units),sim.gas[temp_key],
+    if 'Tinc' in sim.loadable_keys() and two_phase == 'merge':
+        return hist2d(sim.gas['rho'].in_units(rho_units),sim.gas['Tinc'],
                       xlogrange=True,ylogrange=True,xlabel=xlabel,
                       ylabel=ylabel, **kwargs)
 
-    if (gasoline_two_phase or changa_two_phase) and two_phase == 'split':
-        E = sim.g['uHot']*sim.g[mass_hot_key]+sim.g['u']*(sim.g['mass']-sim.g[mass_hot_key])
+    if 'uHot' in sim.loadable_keys() and 'MassHot' in sim.loadable_keys() and two_phase == 'split':
+        E = sim.g['uHot']*sim.g['MassHot']+sim.g['u']*(sim.g['mass']-sim.g['MassHot'])
         rho = np.concatenate((np.array(sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['u'])),
             np.array(sim.g['rho'].in_units(rho_units)*E/(sim.g['mass']*sim.g['uHot']))))
         temp = np.concatenate((np.array(sim.g['temp']), np.array(sim.g['temp']/sim.g['u']*sim.g['uHot'])))

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -29,7 +29,10 @@ import warnings
 import numpy as np
 
 from .. import array, chunk, config, config_parser, family, units, util
-from . import SimSnap, nchilada
+from . import SimSnap, namemapper, nchilada
+
+_name_map, _rev_name_map = namemapper.setup_name_maps('tipsy-name-mapping')
+_translate_array_name = namemapper.name_map_function(_name_map, _rev_name_map)
 
 logger = logging.getLogger('pynbody.snapshot.tipsy')
 
@@ -258,6 +261,10 @@ class TipsySnap(SimSnap):
             fams = self._get_loadable_array_metadata(r)[1]
             for x in fams or list(rdict.keys()):
                 rdict[x].add(r)
+                if r != _translate_array_name(r, reverse=True):
+                    rdict[x].add(_translate_array_name(r, reverse=True))
+                if r != _translate_array_name(r):
+                    rdict[x].add(_translate_array_name(r))
 
         self._loadable_keys_registry = rdict
 
@@ -811,6 +818,12 @@ class TipsySnap(SimSnap):
                 filename = self._filename[:-3] + "." + array_name
             else:
                 filename = self._filename + "." + array_name
+            reverse = (_translate_array_name(array_name) == array_name)
+            if not os.path.isfile(filename):
+                if self._filename[-3:] == '.gz':
+                    filename = self._filename[:-3] + "." + _translate_array_name(array_name, reverse=reverse)
+                else:
+                    filename = self._filename + "." + _translate_array_name(array_name, reverse=reverse)
 
 
         logger.info("Attempting to load auxiliary array %s", filename)


### PR DESCRIPTION
I stupidly changed the names of some of the variables output when superbubble is enabled in ChaNGa relative to their original implementation in gasoline.  The code I wrote in `pynbody.plot.gas.rho_T` to handle this was written forgetting this, so I've fixed that now.  The two relevant auxiliary files are:

- `MassHot` in gasoline is `massHot` in ChaNGa
- `Tinc` in gasoline is `tempEff` in ChaNGa.
