### PR TITLE
AHF MPI compatibility fix

### DIFF
--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -236,7 +236,7 @@ class AHFCatalogue(HaloCatalogue):
                 hnum = 0
                 self._fpos = np.empty(len(self.number_mapper), dtype=int)
                 with util.open_(self._ahfBasename + 'particles') as f:
-                    while hnum<h._num_halos:
+                    while hnum<self._num_halos:
                         nhalo = int(f.readline().split()) #the first line, or one after a block is another number of halos (MPI AHF)
                         assert len(nhalo)==1
                         assert int(nhalo[0])+hnum<=self._num_halos

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -334,14 +334,21 @@ class AHFCatalogue(HaloCatalogue):
         return ids
 
     def _get_all_particle_indices(self):
+        fpos = self._get_file_positions()
         boundaries = np.cumsum(np.concatenate(([0], self._halo_properties['npart'])))
         boundaries = np.vstack((boundaries[:-1], boundaries[1:])).T
         particle_ids = np.empty(boundaries[-1,1], dtype=int)
         with util.open_(self._ahfBasename + 'particles') as f:
-            f.readline()
-            for nparts, (start, end) in zip(self._halo_properties['npart'], boundaries):
-                f.readline()
+            for i in range(len(self._halo_properties['npart'])):
+                nparts = self._halo_properties['npart'][i]
+                f.seek(fpos[i])
                 particle_ids[start:end] = self._load_ahf_particle_block(f, nparts=nparts)
+            #for nparts, (start, end) in zip(self._halo_properties['npart'], boundaries):
+            #    new_halo_start = f.readline().split().strip()
+            #    if new_halo_start[0] != nparts: #this means we hit another header from a concatenated MPI file
+            #        new_halo_start = f.readline().split().strip()
+            #    assert new_halo_start[0] == nparts
+            #    particle_ids[start:end] = self._load_ahf_particle_block(f, nparts=nparts)
 
 
         return HaloParticleIndices(particle_ids=particle_ids, boundaries=boundaries)

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -237,16 +237,17 @@ class AHFCatalogue(HaloCatalogue):
                 self._fpos = np.empty(len(self.number_mapper), dtype=int)
                 with util.open_(self._ahfBasename + 'particles') as f:
                     while hnum<self._num_halos:
-                        nhalo = int(f.readline().split()) #the first line, or one after a block is another number of halos (MPI AHF)
+                        nhalo = f.readline().split() #the first line, or one after a block is another number of halos (MPI AHF)
                         assert len(nhalo)==1
-                        assert int(nhalo[0])+hnum<=self._num_halos
+                        nhalo = int(nhalo[0])
+                        assert nhalo+hnum<=self._num_halos
                         for hnum_part in range(nhalo): #loop through halos in the current part
                             hnum+=1
                             assert hnum<=self._num_halos
                             firstline  = f.readline().split() #read new halo information
                             npart = int(firstline[0].strip())
                             assert npart == self._halo_properties['npart'][hnum-1]
-                            self._fpos[hnum] = f.tell()
+                            self._fpos[hnum-1] = f.tell()
                             for i in range(npart):
                                 f.readline()
                 if self._try_writing_fpos:

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -184,12 +184,13 @@ class AHFCatalogue(HaloCatalogue):
             # 'no host'.
             #
             # Of course, in other runs, halo 0 might be a perfectly valid host halo, so we need to deal with this
-            # by saying the mask is wherever host_halo is not a valid halo number. Rather than compare every entry
-            # to all the halo numbers (which would be expensive), we look for the minimum valid
+            # by saying the mask is wherever host_halo is not a valid halo number. Moreover, sometimes MPI-AHF generates
+            # parent IDs that are >0 simply don't exist. We don't quite know why, but this might be some kind of
+            # domain decomposition issue. Anyway, we need to filter out any host halo number that simply doesn't correspond
+            # to a valid halo.
 
             if len(host_halo) > 0:
-                #mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
-                mask = np.in1d(host_halo, self._ahf_own_number_mapper.all_numbers)
+                mask = np.isin(host_halo, self._ahf_own_number_mapper.all_numbers)
                 host_halo[mask] = self.number_mapper.index_to_number(
                     self._ahf_own_number_mapper.number_to_index(host_halo[mask])
                 )

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -342,6 +342,8 @@ class AHFCatalogue(HaloCatalogue):
             for i in range(len(self._halo_properties['npart'])):
                 nparts = self._halo_properties['npart'][i]
                 f.seek(fpos[i])
+                start = boundaries[i,0]
+                end = boundaries[i,1]
                 particle_ids[start:end] = self._load_ahf_particle_block(f, nparts=nparts)
             #for nparts, (start, end) in zip(self._halo_properties['npart'], boundaries):
             #    new_halo_start = f.readline().split().strip()

--- a/pynbody/halo/ahf.py
+++ b/pynbody/halo/ahf.py
@@ -188,8 +188,8 @@ class AHFCatalogue(HaloCatalogue):
             # to all the halo numbers (which would be expensive), we look for the minimum valid
 
             if len(host_halo) > 0:
-                mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
-
+                #mask = host_halo >= np.min(self._ahf_own_number_mapper.all_numbers)
+                mask = np.in1d(host_halo, self._ahf_own_number_mapper.all_numbers)
                 host_halo[mask] = self.number_mapper.index_to_number(
                     self._ahf_own_number_mapper.number_to_index(host_halo[mask])
                 )

--- a/tests/ahf_halos_test.py
+++ b/tests/ahf_halos_test.py
@@ -130,9 +130,8 @@ def test_ahf_unwritable(snap_in_unwritable_folder):
         warnings.simplefilter("error")
         _ = h[2]
 
-    # check if we use load_all there is no warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    # check that load_all still works with the warning (since it reads fpos too)
+    with pytest.warns(UserWarning, match="Unable to write AHF_fpos file;.*"):
         h = f.halos()
         h.load_all()
         _ = h[1]


### PR DESCRIPTION
changes to _get_file_positions() and _get_all_particle_indices() within pynbody's AHF reader to account for AHF file formats that have AHF_particles files that are concatenated from several separate files when using MPI. In the future the plan is to create a version of pynbody that can account for multiple AHF_particles files that will be present from an MPI output. As it stands, this version is important for reading legacy datasets from, e.g., Romulus25.