### PR TITLE
Update KDTree to use float64 not float32 boundaries

### DIFF
--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -15,15 +15,16 @@ logger = logging.getLogger("pynbody.kdtree")
 
 # Boundary type definition must exactly match the C++ definition (see kd.h)
 Boundary = np.dtype([
-    ('fMin', np.float32, (3,)),
-    ('fMax', np.float32, (3,))
+    ('fMin', np.float64, (3,)),
+    ('fMax', np.float64, (3,))
 ])
 
 # KDNode type definition must exactly match the C++ definition (see kd.h)
 KDNode = np.dtype([
-    ('fSplit', np.float32),
+    ('fSplit', np.float64),
     ('bnd', Boundary),
     ('iDim', np.int32),
+    ('_pad', np.int32),  # padding to align with C struct
     ('pLower', np.intp),
     ('pUpper', np.intp)
 ])

--- a/pynbody/kdtree/kd.h
+++ b/pynbody/kdtree/kd.h
@@ -26,20 +26,20 @@
 #define GAS 2
 #define STAR 4
 
-typedef struct bndBound {
-  float fMin[3];
-  float fMax[3];
-} Boundary;
+struct Boundary {
+  double fMin[3];
+  double fMax[3];
+};
 
-typedef struct kdNode {
-  float fSplit;
+struct KDNode {
+  double fSplit;
   Boundary bnd;
   int iDim;
   npy_intp pLower;
   npy_intp pUpper;
-} KDNode;
+};
 
-typedef struct KDContext {
+struct KDContext {
   npy_intp nBucket;
   npy_intp nParticles;
   npy_intp nActive;
@@ -67,8 +67,8 @@ typedef struct KDContext {
 
 #define INTERSECT(c, cp, fBall2, lx, ly, lz, x, y, z, sx, sy, sz)              \
   {                                                                            \
-    float INTRSCT_dx, INTRSCT_dy, INTRSCT_dz;                                  \
-    float INTRSCT_dx1, INTRSCT_dy1, INTRSCT_dz1, INTRSCT_fDist2;               \
+    double INTRSCT_dx, INTRSCT_dy, INTRSCT_dz;                                 \
+    double INTRSCT_dx1, INTRSCT_dy1, INTRSCT_dz1, INTRSCT_fDist2;              \
     INTRSCT_dx = c[cp].bnd.fMin[0] - x;                                        \
     INTRSCT_dx1 = x - c[cp].bnd.fMax[0];                                       \
     INTRSCT_dy = c[cp].bnd.fMin[1] - y;                                        \

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -326,3 +326,19 @@ def test_boxsize_too_small():
     f.properties['boxsize'] = 0.1
     with pytest.warns(RuntimeWarning, match = "span a region larger than the specified boxsize"):
         _ = f['smooth']
+
+
+def test_kdtree_float64_rounding(npart=1000):
+    """Check boundaries are ok even if float64 is in use"""
+    f = pynbody.new(dm=npart)
+    f.properties['boxsize'] = np.nextafter(1.0, -1.0)  # just below 1.0
+
+    f['pos'] = np.random.uniform(size=(npart, 3))
+    f['mass'] = np.random.uniform(size=npart)
+
+    f['pos'][0,0] = np.nextafter(1.0, -1.0)
+    f['pos'][1,0] = 0.0
+
+    f.build_tree()
+
+    _ = f['smooth']


### PR DESCRIPTION
Otherwise one can hit issues with float64 positions, as exemplified in the added test

Ideally one could use flexible float32 or float64 boundaries using templates, but due to the current code structure this would be a bit of a pain to implement