### PR TITLE
Fix contour plots and update Read the Docs build to use Python 3.13

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
    os: ubuntu-22.04
    tools:
-     python: "3.11"
+     python: "3.13"
    apt_packages:
      - gcc
      - g++

--- a/pynbody/plot/generic.py
+++ b/pynbody/plot/generic.py
@@ -431,10 +431,30 @@ def make_contour_plot(arr, xs, ys, x_range=None, y_range=None, nlevels=20,
     if kwargs.get('ret_im', None) is not None:
         warnings.warn("The 'ret_im' keyword is deprecated. Use 'plot_type' instead.", DeprecationWarning)
         plot_type = 'image'
-
+        del kwargs['ret_im']
 
     if 'norm' in kwargs:
         del(kwargs['norm'])
+
+    xlabel = kwargs.pop('xlabel', None)
+    if xlabel is None:
+        try:
+            if xlabel_display_log:
+                xlabel = r'' + '$log_{10}(' + xs.units.latex() + ')$'
+            else:
+                xlabel = r'' + '$x/' + xs.units.latex() + '$'
+        except AttributeError:
+            xlabel = None
+
+    ylabel = kwargs.pop('ylabel', None)
+    if ylabel is None:
+        try:
+            if ylabel_display_log:
+                ylabel = '$log_{10}(' + ys.units.latex() + ')$'
+            else:
+                ylabel = r'' + '$y/' + ys.units.latex() + '$'
+        except AttributeError:
+            ylabel = None
 
     if colorbar_label is None:
         if hasattr(arr,'units') and arr.units != NoUnit() and arr.units != 1:
@@ -474,33 +494,11 @@ def make_contour_plot(arr, xs, ys, x_range=None, y_range=None, nlevels=20,
     else:
         raise ValueError("Unknown plot_type: %s" % plot_type)
 
-    if 'xlabel' in kwargs:
-        xlabel = kwargs['xlabel']
-    else:
-        try:
-            if xlabel_display_log:
-                xlabel = r'' + '$log_{10}(' + xs.units.latex() + ')$'
-            else:
-                xlabel = r'' + '$x/' + xs.units.latex() + '$'
-        except AttributeError:
-            xlabel = None
-
     if xlabel:
         try:
             plt.xlabel(xlabel)
         except Exception:
             pass
-
-    if 'ylabel' in kwargs:
-        ylabel = kwargs['ylabel']
-    else:
-        try:
-            if ylabel_display_log:
-                ylabel = '$log_{10}(' + ys.units.latex() + ')$'
-            else:
-                ylabel = r'' + '$y/' + ys.units.latex() + '$'
-        except AttributeError:
-            ylabel = None
 
     if ylabel:
         try:

--- a/tests/plot_hist2d_test.py
+++ b/tests/plot_hist2d_test.py
@@ -96,6 +96,19 @@ def test_hist2d_image_type():
 
     assert len(plt.gca().collections) > 0
 
+def test_hist2d_xylabel_with_contour():
+    # regression test: passing xlabel/ylabel used to be forwarded all the way down to
+    # matplotlib's contour/contourf call, where they are not valid keyword arguments
+    x = np.random.randn(10000)
+    y = np.random.randn(10000)
+
+    for plot_type in ('contour', 'contourf', 'image'):
+        plt.clf()
+        hist2d(x, y, nbins=100, plot_type=plot_type, xlabel='my x label', ylabel='my y label')
+
+        assert plt.gca().get_xlabel() == 'my x label'
+        assert plt.gca().get_ylabel() == 'my y label'
+
 def test_hist2d_with_nan():
     np.random.seed(13136)
     x = np.random.normal(size=10000)


### PR DESCRIPTION
Python 3.11 is nearing end of active support; bump the RTD build environment to 3.13 to match current recommendations.