### PR TITLE
Filter out deprecation warnings from healpy

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,12 +17,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2025]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-        numpy-version: ["2.0.2", "2.3.3"]
+        numpy-version: ["2.1.0", "2.5.0"]
         exclude:
           - python-version: "3.14"
-            numpy-version: "2.0.2"
-          - python-version: "3.13"
-            numpy-version: "2.0.2"
+            numpy-version: "2.1.0"
+          - python-version: "3.11"
+            numpy-version: "2.5.0"
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,13 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2025]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         numpy-version: ["2.1.0", "2.5.0"]
         exclude:
           - python-version: "3.14"
             numpy-version: "2.1.0"
-          - python-version: "3.11"
-            numpy-version: "2.5.0"
 
     runs-on: ${{ matrix.os }}
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "h5py>=3.8.0",
     "matplotlib>=3.8.0",
     "numpy>=1.26.0",
-    "scipy>=1.12.0",
+    "scipy>=1.12.0,<1.18.0",
     "osfclient"
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,9 @@ filterwarnings = [
     # ignore deprecation warnings triggered by h5py with python 3.12
     'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning',
     # ignore integration warnings which come up
-    'ignore:The occurrence of roundoff error:UserWarning'
+    'ignore:The occurrence of roundoff error:UserWarning',
+    # ignore healpy's use of deprecated matplotlib functions
+    'ignore:The set_(under|over|bad) function will be deprecated.*:PendingDeprecationWarning',
   ]
 
 [tool.isort]


### PR DESCRIPTION
When running tests with pytest, this filters out PendingDeprecationWarnings generated by healpy calling deprecated matplotlib functions. Addresses #994.

There's another test failure (on this branch and on master) in hmf_test.py, which I think is not related to this one.