### PR TITLE
Add class to enable tracking even with ramses iord int32-truncation bug

### DIFF
--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -230,3 +230,52 @@ def test_fuzzy_match_halos(snapshot_pair):
     assert fuzzy_match_rev.keys() == set(f2['grp'])
 
     assert fuzzy_match_rev[1] == [(0, 2./3), (1, 1./3)]
+
+def test_ramses_bug_bridge():
+    # this seed is chosen by experimentation such that there is a problem with the stars matching if one
+    # tries to treat them in the same way as the dark matter particles, i.e. by using their masses
+    np.random.seed(1338)
+
+    # pretend first 50 particles are from one level, next 25 from another, next 25 from yet another,
+    # in such a way that the iord crosses 2**32 during the second level
+    test_iords_dm = np.empty(100, dtype=np.int64)
+    test_iords_dm[:50] = np.random.permutation(np.arange(0, 50))
+    test_iords_dm[50:] = np.random.permutation(np.arange(0, 50)) - 5 + 2**32
+    test_iords_dm[75:] += 2**30
+
+    test_iords_star = np.random.permutation(np.arange(0, 50)) + 3**32
+
+    test_masses = np.ones(100)
+    test_masses[50:] /= 2
+    test_masses[75:] /= 2
+
+    def make_problematic_i32_truncated_snap():
+        f = pynbody.new(st=50, dm=100)
+        assert f._get_family_slice(pynbody.family.star).start == 0
+        dm_ordering = np.random.permutation(np.arange(0, 100))
+        st_ordering = np.random.permutation(np.arange(0, 50))
+        f.dm['iord_no_bug'] = test_iords_dm[dm_ordering]
+        f.star['iord_no_bug'] = test_iords_star[st_ordering]
+        f['iord'] = f['iord_no_bug'].astype(np.int32).astype(np.int64)
+        f.dm['mass'] = test_masses[dm_ordering]
+        # stellar masses may change:
+        f.st['mass'] = 2**np.random.uniform(-3, 0.0, size=50)
+        return f
+
+    f1 = make_problematic_i32_truncated_snap()
+    f2 = make_problematic_i32_truncated_snap()
+
+    index_st = np.random.choice(np.arange(50), size=20, replace=False)
+    index_dm = np.random.choice(np.arange(50, 150), size=20, replace=False)
+    index = np.concatenate((index_st, index_dm))
+
+    f_sub = f1[index]
+
+    b = pynbody.bridge.RamsesBugOrderBridge(f1, f2)
+
+    bridged_iord = b(f_sub)['iord_no_bug']
+    unbridged_iord = f_sub['iord_no_bug']
+
+    assert len(np.setdiff1d(bridged_iord, unbridged_iord)) == 0
+
+


### PR DESCRIPTION
Some versions of ramses truncate iord values to int32 when communicating. This introduces a special bridge class that uses heuristics to recreate the correct snapshot-to-snapshot mapping as far as possible.