### PR TITLE
PKDGRAV3 hdf5 snapshots support

### DIFF
--- a/docs/loaders.rst
+++ b/docs/loaders.rst
@@ -7,18 +7,19 @@ Code-specific loaders
 care of loading files in different formats. Unfortunately not all of
 these have the same capabilities; see below.
 
-========= ========== ================= ========== ================= ===================================
-Filetype  Can load?  Partial loading?  Can save?  Array-level save? Notes
-========= ========== ================= ========== ================= ===================================
-Tipsy     Yes        Yes               Yes        Yes
-Gadget    Yes        No [1]_           Yes        Yes
-Swift     Yes        Yes [6]_          No         Yes
-GadgetHDF Yes        No [1]_           No         Yes                [2]_
-Ramses    Yes        No [1]_           No         No 		    [3]_, [4]_
-NChilada  Yes        Yes               No         No
-GrafIC    Yes        Yes               No         No                [5]_
+========== ========== ================= ========== ================= ===================================
+Filetype   Can load?  Partial loading?  Can save?  Array-level save? Notes
+========== ========== ================= ========== ================= ===================================
+Tipsy      Yes        Yes               Yes        Yes
+Gadget     Yes        No [1]_           Yes        Yes
+Swift      Yes        Yes [6]_          No         Yes
+GadgetHDF  Yes        No [1]_           No         Yes                [2]_
+Ramses     Yes        No [1]_           No         No 		    [3]_, [4]_
+NChilada   Yes        Yes               No         No
+GrafIC     Yes        Yes               No         No                [5]_
+PkdgravHDF Yes        No [1]_           No         Yes                [2]_
 
-========= ========== ================= ========== ================= ===================================
+========== ========== ================= ========== ================= ===================================
 
 
 
@@ -75,3 +76,5 @@ different loaders, as all types of simulations are loaded with
 .. automodule:: pynbody.snapshot.ramses
 
 .. automodule:: pynbody.snapshot.grafic
+
+.. automodule:: pynbody.snapshot.pkdgravhdf

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -9,7 +9,7 @@
 # When you call pynbody.load, it will by default try interpreting them as formats in
 # the following order. You can override this ordering either as a configuration option, or
 # by passing load(..., priority = [...]) at runtime (see documentation for pynbody.snapshot.load).
-snap-class-priority: RamsesSnap, GrafICSnap, NchiladaSnap, GadgetSnap, SwiftSnap, EagleLikeHDFSnap, ArepoHDFSnap,
+snap-class-priority: RamsesSnap, GrafICSnap, NchiladaSnap, GadgetSnap, SwiftSnap, PkdgravHDFSnap, EagleLikeHDFSnap, ArepoHDFSnap,
                      GadgetHDFSnap, SubFindHDFSnap, TipsySnap, AsciiSnap
 
 # Similarly, when you call .halos() on a SimSnap, different readers are tried in succession,
@@ -89,6 +89,25 @@ threaded-image: True
 # this provides less speed-up than it used to, so you may want to experiment with this setting.
 approximate-fast-images: True
 
+[pkdgrav3hdf-type-mapping]
+gas: PartType0
+dm: PartType1
+star: PartType4
+bh: PartType5
+
+[pkdgrav3hdf-name-mapping]
+Coordinates: pos
+Velocities: vel
+ParticleIDs: iord
+Masses: mass
+InternalEnergy: u
+Temperature: temp
+Metallicity: metals
+Density: rho
+SmoothingLength: smooth
+StellarFormationTime: tform
+BHFormationTime: tform
+Potential: phi
 
 [gadgethdf-type-mapping]
 # GadgetHDF stores six different particle types (numbered 0 to 5). This specifies how they map

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -102,5 +102,5 @@ def new(n_particles = 0, order = None, class_ = SimSnap, **families) -> SimSnap:
     return x
 
 
-from . import ascii, gadget, gadgethdf, grafic, nchilada, ramses, subsnap, swift, tipsy
+from . import ascii, gadget, gadgethdf, grafic, nchilada, ramses, subsnap, swift, tipsy, pkdgravhdf
 from .subsnap import FamilySubSnap, IndexedSubSnap, SubSnap

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -727,14 +727,17 @@ class GadgetHDFSnap(SimSnap):
                     found = False
         return found
 
+    @classmethod
+    def _guess_file_ending(cls, f):
+        return f.with_suffix(".0.hdf5")
 
     @classmethod
     def _can_load(cls, f):
         if hasattr(h5py, "is_hdf5"):
             if h5py.is_hdf5(f):
                 return cls._test_for_hdf5_key(f)
-            elif h5py.is_hdf5(f.with_suffix(".0.hdf5")):
-                return cls._test_for_hdf5_key(f.with_suffix(".0.hdf5"))
+            elif h5py.is_hdf5(cls._guess_file_ending(f)):
+                return cls._test_for_hdf5_key(cls._guess_file_ending(f))
             else:
                 return False
         else:

--- a/pynbody/snapshot/pkdgravhdf.py
+++ b/pynbody/snapshot/pkdgravhdf.py
@@ -1,0 +1,129 @@
+import configparser
+import logging
+import warnings
+
+from .. import config_parser, family, units
+from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
+
+logger = logging.getLogger('pynbody.snapshot.pkdgravhdf')
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+_pkd_default_type_map = {}
+for x in family.family_names():
+    try:
+        _pkd_default_type_map[family.get_family(x)] = \
+            [q.strip() for q in config_parser.get('pkdgrav3hdf-type-mapping', x).split(",")]
+    except configparser.NoOptionError:
+        pass
+
+_pkd_all_hdf_particle_groups = []
+for hdf_groups in _pkd_default_type_map.values():
+    for hdf_group in hdf_groups:
+        _pkd_all_hdf_particle_groups.append(hdf_group)
+
+
+class _PkdgravHdfMultiFileManager(_GadgetHdfMultiFileManager) :
+    _multifile_manager_class = _GadgetHdfMultiFileManager
+    _nfiles_groupname = "Header"
+    _nfiles_attrname = "NumFilesPerSnapshot"
+    _namemapper_config_section = "pkdgrav3hdf-name-mapping"
+
+    def get_cosmo_attrs(self):
+        return self[0].parent['Cosmology'].attrs
+
+
+class PkdgravHDFSnap(GadgetHDFSnap):
+    _multifile_manager_class = _PkdgravHdfMultiFileManager
+    _readable_hdf5_test_group = "Header"
+    _readable_hdf5_test_attr = "Header", "PKDGRAV version"
+
+    def __init__(self, filename, ):
+        super().__init__(filename)
+
+    def _get_units_from_hdf_attr(self, hdfattrs) :
+        pass
+
+    def _all_hdf_groups(self):
+        for hdf in self._hdf_files:
+            for hdf_family_name in _pkd_all_hdf_particle_groups:
+                if hdf_family_name in hdf:
+                    yield hdf[hdf_family_name]
+
+    def _init_unit_information(self):
+        try:
+            atr = self._hdf_files.get_unit_attrs()
+        except KeyError:
+            warnings.warn("No unit information found in PkdgravHDF file",
+                          RuntimeWarning)
+            return {}, {}
+
+        vel_unit = atr['KmPerSecUnit'] * 1e5 * units.cm / units.s
+        dist_unit = atr['KpcUnit'] * units.kpc.in_units("cm") * units.cm
+        mass_unit = atr['MsolUnit'] * units.Msol.in_units("g") * units.g
+        time_unit = atr['SecUnit'] * units.s
+
+        # Create a dictionary for the units, this will come in handy later
+        unitvar = {'U_V': vel_unit, 'U_L': dist_unit, 'U_M': mass_unit,
+                   'U_T': time_unit, '[K]': units.K,
+                   'SEC_PER_YEAR': units.yr, 'SOLAR_MASS': units.Msol}
+        # Last two units are to catch occasional arrays like StarFormationRate
+        # which don't follow the patter of U_ units unfortunately
+        cgsvar = {'U_M': 'g', 'SOLAR_MASS': 'g', 'U_T': 's',
+                  'SEC_PER_YEAR': 's', 'U_V': 'cm s**-1', 'U_L': 'cm', '[K]': 'K'}
+
+        self._hdf_cgsvar = cgsvar
+        self._hdf_unitvar = unitvar
+
+        cosmo = 'HubbleParam' in list(self._get_hdf_parameter_attrs().keys())
+        if cosmo:
+            dist_unit *= units.a
+            vel_unit *= units.a
+
+        self._file_units_system = [units.Unit(x) for x in [
+            vel_unit, dist_unit, mass_unit, "K"]]
+
+    def _get_hdf_cosmo_attrs(self):
+        return self._hdf_files.get_cosmo_attrs()
+
+    def _init_properties(self):
+        atr = self._get_hdf_header_attrs()
+        # Some attributes may be stored in the Cosmology header
+        cosmo_atr = self._get_hdf_cosmo_attrs()
+
+        cosmo_run = cosmo_atr['Cosmological run']
+        if cosmo_run:
+            self.properties['z'] = atr['Redshift']
+            self.properties['a'] = 1. / (1 + atr['Redshift'])
+            self.properties['eps'] = float(atr['Softening']) * self._hdf_unitvar['U_L']
+
+            # Not all omegas need to be specified in the attributes
+            try:
+                self.properties['omegaB0'] = cosmo_atr['Omega_b']
+            except KeyError:
+                pass
+
+            self.properties['omegaM0'] = cosmo_atr['Omega_m']
+            self.properties['omegaL0'] = cosmo_atr['Omega_lambda']
+            self.properties['boxsize'] = atr['BoxSize'] / \
+                cosmo_atr['HubbleParam'] * units.Mpc * units.a
+            self.properties['h'] = cosmo_atr['HubbleParam']
+        else:
+            self.properties['z'] = 0
+            self.properties['a'] = 1
+            self.properties['eps'] = 0
+
+        self.properties['time'] = atr['Time'] * self._hdf_unitvar['U_T']
+
+        for s, value in self._get_hdf_header_attrs().items():
+            if s not in ['Time', 'Omega_m', 'Omega_b', 'Omega_lambda',
+                         'BoxSize', 'HubbleParam']:
+                self.properties[s] = value
+
+        for s, value in self._get_hdf_cosmo_attrs().items():
+            if s not in ['Time', 'Omega_m', 'Omega_b', 'Omega_lambda',
+                         'BoxSize', 'HubbleParam']:
+                self.properties[s] = value

--- a/pynbody/test_utils/__init__.py
+++ b/pynbody/test_utils/__init__.py
@@ -46,6 +46,8 @@ test_data_packages = {
                 'archive_name': 'subfind.tar.gz'},
     'tng_subfind': {'verify_path': 'arepo/tng',
                     'archive_name': 'tng_subfind.tar.gz'},
+    'pkdgrav3': {'verify_path': 'pkdgrav3',
+                 'archive_name': 'pkdgrav3.tar.gz'},
 }
 
 test_data_url = "https://zenodo.org/record/15528615/files/{archive_name}?download=1"

--- a/tests/pkdgravhdf_test.py
+++ b/tests/pkdgravhdf_test.py
@@ -1,0 +1,68 @@
+import gc
+
+import numpy as np
+import pytest
+
+import pynbody
+import pynbody.test_utils
+
+# @pytest.fixture(scope='module', autouse=True)
+# def get_data():
+#     pynbody.test_utils.ensure_test_data_available("pkdgrav3")
+
+
+@pytest.fixture
+def snap():
+    f = pynbody.load('testdata/pkdgrav3/cosmoSF.00010')
+    yield f
+    del f
+    gc.collect()
+
+
+@pytest.fixture
+def multi_snap():
+    f = pynbody.load('testdata/pkdgrav3/cosmoSF.00007')
+    yield f
+    del f
+    gc.collect()
+
+
+def test_npart(multi_snap):
+    print(multi_snap.properties)
+    assert len(multi_snap._hdf_files) == multi_snap.properties['NumFilesPerSnapshot']
+
+    assert len(multi_snap.g) == multi_snap.properties['NumPart_Total'][0]
+    assert len(multi_snap.dm) == multi_snap.properties['NumPart_Total'][1]
+    assert len(multi_snap.s) == multi_snap.properties['NumPart_Total'][4]
+    assert len(multi_snap.bh) == multi_snap.properties['NumPart_Total'][5]
+
+
+def test_cosmo(snap) :
+    """ Check that the cosmological parameters are consistent """
+    assert np.allclose(snap.properties['z'], 0.0)
+    # This holds only in PKDGRAV3 default unit system!
+    assert np.allclose(snap.properties['Omega0'], snap['mass'].sum())
+    assert np.allclose(snap.properties['OmegaB'],
+                       snap.s['mass'].sum()
+                       + snap.g['mass'].sum()
+                       + snap.bh['mass'].sum()
+                       )
+
+
+def test_standard_arrays(snap) :
+    """Check that the data loading works"""
+
+    for s in [snap] :
+        s.dm['pos']
+        s.gas['pos']
+        s.star['pos']
+        s.bh['pos']
+        s['pos']
+        s['mass']
+        # Load a second time to check that family_arrays still work
+        s.dm['pos']
+        s['vel']
+        s['iord']
+        s.gas['rho']
+        s.star['mass']
+        s.bh['pos']


### PR DESCRIPTION
Hello,

This PR implements the `pkdgravhdf` loader (heavily derived from `gadgethdf`), which is able to read snapshots from the latest versions of [PKDGRAV3](https://pkdgrav3.readthedocs.io/en/latest/) (also presented [here](https://ui.adsabs.harvard.edu/link_gateway/2023MNRAS.519..300A/PUB_HTML)). The most notable difference is the unit system.

I have implemented some basic tests and modified  the documentation in the places  with references to the available loaders (maybe I missed some?).

As the test data is not at Zenodo, tests will fail. I can pass around the test data (~3 MB) in the meantime. 

Thanks!