### PR TITLE
Fix for issue with shared memory name collisions

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -69,6 +69,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_array
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -7,6 +7,7 @@ import pynbody.units as units
 SA = pynbody.array.SimArray
 import gc
 import os
+import platform
 import signal
 import sys
 import time
@@ -396,6 +397,7 @@ def _create_shared_array_with_random_name():
     """Create a shared array with a random name to avoid name collisions"""
     remote_ar = shared.make_shared_array((10,), dtype=np.int32, zeros=True)
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="Windows does not support fork")
 def test_shared_name_accidental_rng_collision():
     """Check that if the rng collides (this can happen after a fork made by multiprocessing),
     make_shared_array still succeeds"""


### PR DESCRIPTION
The issue was found in tangos, where multiprocessing forks left multiple child processes with the same RNG for the shared memory random name