### PR TITLE
Fix for occasional bisect() failures in calculating virial radii

### DIFF
--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -145,7 +145,7 @@ def virial_radius(sim, cen=None, overden=178, r_max=None, rho_def='matter'):
     """
 
     if r_max is None:
-        r_max = (sim["pos"].max() - sim["pos"].min())
+        r_max = np.ptp(sim['pos'], axis=0).max()
     else:
         if cen is not None:
             sim = sim[filt.Sphere(r_max, cen)]

--- a/pynbody/analysis/halo.py
+++ b/pynbody/analysis/halo.py
@@ -145,7 +145,7 @@ def virial_radius(sim, cen=None, overden=178, r_max=None, rho_def='matter'):
     """
 
     if r_max is None:
-        r_max = (sim["x"].max() - sim["x"].min())
+        r_max = (sim["pos"].max() - sim["pos"].min())
     else:
         if cen is not None:
             sim = sim[filt.Sphere(r_max, cen)]


### PR DESCRIPTION
The initial guess for r_max in virial_radius currently only uses the x positions, even though the comment says it uses all positions.  I've updated this to use x,y,z positions by taking the max/min of pos.  This should guarantee convergence of the later bisect call even for pathological cases with very aspherical halos.