### PR TITLE
Clean up theoretical_profiles.py and docs

### DIFF
--- a/pynbody/analysis/theoretical_profiles.py
+++ b/pynbody/analysis/theoretical_profiles.py
@@ -107,8 +107,9 @@ class AbstractBaseProfile(abc.ABC):
         if use_analytical_jac:
             def jacobian_wrapper(radius, *args):
                 return cls(*args).jacobian(radius)
-            use_analytical_jac = jacobian_wrapper
-
+            jac = jacobian_wrapper
+        else:
+            jac = '3-point'
 
         lower_bounds, upper_bounds = cls.parameter_bounds(radial_data, profile_data)
 
@@ -127,7 +128,7 @@ class AbstractBaseProfile(abc.ABC):
                                            p0=guess,
                                            bounds=(lower_bounds, upper_bounds),
                                            check_finite=True,
-                                           jac=use_analytical_jac,
+                                           jac=jac,
                                            method='trf',
                                            ftol=1e-10,
                                            xtol=1e-10,
@@ -167,7 +168,7 @@ class AbstractBaseProfile(abc.ABC):
 class NFWprofile(AbstractBaseProfile):
     """Represents a Navarro-Frenk-White (NFW) profile."""
 
-    def __init__(self, scale_radius=None, density_scale_radius=None,
+    def __init__(self, density_scale_radius=None, scale_radius=None,
                  halo_radius=None, concentration=None, halo_mass=None):
         """Represents a Navarro-Frenk-White (NFW) profile.
 

--- a/tests/theoretical_profile_test.py
+++ b/tests/theoretical_profile_test.py
@@ -22,7 +22,7 @@ def setup_module():
 
 
 def test_assignement_nfw():
-    """ There are two ways to initialise an NFW profile. Make sure they are equivalent."""
+    """There are several ways to initialise an NFW profile. Make sure they are equivalent."""
 
     for NFW in [NFW1, NFW2, NFW3]:
         assert(NFW['scale_radius'] == rs)

--- a/tests/theoretical_profile_test.py
+++ b/tests/theoretical_profile_test.py
@@ -25,20 +25,19 @@ def test_assignement_nfw():
     assert(NFW1['scale_radius'] == rs)
     assert(NFW1['density_scale_radius'] == rhos)
     assert(NFW1['concentration'] == c)
-    assert(NFW1.get_enclosed_mass(halo_boundary) == mass)
+    assert(NFW1.enclosed_mass(halo_boundary) == mass)
 
     assert(NFW2['scale_radius'] == rs)
     assert(NFW2['density_scale_radius'] == rhos)
     assert(NFW2['concentration'] == c)
-    assert(NFW2.get_enclosed_mass(halo_boundary) == mass)
+    assert(NFW2.enclosed_mass(halo_boundary) == mass)
 
 
-def test_functionals_nfw():
+def test_nfw_rho():
 
     r = SimArray(np.linspace(10, 500, 100), units="kpc")
 
-    rho_from_static = NFW1.profile_functional_static(r, rhos, rs)
-    rho_from_instance = NFW1.profile_functional(r)
+    rho_from_instance = NFW1(r)
 
     truth = SimArray([  2.50000000e+07,   1.07460773e+07,   5.62154816e+06,
             3.31384573e+06,   2.11880566e+06,   1.43727440e+06,
@@ -76,13 +75,12 @@ def test_functionals_nfw():
             7.68935025e+02], 'Msol kpc**-3')
 
     npt.assert_allclose(rho_from_instance, truth, rtol=1e-5)
-    npt.assert_allclose(rho_from_instance, rho_from_static, rtol=1e-5)
 
 
 def test_fit_nfw():
     r = SimArray(np.linspace(1, 500, 100), units="kpc")
 
-    truth = NFW1.profile_functional_static(r, rhos, rs)
+    truth = NFW1(r)
     noise = np.sqrt(truth) * np.random.normal(0, 1, truth.shape)
     noise.units = "Msol kpc**-3"
 
@@ -90,18 +88,24 @@ def test_fit_nfw():
 
     param, cov = pynbody.analysis.theoretical_profiles.NFWprofile.fit(radial_data=r, profile_data=easy_fit,
                                                                       profile_err=np.sqrt(truth),
-                                                                      use_analytical_jac=True)
+                                                                      use_analytical_jac=True,
+                                                                      return_profile=False)
 
     npt.assert_allclose(param, [rhos, rs], rtol=1e-3)
+
+    prof, cov = pynbody.analysis.theoretical_profiles.NFWprofile.fit(radial_data=r, profile_data=easy_fit,
+                                                                      profile_err=np.sqrt(truth),
+                                                                      use_analytical_jac=True,
+                                                                      return_profile=True)
+
+    npt.assert_allclose(prof['density_scale_radius'], rhos, rtol=1e-3)
+    npt.assert_allclose(prof['scale_radius'], rs, rtol=1e-3)
 
 
 def test_log_slope_nfw():
     r = SimArray(np.linspace(0.01, 1000, 1000), units="kpc")
-    slope_from_instance = NFW1.get_dlogrho_dlogr(r)
-    slope_from_static = NFW1.get_dlogrho_dlogr_static(r, rs)
-
-    npt.assert_allclose(slope_from_instance, slope_from_static, rtol=1e-5)
+    slope_from_instance = NFW1.logarithmic_slope(r)
 
     assert(np.isclose(slope_from_instance[0], -1.0, rtol=1e-2))
     assert(np.isclose(slope_from_instance[-1], -3.0, rtol=1e-2))
-    assert(NFW1.get_dlogrho_dlogr_static(rs, rs) == -2.0)
+    assert(NFW1.logarithmic_slope(rs) == -2.0)

--- a/tests/theoretical_profile_test.py
+++ b/tests/theoretical_profile_test.py
@@ -15,9 +15,8 @@ def setup_module():
     mass = SimArray(3271229711997.4863, units="Msol")
     c = halo_boundary/rs
 
-    NFW1 = pynbody.analysis.theoretical_profiles.NFWprofile(halo_boundary, density_scale_radius=rhos, scale_radius=rs)
-
-    NFW2 = pynbody.analysis.theoretical_profiles.NFWprofile(halo_boundary, halo_mass=mass, concentration=c)
+    NFW1 = pynbody.analysis.theoretical_profiles.NFWprofile(halo_radius=halo_boundary, density_scale_radius=rhos, scale_radius=rs)
+    NFW2 = pynbody.analysis.theoretical_profiles.NFWprofile(halo_radius=halo_boundary, halo_mass=mass, concentration=c)
 
 
 def test_assignement_nfw():


### PR DESCRIPTION
@Martin-Rey seeking your input on this, as part of the clean-up for pynbody v2 (#802).

So far I have made some cosmetic changes:

* Convert `staticmethod` to `classmethod`
* Pull up NFW-only methods to be abstract at base level
* Add docstrings

However, there remains substantial naming convention inconsistency in the interface. Some specific questions:

* The public interface also seems a bit heavy - are all methods needed to be exposed? (E.g. to take one example, is a `log_profile_functional_static` really needed?) 
* Do the class methods (formerly static methods) add anything useful?
* Is `functional` a helpful word in the method names, or could it be removed? 
* What would your thoughts be if I were to rename functions for greater consistency, e.g. `profile_slope` would be more consistent with `profile` than `get_dlogrho_dlogr`?

Thanks for any input! (And let me know if you want to do it yourself rather than have me tinker)
