### PR TITLE
Add support for rendering thin spherical shells in healpix images

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -69,6 +69,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_array
 
-__version__ = '2.4.2'
+__version__ = '2.5.0'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/plot/sph.py
+++ b/pynbody/plot/sph.py
@@ -427,7 +427,7 @@ def _units_imply_projection(sim, qty, units):
         return True
 
 def spherical_image(sim, qty='rho', nside=None, kernel=None, threaded=None, units=None,
-                    weight=False, log=True, vmin=None, vmax=None, cmap=None, xsize=1600):
+                    weight=False, distance=None, log=True, vmin=None, vmax=None, cmap=None, xsize=1600):
     """Make an SPH image on the sky around the origin.
 
     .. note::
@@ -436,6 +436,11 @@ def spherical_image(sim, qty='rho', nside=None, kernel=None, threaded=None, unit
       the healpix image onto a Mollweide projection.
 
       To install healpy, use ``pip install healpy``.
+
+    .. versionchanged :: 2.5.0
+
+      The parameter *distance* has been added. If provided, the quantity is sampled on a thin spherical shell at
+      this radius (in position units).
 
     Parameters
     ----------
@@ -466,6 +471,11 @@ def spherical_image(sim, qty='rho', nside=None, kernel=None, threaded=None, unit
         If True, the requested quantity is volume-averaged down the line of sight. If a string, the requested quantity
         is averaged down the line of sight weighted by the named array (e.g. use 'rho' for density-weighted quantity).
 
+    distance : float, str, pynbody.units.Unit, optional
+        If provided, sample the quantity on a thin spherical shell at this radius (in position units) using the full
+        3D kernel, instead of the default line-of-sight projection. The output then carries volumetric units (e.g. a
+        density) rather than a per-solid-angle column.
+
     log : bool, optional
         If True, the image is log-scaled. (Default is True)
 
@@ -488,7 +498,7 @@ def spherical_image(sim, qty='rho', nside=None, kernel=None, threaded=None, unit
     except ImportError:
         raise ImportError("healpy is required for spherical_image function. Install with: pip install healpy")
     image = sph.render_spherical_image(sim, quantity=qty, nside=nside, kernel=kernel, out_units=units,
-                                       weight=weight, threaded=threaded)
+                                       weight=weight, distance=distance, threaded=threaded)
 
     unit = image.units
     if unit is not None:

--- a/pynbody/sph/__init__.py
+++ b/pynbody/sph/__init__.py
@@ -94,15 +94,23 @@ def rho(sim):
     return rho
 
 def render_spherical_image(snap, quantity='rho', nside=None, kernel=None, denoise=None, out_units=None, threaded=None,
-                           weight=None, qty=None):
-    """Render an SPH image projected onto the sky around the origin.
+                           weight=None, distance=None, qty=None):
+    """Render an SPH image onto the sky around the origin, in healpix format with the specified nside.
 
-    At present, only projection is supported (i.e., there is no implementation for rendering on a spherical
-    shell). For example, if rendering density, the results are in units of mass per solid angle. The image is
-    returned in healpix format, with the specified nside.
+    By default the image is projected onto the sky, i.e. integrated along the line of sight. For example, if
+    rendering density, the results are then in units of mass per solid angle.
+
+    Alternatively, if ``distance`` is provided, a thin spherical shell is sampled at that radius using the full 3D
+    kernel. The result then carries volumetric units (e.g. a density, if rendering density) rather than a
+    per-solid-angle column.
 
     Weighted projections are supported, e.g. one may look at the projected temperature, weighted by density, by
     passing 'temp' as the qty and 'rho' as the weight.
+
+    .. versionchanged :: 2.5.0
+
+      The parameter *distance* has been added. If provided, the quantity is sampled on a thin spherical shell at
+      this radius (in position units).
 
     Parameters
     ----------
@@ -119,6 +127,10 @@ def render_spherical_image(snap, quantity='rho', nside=None, kernel=None, denois
 
     nside : int
         The healpix nside resolution to use (must be power of 2)
+
+    distance : float, str, units.UnitBase, optional
+        If provided, render a thin spherical shell at this radius (in position units) using the full 3D kernel,
+        instead of the default line-of-sight projection. The result then carries volumetric units.
 
     kernel : str, kernels.KernelBase, optional
         The Kernel object to use (defaults to 3D spline kernel)
@@ -146,7 +158,7 @@ def render_spherical_image(snap, quantity='rho', nside=None, kernel=None, denois
         quantity = qty
 
     renderer = renderers.make_render_pipeline(snap, quantity, nside=nside, target='healpix', kernel=kernel,
-                                              out_units=out_units, threaded=threaded,
+                                              shell_distance=distance, out_units=out_units, threaded=threaded,
                                               approximate_fast=False, weight=weight)
 
     return renderer.render()

--- a/pynbody/sph/_render.pyx
+++ b/pynbody/sph/_render.pyx
@@ -5,8 +5,11 @@ cimport libc.math as cmath
 cimport numpy as np
 
 np.import_array()
-from libc.math cimport atan, pow, sqrt
+from libc.math cimport acos, atan, cos, pow, sqrt
 from libc.stdlib cimport free, malloc
+
+
+cdef double PI = 3.14159265358979323846
 
 # The following slightly odd repetitiveness is to force Cython to generate
 # code for different permutations of the possible integer inputs.
@@ -53,17 +56,42 @@ def render_spherical_image_core(np.ndarray[fused_input_type_1, ndim=1] rho, # ar
                                 np.ndarray[fused_input_type_4, ndim=1] z,
                                 np.ndarray[fused_input_type_5, ndim=1] h, # particle smoothing length
                                 unsigned int nside,
-                                kernel) :
+                                kernel,
+                                fixed_input_type shell_radius=0.0) :
+    """Render an SPH quantity onto a healpix sphere around the origin.
+
+    Two modes are supported, selected by the dimension of the ``kernel``:
+
+    * A projected (column) image, obtained by passing a 2D (projected) kernel
+      (``kernel.h_power == 2``). Every particle whose smoothing sphere crosses
+      the line of sight contributes its full column, giving a quantity per unit
+      solid angle. ``shell_radius`` is ignored in this mode.
+
+    * A thin-shell image, obtained by passing a 3D kernel (``kernel.h_power == 3``)
+      together with a positive ``shell_radius``. The 3D kernel is evaluated on the
+      sphere of radius ``shell_radius``, i.e. the field is sampled where each
+      particle's kernel intersects that shell. This is the spherical analogue of
+      the thin-slice mode of :func:`render_image`.
+    """
 
     cdef np.ndarray[image_output_type,ndim=1] im
 
     if nside & (nside - 1) != 0:
         raise ValueError('nside value must be a power of 2')
 
-    if kernel.h_power != 2:
-        raise ValueError('Only kernels of dimension 2 (i.e. projected kernels) are currently supported for healpix maps')
+    cdef int kernel_dim = kernel.h_power
+    if kernel_dim != 2 and kernel_dim != 3:
+        raise ValueError('Only kernels of dimension 2 (projected) or 3 (thin shell) '
+                         'are supported for healpix maps')
+
+    # projected -> column image; otherwise a thin shell at shell_radius
+    cdef int projected = (kernel_dim == 2)
+
+    if not projected and shell_radius <= 0.0:
+        raise ValueError('A positive shell_radius is required to render a 3D (thin shell) healpix map')
 
     cdef fixed_input_type max_d_over_h = kernel.max_d
+    cdef fixed_input_type max_d_over_h_2 = max_d_over_h * max_d_over_h
 
     cdef np.ndarray[image_output_type, ndim=1] samples = kernel.get_samples(dtype=np_image_output_type)
     cdef int num_samples = len(samples)
@@ -82,10 +110,21 @@ def render_spherical_image_core(np.ndarray[fused_input_type_1, ndim=1] rho, # ar
     cdef size_t num_pixels
     cdef double[3] pos_i
     cdef double angular_size
+    cdef double distance, distance2
     cdef double smooth_2
     cdef double kernel_max_2
     cdef double physical_offset
+    cdef double cos_alpha              # thin shell: cosine of the intersection half-angle
+    cdef double shell_2 = shell_radius * shell_radius
+    cdef double d2                     # thin shell: squared 3D distance particle->shell point
+    cdef double two_rs_d               # thin shell: 2 * shell_radius * distance
     cdef fused_input_type_3 qty_i
+
+    # per-particle value of h to the power of the kernel dimension, which get_kernel
+    # divides the (h=1) samples by. For the projected image this additionally carries
+    # a distance^2 Jacobian to express the column per unit solid angle rather than per
+    # unit transverse area.
+    cdef image_output_type h_to_kdim
 
     cdef image_output_type kern
 
@@ -101,16 +140,40 @@ def render_spherical_image_core(np.ndarray[fused_input_type_1, ndim=1] rho, # ar
             pos_i[2] = z[i]
             distance2 = pos_i[0]*pos_i[0] + pos_i[1]*pos_i[1] + pos_i[2]*pos_i[2]
             distance = sqrt(distance2)
-            angular_size = max_d_over_h * h[i] / distance
             smooth_2 = h[i]*h[i]
-            kernel_max_2 = smooth_2*max_d_over_h*max_d_over_h
+            kernel_max_2 = smooth_2*max_d_over_h_2
+
+            if projected:
+                angular_size = max_d_over_h * h[i] / distance
+                h_to_kdim = smooth_2 / distance2
+            else:
+                # The kernel support (sphere of radius sqrt(kernel_max_2) about the
+                # particle) meets the shell in a circle. Its angular radius about the
+                # origin follows from the law of cosines for the triangle
+                # origin-particle-shellpoint:
+                #     cos(alpha) = (shell^2 + distance^2 - kernel_max_2) / (2 shell distance)
+                two_rs_d = 2.0 * shell_radius * distance
+                cos_alpha = (shell_2 + distance2 - kernel_max_2) / two_rs_d
+                if cos_alpha >= 1.0:
+                    # closest approach still outside the kernel: no intersection
+                    continue
+                elif cos_alpha <= -1.0:
+                    angular_size = PI
+                else:
+                    angular_size = acos(cos_alpha)
+                h_to_kdim = smooth_2 * h[i]
 
             num_pixels = query_disc_c(nside, pos_i, angular_size, index_buffer, angle_buffer)
 
             for j in range(num_pixels):
-                physical_offset = distance * angle_buffer[j]
-                kern = get_kernel(physical_offset*physical_offset, kernel_max_2,
-                                  smooth_2/distance2, num_samples, samples_c)
+                if projected:
+                    physical_offset = distance * angle_buffer[j]
+                    d2 = physical_offset*physical_offset
+                else:
+                    # 3D separation between the particle and the shell point in this
+                    # direction, again by the law of cosines
+                    d2 = shell_2 + distance2 - two_rs_d * cos(angle_buffer[j])
+                kern = get_kernel(d2, kernel_max_2, h_to_kdim, num_samples, samples_c)
                 im[index_buffer[j]] += qty_i * kern * mass[i] / rho[i]
 
     return im

--- a/pynbody/sph/renderers.py
+++ b/pynbody/sph/renderers.py
@@ -57,6 +57,9 @@ class ImageGeometry:
 
         # for use by healpix renderer:
         self.nside = None
+        self.shell_distance = None
+        # if set, the healpix renderer produces a thin shell at this radius (in position units)
+        # rather than a projection along the line of sight
 
     @property
     def width(self):
@@ -715,10 +718,33 @@ class Grid3dRenderer(ImageRenderer):
         return image
 
 class HealpixRenderer(ImageRenderer):
-    """Implementation for rendering a simulation snapshot to healpix"""
+    """Implementation for rendering a simulation snapshot to healpix.
+
+    Two modes are available. By default a projection along the line of sight is rendered, giving a quantity per unit
+    solid angle. Alternatively, if a shell distance is set via :meth:`set_shell_distance`, the quantity is sampled on
+    a thin spherical shell at that radius, giving the same (e.g. volumetric density) units as a slice image.
+    """
 
     def __init__(self, snap: snapshot.SimSnap):
         super().__init__(snap)
+
+    def set_shell_distance(self, distance: float | str | units.UnitBase | None):
+        """Render a thin spherical shell at the given radius instead of a line-of-sight projection.
+
+        .. versionadded :: 2.5.0
+
+        Parameters
+        ----------
+        distance : float, str, units.UnitBase or None
+            The radius of the shell on which to sample the quantity, in position units (or a unit/string which is
+            converted accordingly). If None, a projection is rendered instead.
+        """
+        if distance is None:
+            self._geometry.shell_distance = None
+        else:
+            self._geometry.shell_distance = self._to_position_units(distance)
+            # a thin shell is sampled with the full 3D kernel, i.e. it is not a projection
+            self._is_projected = False
 
     def _get_native_area_unit(self, smooth, kernel_h_power=None):
         if kernel_h_power is None:
@@ -731,7 +757,8 @@ class HealpixRenderer(ImageRenderer):
     def _call_c_renderer(self, array, geometry, kernel, mass_array, rho_array, smooth_array, x_array, y_array, z_array):
         return _render.render_spherical_image_core(rho_array, mass_array, array,
                                                    x_array, y_array, z_array,
-                                                   smooth_array, self.geometry.nside, kernel)
+                                                   smooth_array, geometry.nside, kernel,
+                                                   geometry.shell_distance or 0.0)
 
 
 
@@ -747,6 +774,7 @@ def make_render_pipeline(sim : snapshot.SimSnap, /,
                          resolution: int = None,
                          nx: int = None, ny: int = None, nz: int = None,
                          nside: int = None,
+                         shell_distance: float | str | units.UnitBase = None,
                          out_units: str | units.UnitBase = None,
                          weight: bool | str | np.ndarray | NoneType = None,
                          restrict_depth: bool = False,
@@ -759,6 +787,10 @@ def make_render_pipeline(sim : snapshot.SimSnap, /,
                          target: str = 'image',
                          ) -> ImageRendererBase:
     """Generate a renderer object for rendering images of a simulation snapshot.
+
+    .. versionchanged :: 2.5.0
+
+      The parameter *shell_distance* has been added.
 
     Parameters
     ----------
@@ -792,6 +824,11 @@ def make_render_pipeline(sim : snapshot.SimSnap, /,
     nside : int, optional
         The nside of the image to be rendered, for healpix images (target='healpix'). The default is None,
         in which case a default nside is adopted.
+
+    shell_distance : float, str, units.UnitBase, optional
+        For healpix images (target='healpix') only. If provided, a thin spherical shell is sampled at this radius
+        (in position units) using the full 3D kernel, instead of the default line-of-sight projection. The result
+        then carries volumetric (e.g. density) units rather than a per-solid-angle column.
 
     out_units : str, units.UnitBase, optional
         The units to be used for the output image. These are checked for compatibility with the array to be
@@ -903,15 +940,21 @@ def make_render_pipeline(sim : snapshot.SimSnap, /,
     if nside is not None and target != 'healpix':
         raise ValueError("nside is only valid in combination with target='healpix'")
 
+    if shell_distance is not None and target != 'healpix':
+        raise ValueError("shell_distance is only valid in combination with target='healpix'")
+
+    is_shell = target == 'healpix' and shell_distance is not None
+    if is_shell:
+        renderer.set_shell_distance(shell_distance)
 
     renderer.set_quantity(quantity)
 
     if out_units is not None:
         renderer.set_output_units(out_units)
         # this may change the projection status of the image
-    elif target == 'healpix' and not weight:
-        # by _default_, spherical images are projected. In fact, right now, there is no other option
-        # but in future we could implement a distance argument that would enable volume rendering too
+    elif target == 'healpix' and not weight and not is_shell:
+        # by _default_, spherical images are projected onto the sky. A thin shell (is_shell) is instead
+        # sampled with the full 3D kernel and so is not a projection.
         renderer.set_projection(True)
 
     if z_camera is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tests = [
     "pandas",
     "camb",
     "IPython",
-    "healpy; platform_system != 'Windows' and python_version < '3.14'"
+    "healpy; platform_system != 'Windows' and python_version < '3.15'"
 ]
 docs = [
     "ipython>=3",

--- a/tests/sph_image_test.py
+++ b/tests/sph_image_test.py
@@ -275,7 +275,6 @@ def test_spherical_shell_render(simple_test_file):
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Healpy not supported on Windows")
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Healpy binaries seem to be broken on Python 3.14")
 def test_spherical_shell_geometry(simple_test_file):
     """Check the thin-shell geometry against an independent brute-force evaluation on healpix pixels."""
     import healpy as hp
@@ -313,7 +312,6 @@ def test_spherical_shell_geometry(simple_test_file):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.skipif(platform.system() == "Windows", reason="Healpy not supported on Windows")
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Healpy binaries seem to be broken on Python 3.14")
 def test_render_stars_spherical(snap):
     plt.clf()
     res = pynbody.plot.stars.render_mollweide(snap, return_image=True)

--- a/tests/sph_image_test.py
+++ b/tests/sph_image_test.py
@@ -258,6 +258,59 @@ def test_spherical_render(simple_test_file):
                                      -0.46617195], rtol=0.01)
 
 
+def test_spherical_shell_render(simple_test_file):
+    """A thin-shell healpix render should sample the 3D density field, giving volumetric units."""
+    f = simple_test_file
+
+    im = pynbody.sph.render_spherical_image(f, 'rho', nside=16, distance='1.0 kpc')
+
+    # sampling density on a shell gives a volumetric (density) quantity, not a per-solid-angle column
+    assert im.units == "Msol kpc^-3"
+
+    # the shell passes through the bulk of the (unit-variance gaussian) distribution, so it must be
+    # populated with sensible, positive densities
+    assert (im >= 0).all()
+    assert np.count_nonzero(im) > len(im) // 2
+    assert 0.001 < im.mean() < 1.0
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Healpy not supported on Windows")
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Healpy binaries seem to be broken on Python 3.14")
+def test_spherical_shell_geometry(simple_test_file):
+    """Check the thin-shell geometry against an independent brute-force evaluation on healpix pixels."""
+    import healpy as hp
+
+    f = simple_test_file
+    nside = 16
+    distance = 1.3
+
+    kernel = kernels.CubicSplineKernel()
+    im = pynbody.sph.render_spherical_image(f, 'rho', nside=nside, distance=distance, kernel=kernel)
+
+    pos = f['pos'].view(np.ndarray)
+    h = f['smooth'].view(np.ndarray)
+    mass = f['mass'].view(np.ndarray)
+    rho = f['rho'].view(np.ndarray)
+
+    npix = 12 * nside * nside
+    shell_points = distance * np.array(hp.pix2vec(nside, np.arange(npix))).T  # (npix, 3)
+
+    ref = np.zeros(npix)
+    max_d = kernel.max_d
+    for i in range(len(pos)):
+        d = np.linalg.norm(shell_points - pos[i], axis=1)
+        contributing = np.nonzero(d < max_d * h[i])[0]
+        for p in contributing:
+            # get_value's first argument is the normalised distance q = d / h
+            ref[p] += mass[i] * kernel.get_value(d[p] / h[i], h[i])  # rho * mass / rho = mass
+
+    # residual is dominated by the kernel look-up-table quantisation, matching the accuracy of the
+    # flat-image renderer; require agreement to ~1% of the peak with only the small systematic LUT bias
+    peak = np.abs(ref).max()
+    assert np.abs(im - ref).max() < 0.02 * peak
+    assert np.abs((im - ref).mean()) < 5e-3 * peak
+
+
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.skipif(platform.system() == "Windows", reason="Healpy not supported on Windows")
 @pytest.mark.skipif(sys.version_info >= (3, 14), reason="Healpy binaries seem to be broken on Python 3.14")


### PR DESCRIPTION
This pull request introduces a significant new feature to the SPH (Smoothed Particle Hydrodynamics) rendering pipeline: the ability to render spherical "thin shell" images in addition to the existing line-of-sight projections. This enhancement allows users to sample SPH quantities on a thin spherical shell at a specified radius, returning volumetric values (e.g., density) rather than per-solid-angle columns. The implementation includes API changes, core rendering logic updates, documentation improvements, and new tests to validate the feature.

**Testing**
* Added new tests to verify the correctness of the thin-shell rendering, including checks for units, value ranges, and geometric accuracy against a brute-force reference implementation.

**Versioning**
* Bumped the package version to `2.5.0` to reflect the introduction of this new feature.