### PR TITLE
Several fixes for downloading test data on github

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,9 +9,11 @@ defaults:
 jobs:
   fetch-testdata:
     uses: ./.github/workflows/fetch-testdata.yaml
+  fetch-tables:
+    uses: ./.github/workflows/fetch-tables.yaml
 
   build:
-    needs: fetch-testdata
+    needs: [fetch-testdata, fetch-tables]
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +55,17 @@ jobs:
         path: tests/testdata
         key: testdata-${{ needs.fetch-testdata.outputs.testdata-key }}
         enableCrossOsArchive: true
+
+    - name: Restore table data cache
+      id: cache-tables
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          pynbody/analysis/hm12.npz
+          pynbody/analysis/fg20.np2
+        key: project-z46rq-files-hm12-fg20
+        enableCrossOsArchive: true
+
     - name: Run all tests
       working-directory: tests
       run: python -m pytest --ignore=testdata/ --tb=short

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ionfrac_tables
-        key: ionfrac_tables_v1
+        key: ionfrac-${{ needs.fetch-tables.outputs.ionfrac-key }}
         enableCrossOsArchive: true
 
     - name: Copy table data to pynbody installation

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -60,11 +60,15 @@ jobs:
       id: cache-tables
       uses: actions/cache/restore@v5
       with:
-        path: |
-          pynbody/analysis/hm12.npz
-          pynbody/analysis/fg20.np2
-        key: project-z46rq-files-hm12-fg20
+        path: ionfrac_tables
+        key: ionfrac_tables_v1
         enableCrossOsArchive: true
+
+    - name: Copy table data to pynbody installation
+      working-directory: ionfrac_tables
+      run: |
+        DESTDIR=$(python -c "import pynbody ; import os ; print(os.path.dirname(pynbody.analysis.__file__))")
+        cp *.npz "${DESTDIR}"
 
     - name: Run all tests
       working-directory: tests

--- a/.github/workflows/fetch-tables.yaml
+++ b/.github/workflows/fetch-tables.yaml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 jobs:
-  fetch-testdata:
+  fetch-tables:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -21,13 +21,12 @@ jobs:
       id: cache-tables
       uses: actions/cache@v6
       with:
-        path: |
-          pynbody/analysis/hm12.npz
-          pynbody/analysis/fg20.np2
-        key: project-z46rq-files-hm12-fg20
+        path: ionfrac_tables
+        key: ionfrac_tables_v1
+        enableCrossOsArchive: true
 
     - name: Fetch table data
       if: steps.cache-tables.outputs.cache-hit != 'true'
       run: |
-        osf -p z46rq fetch hm12.npz pynbody/analysis/hm12.npz
-        osf -p z46rq fetch fg20.np2 pynbody/analysis/fg20.np2
+        osf -p z46rq fetch hm12.npz ionfrac_tables/hm12.npz
+        osf -p z46rq fetch fg20.npz ionfrac_tables/fg20.npz

--- a/.github/workflows/fetch-tables.yaml
+++ b/.github/workflows/fetch-tables.yaml
@@ -1,32 +1,37 @@
 name: fetch-tables.yaml
 on:
   workflow_call:
+    outputs:
+      ionfrac-key:
+        description: 'The cache key for the ion fraction tables'
+        value: ${{ jobs.fetch-tables.outputs.ionfrac-key }}
 
 jobs:
   fetch-tables:
     runs-on: ubuntu-latest
+    outputs:
+      ionfrac-key: ${{ steps.get-ionfrac-hash.outputs.ionfrachash }}
     steps:
     - uses: actions/checkout@v6
-
     - name: Install Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"
-
     - name: Install osfclient
       run: |
         python -m pip install osfclient
-
+    - name: Get ionfrac tables hash
+      id: get-ionfrac-hash
+      run: |
+        echo "ionfrachash=$(python pynbody/test_utils/__init__.py --hash-ionfrac)" >> $GITHUB_OUTPUT
     - name: Cache table data
       id: cache-tables
       uses: actions/cache@v6
       with:
         path: ionfrac_tables
-        key: ionfrac_tables_v1
+        key: ionfrac-${{ steps.get-ionfrac-hash.outputs.ionfrachash }}
         enableCrossOsArchive: true
-
     - name: Fetch table data
       if: steps.cache-tables.outputs.cache-hit != 'true'
       run: |
-        osf -p z46rq fetch hm12.npz ionfrac_tables/hm12.npz
-        osf -p z46rq fetch fg20.npz ionfrac_tables/fg20.npz
+        python ./pynbody/test_utils/__init__.py --fetch-ionfrac

--- a/.github/workflows/fetch-tables.yaml
+++ b/.github/workflows/fetch-tables.yaml
@@ -1,0 +1,33 @@
+name: fetch-tables.yaml
+on:
+  workflow_call:
+
+jobs:
+  fetch-testdata:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+
+    - name: Install osfclient
+      run: |
+        python -m pip install osfclient
+
+    - name: Cache table data
+      id: cache-tables
+      uses: actions/cache@v6
+      with:
+        path: |
+          pynbody/analysis/hm12.npz
+          pynbody/analysis/fg20.np2
+        key: project-z46rq-files-hm12-fg20
+
+    - name: Fetch table data
+      if: steps.cache-tables.outputs.cache-hit != 'true'
+      run: |
+        osf -p z46rq fetch hm12.npz pynbody/analysis/hm12.npz
+        osf -p z46rq fetch fg20.np2 pynbody/analysis/fg20.np2

--- a/.github/workflows/fetch-testdata.yaml
+++ b/.github/workflows/fetch-testdata.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         echo "testdatahash=$(python pynbody/test_utils/__init__.py)" >> $GITHUB_OUTPUT
     - name: Restore testdata cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache@v6
       id: cache-testdata
       with:
         path: tests/testdata
@@ -36,10 +36,3 @@ jobs:
       working-directory: tests
       run: |
         python ../pynbody/test_utils/__init__.py --fetch
-    - name: Save testdata cache
-      uses: actions/cache/save@v5
-      if: always() && steps.cache-testdata.outputs.cache-hit != 'true'
-      with:
-        path: tests/testdata
-        key: testdata-${{ steps.get-testdata-hash.outputs.testdatahash }}
-        enableCrossOsArchive: true

--- a/.github/workflows/fetch-testdata.yaml
+++ b/.github/workflows/fetch-testdata.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Get testdata hash
       id: get-testdata-hash
       run: |
-        echo "testdatahash=$(python pynbody/test_utils/__init__.py)" >> $GITHUB_OUTPUT
+        echo "testdatahash=$(python pynbody/test_utils/__init__.py --hash-testdata)" >> $GITHUB_OUTPUT
     - name: Restore testdata cache
       uses: actions/cache@v6
       id: cache-testdata
@@ -35,4 +35,4 @@ jobs:
       if: steps.cache-testdata.outputs.cache-hit != 'true'
       working-directory: tests
       run: |
-        python ../pynbody/test_utils/__init__.py --fetch
+        python ../pynbody/test_utils/__init__.py --fetch-testdata

--- a/pynbody/analysis/ionfrac.py
+++ b/pynbody/analysis/ionfrac.py
@@ -317,14 +317,10 @@ class IonFractionTable(IonFractionTableBase):
     @classmethod
     def _download_ionfracs(cls, name):
         """Download an ion fraction table from the pynbody data repository"""
-        from ..test_utils import get_osf_file_object
-
+        from ..test_utils import _download_ionfrac_table
         logger.warning("Downloading ion fraction table %s" % name)
-        osf_file = get_osf_file_object('z46rq', f'{name}.npz')
         filename = cls._table_to_path(name)
-
-        with open(filename, 'wb') as f:
-            osf_file.write_to(f)
+        _download_ionfrac_table(name, filename)
 
     @classmethod
     def from_cloudy(cls, cloudy_path,

--- a/pynbody/analysis/ionfrac.py
+++ b/pynbody/analysis/ionfrac.py
@@ -317,10 +317,10 @@ class IonFractionTable(IonFractionTableBase):
     @classmethod
     def _download_ionfracs(cls, name):
         """Download an ion fraction table from the pynbody data repository"""
-        from ..test_utils import _download_ionfrac_table
+        from ..test_utils import download_ionfrac_table
         logger.warning("Downloading ion fraction table %s" % name)
         filename = cls._table_to_path(name)
-        _download_ionfrac_table(name, filename)
+        download_ionfrac_table(name, filename)
 
     @classmethod
     def from_cloudy(cls, cloudy_path,

--- a/pynbody/test_utils/__init__.py
+++ b/pynbody/test_utils/__init__.py
@@ -162,8 +162,12 @@ def _download_and_unpack_test_data_if_not_present(package, package_name, verbose
 _ionfrac_tables_osf_project_id = "z46rq"
 _required_ionfrac_tables = ("hm12", "fg20") # Tables needed by the tests
 
-def _download_ionfrac_table(name, destination):
-    """Download an ion fraction table from the pynbody data repository"""
+def download_ionfrac_table(name, destination):
+    """Download an ion fraction table from the pynbody data repository
+
+    Note that this is also called from pynbody.analysis.ionfrac to fetch
+    the tables when they are needed and not already present.
+    """
     osf_file = get_osf_file_object(_ionfrac_tables_osf_project_id, f'{name}.npz')
     with open(destination, 'wb') as f:
         osf_file.write_to(f)
@@ -174,7 +178,7 @@ def precache_ionfrac_tables(verbose=False):
     for name in _required_ionfrac_tables:
         if verbose:
             print(f"Downloading table: {name}")
-        _download_ionfrac_table(name, pathlib.Path("ionfrac_tables") / pathlib.Path(name+".npz"))
+        download_ionfrac_table(name, pathlib.Path("ionfrac_tables") / pathlib.Path(name+".npz"))
 
 def ionfrac_tables_hash():
     """Return a hash of the ionfrac table names"""

--- a/pynbody/test_utils/__init__.py
+++ b/pynbody/test_utils/__init__.py
@@ -5,6 +5,7 @@ It is used during CI to download test data before pynbody is built/installed.
 Only use standard library modules and osfclient (which is available in CI).
 """
 
+import argparse
 import os
 import pathlib
 import shutil
@@ -158,9 +159,49 @@ def _download_and_unpack_test_data_if_not_present(package, package_name, verbose
         print(f"Test data package '{package_name}' already exists, skipping")
 
 
+_ionfrac_tables_osf_project_id = "z46rq"
+_required_ionfrac_tables = ("hm12", "fg20") # Tables needed by the tests
+
+def _download_ionfrac_table(name, destination):
+    """Download an ion fraction table from the pynbody data repository"""
+    osf_file = get_osf_file_object(_ionfrac_tables_osf_project_id, f'{name}.npz')
+    with open(destination, 'wb') as f:
+        osf_file.write_to(f)
+
+def precache_ionfrac_tables(verbose=False):
+    """Download all ionfrac tables needed for tests"""
+    os.makedirs("ionfrac_tables", exist_ok=True)
+    for name in _required_ionfrac_tables:
+        if verbose:
+            print(f"Downloading table: {name}")
+        _download_ionfrac_table(name, pathlib.Path("ionfrac_tables") / pathlib.Path(name+".npz"))
+
+def ionfrac_tables_hash():
+    """Return a hash of the ionfrac table names"""
+    import hashlib
+    m = hashlib.sha256()
+    for name in _required_ionfrac_tables:
+        m.update(name.encode())
+    return m.hexdigest()
+
+
 if __name__ == "__main__":
-    import sys
-    if len(sys.argv) > 1 and sys.argv[1] == "--fetch":
+
+    parser = argparse.ArgumentParser(description='Download data files needed for tests')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--fetch-testdata", action="store_true", help="Download pynbody test data files")
+    group.add_argument("--hash-testdata", action="store_true", help="Output the hash of the test data files")
+    group.add_argument("--fetch-ionfrac", action="store_true", help="Download ionfrac table files needed for tests")
+    group.add_argument("--hash-ionfrac", action="store_true", help="Output the hash of the ionfrac table names")
+    args = parser.parse_args()
+
+    if args.fetch_testdata:
         precache_test_data(verbose=True)
-    else:
+    elif args.hash_testdata:
         print(test_data_hash())
+    elif args.fetch_ionfrac:
+        precache_ionfrac_tables(verbose=True)
+    elif args.hash_ionfrac:
+        print(ionfrac_tables_hash())
+    else:
+        raise RuntimeError("No operation specified!")

--- a/pynbody/test_utils/__init__.py
+++ b/pynbody/test_utils/__init__.py
@@ -14,6 +14,9 @@ import urllib.request
 
 import osfclient
 
+# Cache OSF file objects to avoid repeating http requests
+_OSF_STORAGE_CACHE = {}
+
 test_data_packages = {
     'swift': {'verify_path': 'SWIFT',
               'archive_name': 'swift.tar.gz'},
@@ -86,17 +89,18 @@ def test_data_hash():
 
 def get_osf_file_object(osf_project_id, archive_name):
     """Retrieve the OSF file object for the given archive name in the specified OSF project."""
-    osf = osfclient.OSF()
-    osf_project = osf.project(osf_project_id)
-    osf_storage = osf_project.storage('osfstorage')
 
-    for file in osf_storage.files:
-        if file.name == archive_name:
-            osf_file = file
-            break
-    else:
-        raise ValueError(f"File {archive_name} not found in OSF project {osf_project_id}")
-    return osf_file
+    # Open the OSF project storage, if we didn't already
+    if osf_project_id not in _OSF_STORAGE_CACHE:
+        osf = osfclient.OSF()
+        osf_project = osf.project(osf_project_id)
+        osf_storage = osf_project.storage('osfstorage')
+        _OSF_STORAGE_CACHE[osf_project_id] = {}
+        for file in osf_storage.files:
+            _OSF_STORAGE_CACHE[osf_project_id][file.name] = file
+
+    # Return the cached file
+    return _OSF_STORAGE_CACHE[osf_project_id][archive_name]
 
 def download_and_unpack_test_data(archive_name, unpack_path="", verbose=False):
     """Download and unpack test data with the given archive name and unpack path.


### PR DESCRIPTION
This PR makes several changes intended to reduce failures when running the pynbody tests through github:

  * osfclient file objects are cached to reduce the number of requests. This avoids downloading the directory listing again for each file so fetching the test data takes ~20 requests instead of ~100.
  * The .npz files used in ionfrac_test.py are downloaded and cached in the same way as the test data, so we don't have all jobs in the test matrix requesting them in parallel.
  * The fetch_testdata workflow should no longer save a corrupted cache if downloads fail (see issue #968)

OSF unauthenticated requests seem to be limited to 100 per hour. I think one test run will now be well below this limit and we shouldn't generate any requests once the test data and tables are cached.