### PR TITLE
Create .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,4 @@ build:
       python: "3.11"
     commands: 
       - mkdir --parents _readthedocs/html/
-      - rsync -av --exclude 'readthedocs' --exclude '.git' ./ _readthedocs/html/
+      - cp -r $(find . -maxdepth 1 -mindepth 1 | grep -v readthedocs) _readthedocs/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,4 @@ build:
       python: "3.11"
     commands: 
       - mkdir --parents _readthedocs/html/
-      - cp --recursive $(find . -maxdepth 1 | grep -v readthedocs) _readthedocs/html/
+      - rsync -av --exclude 'readthedocs' --exclude '.git' ./ _readthedocs/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+    os: ubuntu-20.04
+    tools:
+      python: "3.11"
+    commands: 
+      - mkdir --parents _readthedocs/html/
+      - cp --recursive * _readthedocs/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,4 @@ build:
       python: "3.11"
     commands: 
       - mkdir --parents _readthedocs/html/
-      - cp --recursive * _readthedocs/html/
+      - cp --recursive $(find . -maxdepth 1 | grep -v readthedocs) _readthedocs/html/


### PR DESCRIPTION
Attempt to get readthedocs to archive a version of the v1 documentation, so that we can remove the old github pages site entirely