### PR TITLE
Fix bug in shared-memory mode loading DM-only tipsy snapshots.

### DIFF
--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -171,6 +171,7 @@ class TipsySnap(SimSnap):
             for k in "rho", "temp", "metals":
                 if k in write:
                     self.gas[k].set_default_units(quiet=True)
+
         if 'star' in self.families():
             if "metals" not in list(self.star.keys()):
                 self.star._create_array("metals", zeros=False)
@@ -201,8 +202,6 @@ class TipsySnap(SimSnap):
         tbuf = bytearray(max_item_size * 10240)
 
         for fam, dtype in ((family.gas, self._g_dtype), (family.dm, self._d_dtype), (family.star, self._s_dtype)):
-            if fam not in self.families():
-                continue
             self_fam = self[fam]
             st_len = dtype.itemsize
             for readlen, buf_index, mem_index in self._load_control.iterate([fam], [fam], multiskip=True):
@@ -217,7 +216,7 @@ class TipsySnap(SimSnap):
                 if self._byteswap:
                     buf = buf.byteswap()
 
-                if mem_index is not None:
+                if fam in self.families() and mem_index is not None:
                     # Copy into the correct arrays
                     for name in dtype.names:
                         if name in write:

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -151,38 +151,44 @@ class TipsySnap(SimSnap):
                 self._create_array(w, ndim, zeros=False)
                 write.append(w)
 
-        for w in "rho", "temp":
-            if w not in list(self.gas.keys()):
-                self.gas._create_array(w, zeros=False)
-                write.append(w)
-
-        if ("metals" not in list(self.gas.keys())) and ("metals" not in list(self.star.keys())):
-            self.gas._create_array("metals", zeros=False)
-            self.star._create_array("metals", zeros=False)
-            write.append("metals")
-
-        if "tform" not in list(self.star.keys()):
-            self.star._create_array("tform", zeros=False)
-            write.append("tform")
-
-        if "temp" in write:
-            self.gas["temp"].units = "K"
-
         for k in "pos", "vel", "mass", "eps", "phi":
             if k in write:
                 self[k].set_default_units(quiet=True)
+
+        if 'gas' in self.families():
+            for w in "rho", "temp":
+                if w not in list(self.gas.keys()):
+                    self.gas._create_array(w, zeros=False)
+                    write.append(w)
+
+            if "metals" not in list(self.gas.keys()):
+                self.gas._create_array("metals", zeros=False)
+                write.append("metals")
+
+            if "temp" in write:
+                self.gas["temp"].units = "K"
+
+            for k in "rho", "temp", "metals":
+                if k in write:
+                    self.gas[k].set_default_units(quiet=True)
+        if 'star' in self.families():
+            if "metals" not in list(self.star.keys()):
+                self.star._create_array("metals", zeros=False)
+                if "metals" not in write:
+                    write.append("metals")
+
+            if "tform" not in list(self.star.keys()):
+                self.star._create_array("tform", zeros=False)
+                write.append("tform")
+
+            for k in "metals", "tform":
+                if k in write:
+                    self.star[k].set_default_units(quiet=True)
 
         # only do this for cosmo runs
         if "phi" in write and 'h' in self.properties:
             self['phi'].units = self['phi'].units * units.a ** -3  # messy :-(
 
-        for k in "rho", "temp", "metals":
-            if k in write:
-                self.gas[k].set_default_units(quiet=True)
-
-        for k in "metals", "tform":
-            if k in write:
-                self.star[k].set_default_units(quiet=True)
 
         if "pos" in write:
             write += ['x', 'y', 'z']
@@ -195,6 +201,8 @@ class TipsySnap(SimSnap):
         tbuf = bytearray(max_item_size * 10240)
 
         for fam, dtype in ((family.gas, self._g_dtype), (family.dm, self._d_dtype), (family.star, self._s_dtype)):
+            if fam not in self.families():
+                continue
             self_fam = self[fam]
             st_len = dtype.itemsize
             for readlen, buf_index, mem_index in self._load_control.iterate([fam], [fam], multiskip=True):

--- a/tests/tipsy_test.py
+++ b/tests/tipsy_test.py
@@ -429,3 +429,18 @@ def test_load_without_paramfile(no_paramfile_snap):
         f = pynbody.load(no_paramfile_snap)
         assert isinstance(f, pynbody.snapshot.tipsy.TipsySnap)
         assert len(f) == 1717156
+
+@pytest.fixture
+def gen_DM_snap():
+    f = pynbody.new(dm=100)
+    f.properties['a'] = 0
+    f.properties['time'] = 0
+    f.write(fmt=pynbody.snapshot.tipsy.TipsySnap, filename="testdata/dm_only.tipsy")
+    yield "testdata/dm_only.tipsy"
+    os.unlink("testdata/dm_only.tipsy")
+
+@pytest.mark.filterwarnings("ignore:No readable param file.*:RuntimeWarning")
+def test_shared_memory_DM(gen_DM_snap):
+    f2 = pynbody.load(gen_DM_snap)
+    f2.enable_shared_arrays()
+    f2._load_main_file() # This will fail as per issue #983

--- a/tests/tipsy_test.py
+++ b/tests/tipsy_test.py
@@ -431,16 +431,18 @@ def test_load_without_paramfile(no_paramfile_snap):
         assert len(f) == 1717156
 
 @pytest.fixture
-def gen_DM_snap():
+def DMO_snap():
     f = pynbody.new(dm=100)
     f.properties['a'] = 0
     f.properties['time'] = 0
     f.write(fmt=pynbody.snapshot.tipsy.TipsySnap, filename="testdata/dm_only.tipsy")
-    yield "testdata/dm_only.tipsy"
-    os.unlink("testdata/dm_only.tipsy")
+    del f
+    yield pynbody.load("testdata/dm_only.tipsy")
+    for fname in glob.glob("testdata/dm_only.tipsy*"):
+        os.unlink(fname)
 
 @pytest.mark.filterwarnings("ignore:No readable param file.*:RuntimeWarning")
-def test_shared_memory_DM(gen_DM_snap):
-    f2 = pynbody.load(gen_DM_snap)
-    f2.enable_shared_arrays()
-    f2._load_main_file() # This will fail as per issue #983
+@pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")
+def test_shared_memory_DM(DMO_snap):
+    DMO_snap.enable_shared_arrays()
+    DMO_snap._load_main_file() # This will fail as per issue #983


### PR DESCRIPTION
This PR prevents `_load_main_file` method of `TipsySnap` from creating arrays for gas or star particles if those families do not exist.  Prior to this, if pynbody is used to load a DM-only snapshot for tangos to write a property using `--load-mode=server-shared-mem`, the calculation will fail for the first halo calculation, and potentially silently write incorrect information for subsequent halos.

This fixes #983.  