### PR TITLE
Implement partial loading of Swift snapshots using the GadgetHdfSnap take parameter

### DIFF
--- a/pynbody/chunk/__init__.py
+++ b/pynbody/chunk/__init__.py
@@ -233,7 +233,7 @@ class LoadControl:
         i = 0
         next_dip = disk_interrupt_points[i]
         for nread_disk, disk_slice, mem_slice in self.iterate(families_on_disk, families_in_memory, multiskip):
-            while next_dip and fpos + nread_disk > next_dip:
+            while (next_dip is not None) and fpos + nread_disk > next_dip:
                 # an interrupt falls in the middle of our slice
                 # work out what to read first
                 len_pre = next_dip - fpos

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -532,7 +532,7 @@ class GadgetHDFSnap(SimSnap):
         self._init_unit_information()
         self.__init_family_map()
 
-        take = kwargs.pop("take", None)
+        take = self._get_take_parameter(**kwargs)
         self.partial_load = take is not None
         self.__init_file_map(take)
         self._remove_empty_particle_groups()
@@ -540,6 +540,9 @@ class GadgetHDFSnap(SimSnap):
         self.__infer_mass_dtype()
         self._init_properties()
         self._decorate()
+
+    def _get_take_parameter(self, **kwargs):
+        return kwargs.pop("take", None)
 
     def _have_softening_for_particle_type(self, particle_type):
         attrs = self._get_hdf_parameter_attrs()

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -465,8 +465,6 @@ class HDFArrayLoader:
         # Find the first dataset for this family to determine file element size
         first_dataset = None
         for hdf_group_name in self._family_to_group_map[loading_fam]:
-            if self._file_ptype_slice[hdf_group_name].stop <= self._file_ptype_slice[hdf_group_name].start:
-                continue
             for hdf_group in self._hdf_files.iter_particle_groups_with_name(hdf_group_name):
                 first_dataset = self._get_dataset_from_translated_names(sim, hdf_group, translated_names)
                 if first_dataset is not None:
@@ -535,7 +533,6 @@ class GadgetHDFSnap(SimSnap):
         take = self._get_take_parameter(**kwargs)
         self.partial_load = take is not None
         self.__init_file_map(take)
-        self._remove_empty_particle_groups()
         self.__init_loadable_keys()
         self.__infer_mass_dtype()
         self._init_properties()
@@ -635,15 +632,6 @@ class GadgetHDFSnap(SimSnap):
         self._family_slice = self._array_loader._family_slice_to_load
         self._num_particles = self._array_loader._num_particles_to_load
 
-    def _remove_empty_particle_groups(self):
-        """Remove particle groups that contain no particles from the internal family mapping.
-
-        This is important for some formats like Arepo where tracer particles might be defined
-        but not present, which can cause issues with `HaloCatalogue`.
-        """
-        for family_name in self._family_to_group_map:
-            self._family_to_group_map[family_name] = [group_name for group_name in self._family_to_group_map[family_name]
-                                           if self._gadget_ptype_slice[group_name].stop > self._gadget_ptype_slice[group_name].start]
 
     def __infer_mass_dtype(self):
         """Some files have a mixture of header-based masses and, for other partile types, explicit mass

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -542,6 +542,10 @@ class GadgetHDFSnap(SimSnap):
         self._decorate()
 
     def _get_take_parameter(self, **kwargs):
+        """This can be overridden by sub-classes to allow alternate ways to
+        specify subsets of particles to read. For standard GadgetHDF snapshots
+        we just allow specifying an array of particle indexes with take=...
+        """
         return kwargs.pop("take", None)
 
     def _have_softening_for_particle_type(self, particle_type):

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -653,10 +653,13 @@ class GadgetHDFSnap(SimSnap):
         type_map = {}
         for fam, g_types in _default_type_map.items():
             my_types = []
+            # Loop over particle type groups for this family (PartType1, PartType2, ...)
             for x in g_types:
-                # Get all keys from all hdf files
+                # Find instances of this group in all files. Discard any that
+                # don't have the dataset we'd use to get the number of
+                # particles (e.g. Arepo tracers don't have ParticleIDs)
                 for hdf in self._hdf_files:
-                    if x in list(hdf.keys()):
+                    if x in hdf and self._hdf_files._size_from_hdf5_key in hdf[x]:
                         my_types.append(x)
                         break
             if len(my_types):

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -94,7 +94,7 @@ class _GadgetHdfMultiFileManager:
                 self._numfiles = self._numfiles[0]
             self._filenames = [self._make_filename_for_cpu(filename, i) for i in range(self._numfiles)]
             assert filename0 == self._filenames[0]
-            self._open_files[0] = file0
+            self._cache_file(0, file0)
 
     def _get_num_files(self, first_file):
         return first_file[self._nfiles_groupname].attrs[self._nfiles_attrname]
@@ -105,13 +105,16 @@ class _GadgetHdfMultiFileManager:
     def __len__(self):
         return self._numfiles
 
+    def _cache_file(self, i, h5file):
+        if self._subgroup_name is None:
+            self._open_files[i] = h5file
+        else:
+            self._open_files[i] = h5file[self._subgroup_name]
+
     def __iter__(self) :
         for i in range(self._numfiles) :
             if i not in self._open_files:
-                self._open_files[i] = h5py.File(self._filenames[i], self._mode)
-                if self._subgroup_name is not None:
-                    self._open_files[i] = self._open_files[i][self._subgroup_name]
-
+                self._cache_file(i, h5py.File(self._filenames[i], self._mode))
             yield self._open_files[i]
 
     def __getitem__(self, i) :

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -723,10 +723,14 @@ class GadgetHDFSnap(SimSnap):
                                                               target_array_this.dtype)
     
                     dataset.write_direct(target_array_this.reshape(dataset.shape))
-    
+                    self._update_group_attributes_on_write(hdf)
                     i0 = i1
         finally:
             self._hdf_files.reopen_in_mode('r')
+
+    def _update_group_attributes_on_write(self, hdf):
+        """Sub-classes might have group metadata to update on writing arrays"""
+        pass
 
     @staticmethod
     def _get_hdf_allarray_keys(group):
@@ -749,6 +753,7 @@ class GadgetHDFSnap(SimSnap):
             ret =ret[tpart]
 
         dataset_name = hdf_name.split("/")[-1]
+
         return ret.require_dataset(dataset_name, shape, dtype, exact=True)
 
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -81,18 +81,20 @@ class _GadgetHdfMultiFileManager:
     def __init__(self, filename, mode='r') :
         filename = str(filename)
         self._mode = mode
+        self._open_files = {}
         if h5py.is_hdf5(filename):
             self._filenames = [filename]
             self._numfiles = 1
         else:
-            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
-            self._numfiles = self._get_num_files(h1)
+            filename0 = self._make_filename_for_cpu(filename, 0)
+            file0 = h5py.File(filename0, mode)
+            self._numfiles = self._get_num_files(file0)
             if hasattr(self._numfiles, "__len__"):
                 assert len(self._numfiles) == 1
                 self._numfiles = self._numfiles[0]
             self._filenames = [self._make_filename_for_cpu(filename, i) for i in range(self._numfiles)]
-
-        self._open_files = {}
+            assert filename0 == self._filenames[0]
+            self._open_files[0] = file0
 
     def _get_num_files(self, first_file):
         return first_file[self._nfiles_groupname].attrs[self._nfiles_attrname]

--- a/pynbody/snapshot/simsnap.py
+++ b/pynbody/snapshot/simsnap.py
@@ -988,7 +988,7 @@ class SimSnap(ContainerWithPhysicalUnitsOption, iter_subclasses.IterableSubclass
     # WRITING FUNCTIONS
     ############################################
     def write(self, fmt=None, filename=None, **kwargs):
-        if filename is None and "<" in self.filename:
+        if filename is None and "<" in str(self.filename):
             raise RuntimeError(
                 'Cannot infer a filename; please provide one (use obj.write(filename="filename"))')
 

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -143,6 +143,17 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
     def _all_group_names(self):
         return self[0]['Cells/Counts'].keys()
 
+    def iter_particle_groups_with_name(self, hdf_family_name):
+        """
+        Swift snapshots can contain zero length datasets, which we need to skip.
+        TODO: should this be handled in GadgetHdfSnap somewhere?
+        """
+        for hdf in self:
+            if hdf_family_name in hdf:
+                if self._size_from_hdf5_key in hdf[hdf_family_name]:
+                    n = hdf[hdf_family_name][self._size_from_hdf5_key].shape[0]
+                    if n > 0:
+                        yield hdf[hdf_family_name]
 
 class ExtractScalarWrapper:
     def __init__(self, underlying):

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -13,39 +13,6 @@ from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
-    def __init__(self, filename: pathlib.Path, take_cells, take_region, mode='r'):
-        self._take_cells = take_cells
-
-        if take_cells is not None and take_region is not None:
-            raise ValueError("Either take_cells or take_region must be specified, not both")
-
-        if take_cells is not None or take_region is not None:
-            # we need to avoid loading a VDS file, as it won't have the info needed to make our own VDS
-            # pointers to the right cells
-            try:
-                with h5py.File(filename, mode='r') as f:
-                    if f['Header'].attrs['Virtual'][0] == 1 and filename.suffix == '.hdf5':
-                        # if we simply strip off .hdf5, GadgetHDFSnap will find the underlying files (hopefully..)
-                        filename = filename.with_suffix('')
-                    # it's not a virtual file anyway, so we're ok
-            except FileNotFoundError:
-                pass # perfect, this is either going to be pieced together by pynbody, or it'll fail anyway
-        super().__init__(filename, mode)
-
-        if take_region is not None:
-            # convert take to take_cells
-            take_cells = self._identify_cells_to_take(take_region)
-
-        # hopefully the shenanigans above mean we don't end up with a VDS, but just in case we do, check again:
-        if self.is_virtual() and take_cells is not None:
-            raise ValueError("Can't take a subset of cells from a VDS-based HDF5 file pointing to multiple underlying files")
-
-        self._make_hdf_vfile(take_cells)
-
-    def _identify_cells_to_take(self, take):
-        centres = self[0]['Cells/Centres'][:]
-        return np.where(take.cubic_cell_intersection(centres))[0]
-
     def get_unit_attrs(self):
         return self[0].parent['InternalCodeUnits'].attrs
 
@@ -58,94 +25,8 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
         except KeyError:
             return False
 
-    def iter_particle_groups_with_name(self, hdf_family_name):
-        if hdf_family_name in self._hdf_vfile:
-            if self._size_from_hdf5_key in self._hdf_vfile[hdf_family_name]:
-                yield self._hdf_vfile[hdf_family_name]
-
     def _all_group_names(self):
         return self[0]['Cells/Counts'].keys()
-
-    def _make_hdf_vfile(self, take_cells):
-        temp_dir_path = tempfile.mkdtemp()
-        tmpfile_path = os.path.join(temp_dir_path, "nofile.hdf5")
-        with h5py.File(name=tmpfile_path, mode='w') as hdf_vfile:
-            # ideally one would simply use  backing_store=False, to File but then there doesn't seem to be a way
-            # to actually use the file (the VDS views just returns zeros).
-            # Instead we write then re-read it, which presumably carries minimal overhead but is a bit ugly.
-
-            for group_name in self._all_group_names():
-
-                if take_cells is None:
-                    source_groups, source_slices = self._generate_groups_and_slices_for_full_file(group_name)
-                else:
-                    source_groups, source_slices = self._generate_groups_and_slices_from_cells(group_name,
-                                                                                               take_cells)
-
-                target_group = hdf_vfile.create_group(group_name)
-                self._make_hdf_group_with_slicing(source_groups, source_slices, target_group)
-
-        self._hdf_vfile = h5py.File(name=tmpfile_path, mode='r')
-        self._finalizer = weakref.finalize(self, self._finalize, self._hdf_vfile, temp_dir_path)
-
-    @classmethod
-    def _finalize(cls, hdf_vfile, temp_dir_path):
-        try:
-           hdf_vfile.close()
-        except Exception:
-            pass
-
-        shutil.rmtree(temp_dir_path)
-
-    def _generate_groups_and_slices_for_full_file(self, group_name):
-        source_groups = [hdf_file[group_name] for hdf_file in self]
-        source_lens = [len(f[group_name][self._size_from_hdf5_key]) for f in self]
-        source_slices = [[slice(0, l)] for l in source_lens]
-        return source_groups, source_slices
-
-    def _generate_groups_and_slices_from_cells(self, group_name, take_cells):
-        # we get the cell info from the first file, and assume it's consistent between files
-        offsets = self[0]['Cells']['OffsetsInFile'][group_name]
-        lens = self[0]['Cells']['Counts'][group_name]
-        file_responsible = self[0]['Cells']['Files'][group_name]
-
-        # First, make a map from the file ID to the slices to be taken from that file
-        file_id_to_slices_map = {}
-        for cell in take_cells:
-            if file_responsible[cell] not in file_id_to_slices_map:
-                file_id_to_slices_map[file_responsible[cell]] = []
-            sl = slice(offsets[cell], offsets[cell] + lens[cell])
-            file_id_to_slices_map[file_responsible[cell]].append(sl)
-
-        # Now, reformat everything into the format expected by _make_hdf_group_with_slicing
-        source_slices = []
-        source_groups = []
-
-        for file_id in sorted(list(file_id_to_slices_map)):
-            source_groups.append(self[file_id][group_name])
-            source_slices.append(sorted(file_id_to_slices_map[file_id]))
-
-        return source_groups, source_slices
-
-    def _make_hdf_group_with_slicing(self, source_groups, source_slices, target_group):
-        total_len = 0
-        for take_slices in source_slices:
-            for s in take_slices:
-                assert s.step is None
-                total_len += s.stop - s.start
-
-        for array_name in source_groups[0]:
-            offset = 0
-            target_dims = (total_len,) + source_groups[0][array_name].shape[1:]
-            layout = h5py.VirtualLayout(shape=target_dims, dtype=source_groups[0][array_name].dtype)
-
-            for source_group, take_slices in zip(source_groups, source_slices):
-                source = h5py.VirtualSource(source_group[array_name])
-                for s in take_slices:
-                    layout[slice(offset, offset+s.stop-s.start)] = source[s]
-                    offset += s.stop-s.start
-
-            target_group.create_virtual_dataset(array_name, layout)
 
 
 class ExtractScalarWrapper:
@@ -170,14 +51,61 @@ class SwiftSnap(GadgetHDFSnap):
 
     _namemapper_config_section = 'swift-name-mapping'
 
-    def __init__(self, filename, take_swift_cells=None, take_region=None):
-        self._take_swift_cells = take_swift_cells
-        self._take_region = take_region
-        super().__init__(filename)
 
+    def _get_take_parameter(self, **kwargs):
+        if len({"take", "take_swift_region", "take_swift_cells"} & kwargs.keys()) > 1:
+            raise ValueError("Can only specify one of take, take_cells or take_region")
+        if "take" in kwargs:
+            return kwargs.pop("take")
+        elif "take_swift_cells" in kwargs:
+            return self._take_from_cells(kwargs.pop("take_swift_cells"))
+        elif "take_region" in kwargs:
+            return self._take_from_region(kwargs.pop("take_region"))
+        else:
+            return None
 
-    def _init_hdf_filemanager(self, filename):
-        self._hdf_files = self._multifile_manager_class(filename, self._take_swift_cells, self._take_region)
+    def _take_from_cells(self, take_cells):
+        if take_cells is None:
+            return None
+
+        # Check if we're reading one file from a multi file snapshot
+        snap = self._hdf_files[0]
+        header = ExtractScalarWrapper(snap["Header"].attrs)
+        nr_files = header["NumFilesPerSnapshot"]
+        if len(self._hdf_files) < nr_files:
+            raise NotImplementedError("Can't use take_cells or take_region on a single sub-file")
+
+        # Validate the input cell index array
+        take_cells = np.unique(np.asarray(take_cells, dtype=int))
+        nr_cells = snap["Cells/Centres"].shape[0]
+        if np.any(take_cells < 0) or np.any(take_cells >= nr_cells):
+            raise ValueError("SWIFT cell index is out of range!")
+
+        # Compute particle indices corresponding to the selected cells
+        take = []
+        ptype_offset = 0
+        for family in self._families_ordered():
+            for name in self._family_to_group_map[family]:
+                cell_file_index = snap["Cells/Files"][name][...]
+                cell_file_offset = snap["Cells/OffsetsInFile"][name][...]
+                particles_per_cell = snap["Cells/Counts"][name][...]
+                particles_per_file = np.bincount(cell_file_index, weights=particles_per_cell, minlength=nr_files)
+                offset_to_file = np.cumsum(particles_per_file, dtype=np.int64) - particles_per_file
+                offset_to_cell = ptype_offset + offset_to_file[cell_file_index] + cell_file_offset
+                cell_offsets_to_take = offset_to_cell[take_cells]
+                cell_counts_to_take = particles_per_cell[take_cells]
+                order = np.argsort(cell_offsets_to_take)
+                for cell_count, cell_offset in zip(cell_counts_to_take[order], cell_offsets_to_take[order]):
+                    take.append(np.arange(cell_offset, cell_offset+cell_count, dtype=np.int64))
+                ptype_offset += np.sum(particles_per_cell, dtype=np.int64)
+        return np.concatenate(take)
+
+    def _take_from_region(self, take_region):
+        if take_region is None:
+            return None
+        centres = self._hdf_files[0]['Cells/Centres'][:]
+        take_cells = np.where(take_region.cubic_cell_intersection(centres))[0]
+        return self._take_from_cells(take_cells)
 
     def _is_cosmological(self):
         cosmo = ExtractScalarWrapper(self._hdf_files[0]['Cosmology'].attrs)

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -143,17 +143,6 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
     def _all_group_names(self):
         return self[0]['Cells/Counts'].keys()
 
-    def iter_particle_groups_with_name(self, hdf_family_name):
-        """
-        Swift snapshots can contain zero length datasets, which we need to skip.
-        TODO: should this be handled in GadgetHdfSnap somewhere?
-        """
-        for hdf in self:
-            if hdf_family_name in hdf:
-                if self._size_from_hdf5_key in hdf[hdf_family_name]:
-                    n = hdf[hdf_family_name][self._size_from_hdf5_key].shape[0]
-                    if n > 0:
-                        yield hdf[hdf_family_name]
 
 class ExtractScalarWrapper:
     def __init__(self, underlying):

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -13,6 +13,118 @@ from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
+    def __init__(self, filename, mode='r', take_swift_cells=None, take_region=None):
+
+        if take_swift_cells is not None and take_region is not None:
+            raise ValueError("Either take_swift_cells or take_region must be specified, not both")
+
+        filename = str(filename)
+        self._mode = mode
+        if h5py.is_hdf5(filename):
+            # We have a single file snapshot, we're reading one file from a
+            # snapshot, or we're reading the VDS file of a multi file snapshot.
+            filenames = [filename]
+            numfiles = 1
+            h1 = h5py.File(filename, mode)
+            # Don't allow reading regions from a sub-file because they might be incomplete
+            if self._get_num_files(h1) > 1 and (take_swift_cells is not None or take_region is not None):
+                raise ValueError("Cannot select part of a sub-file from a multi file snapshot")
+        else:
+            # We're reading a full set of snapshot files
+            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
+            numfiles = self._get_num_files(h1)
+            if hasattr(numfiles, "__len__"):
+                assert len(numfiles) == 1
+                numfiles = numfiles[0]
+            filenames = [self._make_filename_for_cpu(filename, i) for i in range(numfiles)]
+
+        self._read_cell_metadata(h1)
+        if take_region is not None:
+            take_swift_cells = self._identify_cells_to_take(take_region)
+        if take_swift_cells is not None:
+            take_swift_cells = np.unique(np.asarray(take_swift_cells, dtype=int))
+        self._file_mask = self._select_files(filenames, take_swift_cells)
+        self._filenames = [filename for (filename, keep) in zip(filenames, self._file_mask) if keep]
+        self._numfiles = len(self._filenames)
+        self._open_files = {}
+        self._take_swift_cells = take_swift_cells
+
+    def _select_files(self, filenames, take_swift_cells):
+        """Choose which files to open and return a boolean mask"""
+        # If we're not reading a subset, open all of the files
+        if take_swift_cells is None:
+            return np.ones(len(filenames), dtype=bool)
+
+        # Find the set of files which contain selected cells
+        required_files = set()
+        nr_parts = {}
+        for name in self._cells:
+            counts = self._cells[name]["counts"][take_swift_cells].astype(np.int64)
+            files = self._cells[name]["files"][take_swift_cells].astype(np.int64)
+            required_files = required_files.union(set(files[counts>0]))
+            # Open at least one file with a non-zero number of particles of each
+            # type, if there is one. This so that we still know that stars
+            # exist, for example, even if we picked a region without any.
+            if sum(counts) == 0:
+                files_with_type = files[np.nonzero(counts)[0]]
+                if len(files_with_type) > 0:
+                    required_files.add(files_with_type[0])
+
+        # Return the selection mask
+        mask = np.zeros(len(filenames), dtype=bool)
+        for i in required_files:
+            mask[i] = True
+        return mask
+
+    def get_take_parameter(self, families_ordered, family_to_group_map):
+        """Return the array of particle indexes to read
+        """
+        # Handle the case where we're reading everything
+        if self._take_swift_cells is None:
+            return None
+
+        # Compute particle "take" indices corresponding to the selected cells
+        take = []
+        ptype_offset = 0
+        for family in families_ordered:
+            for name in family_to_group_map[family]:
+                # Find the cell metadata
+                cell_file_index = self._cells[name]["files"]
+                cell_file_offset = self._cells[name]["offsets"]
+                particles_per_cell = self._cells[name]["counts"]
+                # Get the original number of files in the full snapshot
+                nr_files_total = np.amax(cell_file_index) + 1
+                # Treat cells in files we don't open as empty, because we're
+                # computing an index into the subset of files we opened.
+                particles_per_cell[self._file_mask[cell_file_index]==False] = 0
+                # Compute the offset to the first particle in each file in the subset.
+                # Note that the file index refers to the full set of snapshot files here.
+                particles_per_file = np.bincount(cell_file_index, weights=particles_per_cell, minlength=nr_files_total)
+                offset_to_file = np.cumsum(particles_per_file, dtype=np.int64) - particles_per_file
+                # Compute the offset to the first particle in each cell
+                offset_to_cell = ptype_offset + offset_to_file[cell_file_index] + cell_file_offset
+                # Extract offsets and lengths of the selected subsets of cells
+                cell_offsets_to_take = offset_to_cell[self._take_swift_cells]
+                cell_counts_to_take = particles_per_cell[self._take_swift_cells]
+                # Construct a sorted array of particle indexes to take
+                order = np.argsort(cell_offsets_to_take)
+                for cell_count, cell_offset in zip(cell_counts_to_take[order], cell_offsets_to_take[order]):
+                    take.append(np.arange(cell_offset, cell_offset+cell_count, dtype=np.int64))
+                ptype_offset += np.sum(particles_per_cell, dtype=np.int64)
+        return np.concatenate(take)
+
+    def _read_cell_metadata(self, h1):
+        self._cells = {}
+        for name in h1["Cells/Counts"]:
+            self._cells[name] = {}
+            self._cells[name]["counts"] = h1["Cells/Counts"][name][...]
+            self._cells[name]["files"] = h1["Cells/Files"][name][...]
+            self._cells[name]["offsets"] = h1["Cells/OffsetsInFile"][name][...]
+        self._cell_centres = h1["Cells/Centres"][...]
+
+    def _identify_cells_to_take(self, take):
+        return np.where(take.cubic_cell_intersection(self._cell_centres))[0]
+
     def get_unit_attrs(self):
         return self[0].parent['InternalCodeUnits'].attrs
 
@@ -51,61 +163,22 @@ class SwiftSnap(GadgetHDFSnap):
 
     _namemapper_config_section = 'swift-name-mapping'
 
+    def __init__(self, filename, take_swift_cells=None, take_region=None):
+        """Initialise a SWIFT snapshot.
+
+        Extra parameters can be passed to the multi file manager by
+        storing them here and overriding the _init_hdf_filemanager
+        method.
+        """
+        self._take_swift_cells = take_swift_cells
+        self._take_region = take_region
+        super().__init__(filename)
+
+    def _init_hdf_filemanager(self, filename):
+        self._hdf_files = self._multifile_manager_class(filename, take_swift_cells=self._take_swift_cells, take_region=self._take_region)
 
     def _get_take_parameter(self, **kwargs):
-        if len({"take", "take_swift_region", "take_swift_cells"} & kwargs.keys()) > 1:
-            raise ValueError("Can only specify one of take, take_cells or take_region")
-        if "take" in kwargs:
-            return kwargs.pop("take")
-        elif "take_swift_cells" in kwargs:
-            return self._take_from_cells(kwargs.pop("take_swift_cells"))
-        elif "take_region" in kwargs:
-            return self._take_from_region(kwargs.pop("take_region"))
-        else:
-            return None
-
-    def _take_from_cells(self, take_cells):
-        if take_cells is None:
-            return None
-
-        # Check if we're reading one file from a multi file snapshot
-        snap = self._hdf_files[0]
-        header = ExtractScalarWrapper(snap["Header"].attrs)
-        nr_files = header["NumFilesPerSnapshot"]
-        if len(self._hdf_files) < nr_files:
-            raise NotImplementedError("Can't use take_cells or take_region on a single sub-file")
-
-        # Validate the input cell index array
-        take_cells = np.unique(np.asarray(take_cells, dtype=int))
-        nr_cells = snap["Cells/Centres"].shape[0]
-        if np.any(take_cells < 0) or np.any(take_cells >= nr_cells):
-            raise ValueError("SWIFT cell index is out of range!")
-
-        # Compute particle indices corresponding to the selected cells
-        take = []
-        ptype_offset = 0
-        for family in self._families_ordered():
-            for name in self._family_to_group_map[family]:
-                cell_file_index = snap["Cells/Files"][name][...]
-                cell_file_offset = snap["Cells/OffsetsInFile"][name][...]
-                particles_per_cell = snap["Cells/Counts"][name][...]
-                particles_per_file = np.bincount(cell_file_index, weights=particles_per_cell, minlength=nr_files)
-                offset_to_file = np.cumsum(particles_per_file, dtype=np.int64) - particles_per_file
-                offset_to_cell = ptype_offset + offset_to_file[cell_file_index] + cell_file_offset
-                cell_offsets_to_take = offset_to_cell[take_cells]
-                cell_counts_to_take = particles_per_cell[take_cells]
-                order = np.argsort(cell_offsets_to_take)
-                for cell_count, cell_offset in zip(cell_counts_to_take[order], cell_offsets_to_take[order]):
-                    take.append(np.arange(cell_offset, cell_offset+cell_count, dtype=np.int64))
-                ptype_offset += np.sum(particles_per_cell, dtype=np.int64)
-        return np.concatenate(take)
-
-    def _take_from_region(self, take_region):
-        if take_region is None:
-            return None
-        centres = self._hdf_files[0]['Cells/Centres'][:]
-        take_cells = np.where(take_region.cubic_cell_intersection(centres))[0]
-        return self._take_from_cells(take_cells)
+        return self._hdf_files.get_take_parameter(list(self._families_ordered()), self._family_to_group_map)
 
     def _is_cosmological(self):
         cosmo = ExtractScalarWrapper(self._hdf_files[0]['Cosmology'].attrs)

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -57,7 +57,6 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
         # Find the set of files which contain selected cells
         required_files = set()
-        nr_parts = {}
         for name in self._cells:
             counts = self._cells[name]["counts"][take_swift_cells].astype(np.int64)
             files = self._cells[name]["files"][take_swift_cells].astype(np.int64)
@@ -95,7 +94,7 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 # Find the cell metadata
                 cell_file_index = self._cells[name]["files"]
                 cell_file_offset = self._cells[name]["offsets"]
-                particles_per_cell = self._cells[name]["counts"]
+                particles_per_cell = self._cells[name]["counts"].copy()
                 # Get the original number of files in the full snapshot
                 nr_files_total = np.amax(cell_file_index) + 1
                 # Treat cells in files we don't open as empty, because we're

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -62,18 +62,22 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
             counts = self._cells[name]["counts"][take_swift_cells].astype(np.int64)
             files = self._cells[name]["files"][take_swift_cells].astype(np.int64)
             required_files = required_files.union(set(files[counts>0]))
-            # Open at least one file with a non-zero number of particles of each
-            # type, if there is one. This so that we still know that stars
-            # exist, for example, even if we picked a region without any.
+            # Gadget and older Swift versions completely omit particle type
+            # groups which would contain zero particles. We don't want to be
+            # missing a particle type just because the selected region happens
+            # not to contain that type, so ensure we open a file containing at
+            # least one particle of the current type. This also prevents us
+            # from opening zero files when no particles are in the region.
             if sum(counts) == 0:
-                files_with_type = files[np.nonzero(counts)[0]]
+                all_counts = self._cells[name]["counts"]
+                all_files = self._cells[name]["files"]
+                files_with_type = np.unique(all_files[all_counts>0])
                 if len(files_with_type) > 0:
                     required_files.add(files_with_type[0])
 
-        # Return the selection mask
+        # Return the file selection mask
         mask = np.zeros(len(filenames), dtype=bool)
-        for i in required_files:
-            mask[i] = True
+        mask[list(required_files)] = True
         return mask
 
     def get_take_parameter(self, families_ordered, family_to_group_map):
@@ -111,7 +115,7 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 for cell_count, cell_offset in zip(cell_counts_to_take[order], cell_offsets_to_take[order]):
                     take.append(np.arange(cell_offset, cell_offset+cell_count, dtype=np.int64))
                 ptype_offset += np.sum(particles_per_cell, dtype=np.int64)
-        return np.concatenate(take)
+        return np.concatenate(take) if len(take) > 0 else np.zeros(0, dtype=np.int64)
 
     def _read_cell_metadata(self, h1):
         self._cells = {}

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -96,7 +96,8 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 particles_per_cell[self._file_mask[cell_file_index]==False] = 0
                 # Compute the offset to the first particle in each file in the subset.
                 # Note that the file index refers to the full set of snapshot files here.
-                particles_per_file = np.bincount(cell_file_index, weights=particles_per_cell, minlength=nr_files_total)
+                particles_per_file = np.zeros(nr_files_total, dtype=np.int64)
+                np.add.at(particles_per_file, cell_file_index, particles_per_cell)
                 offset_to_file = np.cumsum(particles_per_file, dtype=np.int64) - particles_per_file
                 # Compute the offset to the first particle in each cell
                 offset_to_cell = ptype_offset + offset_to_file[cell_file_index] + cell_file_offset

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -308,3 +308,11 @@ class SwiftSnap(GadgetHDFSnap):
                 return GadgetHDFSnap._get_hdf_allarray_keys(group)
         else:
             raise ValueError(f"The expected NumberOfFields attribute of group {group.name} is not present")
+
+    def write_array(self, *args, **kwargs):
+        """
+        We can't yet write arrays if we selected a region or cells
+        """
+        if self._take_region is not None or self._take_swift_cells is not None:
+            raise NotImplementedError("Unable to write array to a selected region or cells")
+        super().write_array(*args, **kwargs)

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -316,3 +316,10 @@ class SwiftSnap(GadgetHDFSnap):
         if self._take_region is not None or self._take_swift_cells is not None:
             raise NotImplementedError("Unable to write array to a selected region or cells")
         super().write_array(*args, **kwargs)
+
+    def _update_group_attributes_on_write(self, hdf):
+        """
+        Update group's NumberOfFields attribute on writing an array
+        """
+        if "NumberOfFields" in hdf.attrs:
+            hdf.attrs.modify("NumberOfFields", (len(hdf),))

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,3 +1,5 @@
+import functools
+
 import h5py
 import numpy as np
 
@@ -278,6 +280,7 @@ class SwiftSnap(GadgetHDFSnap):
         if "NumberOfFields" in group.attrs and group.attrs["NumberOfFields"][0] == len(group):
             return list(group.keys())
         else:
+            return GadgetHDFSnap._get_hdf_allarray_keys(group)
             keys = []
             def _append_if_array(to_list, name, obj):
                 if not hasattr(obj, 'keys'):

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,9 +1,3 @@
-import os
-import pathlib
-import shutil
-import tempfile
-import weakref
-
 import h5py
 import numpy as np
 

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -266,12 +266,15 @@ class SwiftSnap(GadgetHDFSnap):
 
     @staticmethod
     def _get_hdf_allarray_keys(group):
-        """Return all HDF array keys underneath group (includes nested groups)
+        """
+        Return all HDF array keys underneath group (includes nested groups)
 
         Swift snapshots do not have nested groups in the PartTypeX groups and
         checking the type of every key can be slow when there are many keys.
-        Here we assume that all keys in the PartTypeX groups are datasets."""
-        if group.name.startswith("/PartType"):
+        Here we assume that if the number of keys matches the number of datasets
+        from the group's attributes, then all of the keys must be datasets.
+        """
+        if "NumberOfFields" in group.attrs and group.attrs["NumberOfFields"][0] == len(group):
             return list(group.keys())
         else:
             keys = []

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -11,42 +11,34 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
     def __init__(self, filename, mode='r', take_swift_cells=None, take_region=None):
 
+        super().__init__(filename, mode)
+
         if take_swift_cells is not None and take_region is not None:
             raise ValueError("Either take_swift_cells or take_region must be specified, not both")
 
-        filename = str(filename)
-        self._mode = mode
-        if h5py.is_hdf5(filename):
-            # We have a single file snapshot, we're reading one file from a
-            # snapshot, or we're reading the VDS file of a multi file snapshot.
-            filenames = [filename]
-            numfiles = 1
-            h1 = h5py.File(filename, mode)
-            # Don't allow reading regions from a sub-file because they might be incomplete
-            if self._get_num_files(h1) > 1 and (take_swift_cells is not None or take_region is not None):
-                raise ValueError("Cannot select part of a sub-file from a multi file snapshot")
-        else:
-            # We're reading a full set of snapshot files
-            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
-            numfiles = self._get_num_files(h1)
-            if hasattr(numfiles, "__len__"):
-                assert len(numfiles) == 1
-                numfiles = numfiles[0]
-            filenames = [self._make_filename_for_cpu(filename, i) for i in range(numfiles)]
+        # We can only cut out regions or cells if we're reading all files in the set
+        file0 = self[0] # the file might already have been opened
+        if self._get_num_files(file0) != len(self._filenames) and (take_swift_cells is not None or take_region is not None):
+            raise ValueError("Cannot select part of a sub-file from a multi file snapshot")
 
-        # Only read cell metadata if we need it (e.g. the planetary example
-        # does not have valid cell info)
+        # Determine which cells we need. Avoid reading cells if we don't
+        # need them in case the snapshot doesn't have valid metadata (e.g.
+        # the planetary example in the test data).
         if take_region is not None or take_swift_cells is not None:
-            self._read_cell_metadata(h1)
+            self._read_cell_metadata(file0)
             if take_region is not None:
                 take_swift_cells = self._identify_cells_to_take(take_region)
             if take_swift_cells is not None:
                 take_swift_cells = np.unique(np.asarray(take_swift_cells, dtype=int))
-        self._file_mask = self._select_files(filenames, take_swift_cells)
-        self._filenames = [filename for (filename, keep) in zip(filenames, self._file_mask) if keep]
-        self._numfiles = len(self._filenames)
-        self._open_files = {}
         self._take_swift_cells = take_swift_cells
+
+        # Determine which files we need to read
+        self._file_mask = self._select_files(self._filenames, take_swift_cells)
+
+        # Discard the files we're not reading
+        self._filenames = [filename for (filename, keep) in zip(self._filenames, self._file_mask) if keep]
+        self._numfiles = len(self._filenames)
+        self._open_files = {0: file0} if self._file_mask[0] else {}
 
     def _select_files(self, filenames, take_swift_cells):
         """Choose which files to open and return a boolean mask"""

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,5 +1,3 @@
-import functools
-
 import h5py
 import numpy as np
 
@@ -274,16 +272,13 @@ class SwiftSnap(GadgetHDFSnap):
 
         Swift snapshots do not have nested groups in the PartTypeX groups and
         checking the type of every key can be slow when there are many keys.
-        Here we assume that if the number of keys matches the number of datasets
-        from the group's attributes, then all of the keys must be datasets.
+        Here we check that we have the expected number of keys (given by the
+        NumberOfFields attribute) and assume that they're all datasets.
         """
-        if "NumberOfFields" in group.attrs and group.attrs["NumberOfFields"][0] == len(group):
-            return list(group.keys())
+        if "NumberOfFields" in group.attrs:
+            if group.attrs["NumberOfFields"][0] == len(group):
+                return list(group.keys())
+            else:
+                raise ValueError(f"The NumberOfFields attribute of group {group.name} does not match the number of keys in the group")
         else:
-            return GadgetHDFSnap._get_hdf_allarray_keys(group)
-            keys = []
-            def _append_if_array(to_list, name, obj):
-                if not hasattr(obj, 'keys'):
-                    to_list.append(name)
-            group.visititems(functools.partial(_append_if_array, keys))
-            return keys
+            raise ValueError(f"The expected NumberOfFields attribute of group {group.name} is not present")

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -128,6 +128,8 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
             self._cells[name]["files"] = h1["Cells/Files"][name][...]
             self._cells[name]["offsets"] = h1["Cells/OffsetsInFile"][name][...]
             # Do some sanity checks
+            if np.all(self._cells[name]["counts"] == 0):
+                raise ValueError("No spatial index found in this snapshot; unable to load a region.")
             if np.any(self._cells[name]["counts"] < 0):
                 raise ValueError("A SWIFT cell contains a negative number of particles!")
             if np.any((self._cells[name]["files"] < 0) | (self._cells[name]["files"] >= num_files)):

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,3 +1,5 @@
+import re
+
 import h5py
 import numpy as np
 
@@ -32,11 +34,14 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 numfiles = numfiles[0]
             filenames = [self._make_filename_for_cpu(filename, i) for i in range(numfiles)]
 
-        self._read_cell_metadata(h1)
-        if take_region is not None:
-            take_swift_cells = self._identify_cells_to_take(take_region)
-        if take_swift_cells is not None:
-            take_swift_cells = np.unique(np.asarray(take_swift_cells, dtype=int))
+        # Only read cell metadata if we need it (e.g. the planetary example
+        # does not have valid cell info)
+        if take_region is not None or take_swift_cells is not None:
+            self._read_cell_metadata(h1)
+            if take_region is not None:
+                take_swift_cells = self._identify_cells_to_take(take_region)
+            if take_swift_cells is not None:
+                take_swift_cells = np.unique(np.asarray(take_swift_cells, dtype=int))
         self._file_mask = self._select_files(filenames, take_swift_cells)
         self._filenames = [filename for (filename, keep) in zip(filenames, self._file_mask) if keep]
         self._numfiles = len(self._filenames)
@@ -112,12 +117,35 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
         return np.concatenate(take) if len(take) > 0 else np.zeros(0, dtype=np.int64)
 
     def _read_cell_metadata(self, h1):
+        num_files = self._get_num_files(h1)
+        numpart_total = (h1["Header"].attrs["NumPart_Total"].astype(np.int64) +
+                         (h1["Header"].attrs["NumPart_Total_HighWord"].astype(np.int64) << 32))
         self._cells = {}
         for name in h1["Cells/Counts"]:
+            # Get the total number of particles of this type. Read the header
+            # because the PartType group might not be present if this sub-file
+            # happens to contain zero particles.
+            m = re.match(r"PartType([0-9]+)", name)
+            if m is None:
+                raise ValueError(f"Unexpected particle group name: {name}")
+            else:
+                nptot = numpart_total[int(m.group(1))]
+            # Read the cell information
             self._cells[name] = {}
             self._cells[name]["counts"] = h1["Cells/Counts"][name][...]
             self._cells[name]["files"] = h1["Cells/Files"][name][...]
             self._cells[name]["offsets"] = h1["Cells/OffsetsInFile"][name][...]
+            # Do some sanity checks
+            if np.any(self._cells[name]["counts"] < 0):
+                raise ValueError("A SWIFT cell contains a negative number of particles!")
+            if np.any((self._cells[name]["files"] < 0) | (self._cells[name]["files"] >= num_files)):
+                raise ValueError("A SWIFT cell's file index is out of range!")
+            if np.any(self._cells[name]["offsets"] < 0):
+                raise ValueError("A SWIFT cell offset is negative!")
+            if np.any((self._cells[name]["offsets"] + self._cells[name]["counts"]) > nptot):
+                raise ValueError("A SWIFT cell's offset+count is out of range")
+            if np.sum(self._cells[name]["counts"], dtype=np.int64) != nptot:
+                raise ValueError("The total number of particles in all cells does not match the snapshot header")
         self._cell_centres = h1["Cells/Centres"][...]
 
     def _identify_cells_to_take(self, take):

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import h5py
 import numpy as np
@@ -301,6 +302,9 @@ class SwiftSnap(GadgetHDFSnap):
             if group.attrs["NumberOfFields"][0] == len(group):
                 return list(group.keys())
             else:
-                raise ValueError(f"The NumberOfFields attribute of group {group.name} does not match the number of keys in the group")
+                # NumberOfFields can be wrong if we wrote a new field to the snapshot, for example.
+                warnings.warn(f"The NumberOfFields attribute of group {group.name} does not match the number of keys in the group",
+                              RuntimeWarning)
+                return GadgetHDFSnap._get_hdf_allarray_keys(group)
         else:
             raise ValueError(f"The expected NumberOfFields attribute of group {group.name} is not present")

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -263,3 +263,20 @@ class SwiftSnap(GadgetHDFSnap):
             return halo.number_array.HaloNumberCatalogue(self, ignore=ignore, **kwargs)
 
         return h
+
+    @staticmethod
+    def _get_hdf_allarray_keys(group):
+        """Return all HDF array keys underneath group (includes nested groups)
+
+        Swift snapshots do not have nested groups in the PartTypeX groups and
+        checking the type of every key can be slow when there are many keys.
+        Here we assume that all keys in the PartTypeX groups are datasets."""
+        if group.name.startswith("/PartType"):
+            return list(group.keys())
+        else:
+            keys = []
+            def _append_if_array(to_list, name, obj):
+                if not hasattr(obj, 'keys'):
+                    to_list.append(name)
+            group.visititems(functools.partial(_append_if_array, keys))
+            return keys

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -139,10 +139,22 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
     input_snap.close()
 
 
-def hash_swift_cell_coordinates(filename):
-    """Hash the coordinates of particles in each cell in sequence. This hash
-    should not be affected by splitting a snapshot into multiple files,
-    assuming the input did not use lossy compression.
+def hash_swift_cell_coordinates(filename, cell_mask=None):
+    """
+    Hash the coordinates of particles in each cell in sequence.
+
+    This hash should not be affected by splitting a snapshot into multiple
+    files, assuming the input did not use lossy compression.
+
+    Parameters
+    ----------
+
+    filename: pathlib.Path or str
+        Name of a file from the snapshot
+    cell_mask: dict
+        Dict where the keys are particle type names (PartTypeX) and the
+        values are boolean masks indicating which cells to hash for that
+        particle type.
     """
     with h5py.File(filename, "r") as f0:
         nr_files = f0["Header"].attrs["NumFilesPerSnapshot"][0]
@@ -160,7 +172,7 @@ def hash_swift_cell_coordinates(filename):
     # Open all of the files
     snap_file = [h5py.File(filename, "r") for filename in filenames]
 
-    # For each cell, read the particle coordinates and add them to the hash
+    # For each selected cell, read the particle coordinates and add them to the hash
     import hashlib
     m = hashlib.sha256()
     ptypes = sorted(list(snap_file[0]["Cells/Counts"]))
@@ -168,13 +180,21 @@ def hash_swift_cell_coordinates(filename):
         cell_file_index = snap_file[0]["Cells/Files"][ptype][...]
         cell_offsets = snap_file[0]["Cells/OffsetsInFile"][ptype][...]
         cell_counts = snap_file[0]["Cells/Counts"][ptype][...]
-        all_coords = [snap_file[file_nr][ptype]["Coordinates"][...] for file_nr in range(nr_files)]
+        if cell_mask is not None:
+            cell_counts[cell_mask[ptype]==False] = 0 # skip masked out cells
+        all_coords = []
+        for file_nr in range(nr_files):
+            if ptype in snap_file[file_nr]:
+                all_coords.append(snap_file[file_nr][ptype]["Coordinates"][...])
+            else:
+                all_coords.append(None)
         for cell_nr in range(nr_cells):
             file_nr = cell_file_index[cell_nr]
             offset = cell_offsets[cell_nr]
             count = cell_counts[cell_nr]
-            pos = all_coords[file_nr][offset:offset+count,...]
-            m.update(pos)
+            if count > 0:
+                pos = all_coords[file_nr][offset:offset+count,...]
+                m.update(pos)
 
     for f in snap_file:
         f.close()

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -4,6 +4,13 @@ import h5py
 import numpy as np
 
 
+def _update_array_attribute(obj, attr_name, index, value):
+    """Update an element in a HDF5 object array attribute"""
+    data = obj.attrs[attr_name]
+    data[index] = value
+    obj.attrs.modify(attr_name, data)
+
+
 def split_swift_snapshot(template_file, nr_files, cell_file_index,
                          output_name):
     """
@@ -11,6 +18,12 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
     multi-file snapshot by assigning cells to files using cell_file_index.
     """
     input_snap = h5py.File(template_file, "r")
+
+    # Remove any .X.hdf5 suffix from the output name
+    output_name = str(output_name)
+    m = re.match(r"^(.*)\.[0-9]+\.hdf5", output_name)
+    if m is not None:
+        output_name = m.group(1)
 
     # Get list of particle types and cell metadata
     ptypes = list(input_snap["Cells/Counts"])
@@ -35,7 +48,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             file_nr = cell_file_index[cell_nr]
             cell_output_offsets[ptype][cell_nr] = particles_in_file[file_nr]
             particles_in_file[file_nr] += cell_counts[ptype][cell_nr]
-        assert particles_in_file[file_nr] == input_snap[ptype].attrs["NumberOfParticles"][0]
+        assert sum(particles_in_file) == input_snap[ptype].attrs["NumberOfParticles"][0]
 
     # Loop over output files to create
     for file_nr in range(nr_files):
@@ -45,7 +58,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
         for name, h5obj in input_snap.items():
             if not name.startswith("PartType"):
                 input_snap.copy(name, output_snap)
-        output_snap["Header"].attrs["NumFilesPerSnapshot"][0] = nr_files
+        output_snap["Header"].attrs.modify("NumFilesPerSnapshot", nr_files)
 
         # Loop over particle types
         for ptype in ptypes:
@@ -60,15 +73,15 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             group = output_snap.create_group(ptype)
             for attr_name, attr_val in input_snap[ptype].attrs.items():
                 group.attrs[attr_name] = attr_val
-            group.attrs["NumberOfParticles"] = nr_particles
-            group.attrs["TotalNumberOfParticles"] = total_nr_particles
+            group.attrs.modify("NumberOfParticles", nr_particles)
+            group.attrs.modify("TotalNumberOfParticles", total_nr_particles)
 
             # Update header attributes for this type
             index = int(ptype[-1])
             assert f"PartType{index}" == ptype
-            output_snap["Header"].attrs["NumPart_ThisFile"][index] = nr_particles
-            output_snap["Header"].attrs["NumPart_Total"][index] = total_nr_particles
-            output_snap["Header"].attrs["NumPart_Total_HighWord"][index] = 0
+            _update_array_attribute(output_snap["Header"], "NumPart_ThisFile", index, nr_particles)
+            _update_array_attribute(output_snap["Header"], "NumPart_Total", index, total_nr_particles)
+            _update_array_attribute(output_snap["Header"], "NumPart_Total_HighWord", index, 0)
 
             # Update cell metadata
             output_snap["Cells/OffsetsInFile"][ptype][...] = cell_output_offsets[ptype]
@@ -80,7 +93,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
                 assert isinstance(input_dset, h5py.Dataset)
                 shape = list(input_dset.shape)
                 shape[0] = nr_particles
-                output_dset = output_snap[ptype].create_dataset_like(name, input_dset, shape=shape)
+                output_dset = output_snap[ptype].create_dataset_like(name, input_dset, shape=shape, chunks=None)
                 for attr_name, attr_val in input_dset.attrs.items():
                     output_dset.attrs[attr_name] = attr_val
                 for input_offset, output_offset, count in zip(cell_input_offsets[ptype][cell_file_index==file_nr],
@@ -103,6 +116,7 @@ def hash_swift_cell_coordinates(filename):
         nr_cells = f0["Cells/Centres"].shape[0]
 
     # Get the full list of filenames
+    filename = str(filename)
     if nr_files == 1:
         filenames = [filename,]
     else:

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -69,16 +69,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
 
             # Count particles of this type in this file
             nr_particles = sum(cell_counts[ptype][cell_file_index==file_nr])
-            if nr_particles == 0:
-                continue
             total_nr_particles = sum(cell_counts[ptype])
-
-            # Create the PartType group
-            group = output_snap.create_group(ptype)
-            for attr_name, attr_val in input_snap[ptype].attrs.items():
-                group.attrs[attr_name] = attr_val
-            group.attrs.modify("NumberOfParticles", nr_particles)
-            group.attrs.modify("TotalNumberOfParticles", total_nr_particles)
 
             # Update header attributes for this type
             index = int(ptype[-1])
@@ -90,6 +81,17 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             # Update cell metadata
             output_snap["Cells/OffsetsInFile"][ptype][...] = cell_output_offsets[ptype]
             output_snap["Cells/Files"][ptype][...] = cell_file_index
+
+            # If there are no particles of this type in this file, don't create the PartType group or datasets
+            if nr_particles == 0:
+                continue
+
+            # Create the PartType group
+            group = output_snap.create_group(ptype)
+            for attr_name, attr_val in input_snap[ptype].attrs.items():
+                group.attrs[attr_name] = attr_val
+            group.attrs.modify("NumberOfParticles", nr_particles)
+            group.attrs.modify("TotalNumberOfParticles", total_nr_particles)
 
             # Copy dataset contents and attributes
             for name in input_snap[ptype]:

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -81,6 +81,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             # Update cell metadata
             output_snap["Cells/OffsetsInFile"][ptype][...] = cell_output_offsets[ptype]
             output_snap["Cells/Files"][ptype][...] = cell_file_index
+            output_snap["Cells/Counts"][ptype][...] = cell_counts[ptype]
 
             # If there are no particles of this type in this file, don't create the PartType group or datasets
             if nr_particles == 0:

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -12,7 +12,7 @@ def _update_array_attribute(obj, attr_name, index, value):
 
 
 def split_swift_snapshot(template_file, nr_files, cell_file_index,
-                         output_name):
+                         output_name, cell_mask=None):
     """
     Given a single file SWIFT snapshot at path template_file, write a new,
     multi-file snapshot by assigning cells to files using cell_file_index.
@@ -35,6 +35,11 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
         # Here we assume that the cells are sorted by offset in the input snapshot
         assert np.all(cell_input_offsets[ptype][1:] >= cell_input_offsets[ptype][:-1])
 
+    # If a cell mask is specified, discard cells which are not selected
+    if cell_mask is not None:
+        for ptype in cell_mask:
+            cell_counts[ptype][cell_mask[ptype]==False] = 0
+
     # Check total number of cells
     nr_cells = len(cell_file_index)
     assert nr_cells == input_snap["Cells/Centres"].shape[0]
@@ -48,7 +53,6 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             file_nr = cell_file_index[cell_nr]
             cell_output_offsets[ptype][cell_nr] = particles_in_file[file_nr]
             particles_in_file[file_nr] += cell_counts[ptype][cell_nr]
-        assert sum(particles_in_file) == input_snap[ptype].attrs["NumberOfParticles"][0]
 
     # Loop over output files to create
     for file_nr in range(nr_files):

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -1,0 +1,135 @@
+import re
+
+import h5py
+import numpy as np
+
+
+def split_swift_snapshot(template_file, nr_files, cell_file_index,
+                         output_name):
+    """
+    Given a single file SWIFT snapshot at path template_file, write a new,
+    multi-file snapshot by assigning cells to files using cell_file_index.
+    """
+    input_snap = h5py.File(template_file, "r")
+
+    # Get list of particle types and cell metadata
+    ptypes = list(input_snap["Cells/Counts"])
+    cell_counts = {}
+    cell_input_offsets = {}
+    for ptype in ptypes:
+        cell_counts[ptype] = input_snap["Cells/Counts"][ptype][...]
+        cell_input_offsets[ptype] = input_snap["Cells/OffsetsInFile"][ptype][...]
+        # Here we assume that the cells are sorted by offset in the input snapshot
+        assert np.all(cell_input_offsets[ptype][1:] >= cell_input_offsets[ptype][:-1])
+
+    # Check total number of cells
+    nr_cells = len(cell_file_index)
+    assert nr_cells == input_snap["Cells/Centres"].shape[0]
+
+    # Compute the offset to each cell in the output files
+    cell_output_offsets = {}
+    for ptype in ptypes:
+        cell_output_offsets[ptype] = np.zeros(nr_cells, dtype=np.int64)
+        particles_in_file = np.zeros(nr_files, dtype=int)
+        for cell_nr in range(nr_cells):
+            file_nr = cell_file_index[cell_nr]
+            cell_output_offsets[ptype][cell_nr] = particles_in_file[file_nr]
+            particles_in_file[file_nr] += cell_counts[ptype][cell_nr]
+        assert particles_in_file[file_nr] == input_snap[ptype].attrs["NumberOfParticles"][0]
+
+    # Loop over output files to create
+    for file_nr in range(nr_files):
+        output_snap = h5py.File(f"{output_name}.{file_nr}.hdf5", "w")
+
+        # Copy everything except the particle data arrays to the output
+        for name, h5obj in input_snap.items():
+            if not name.startswith("PartType"):
+                input_snap.copy(name, output_snap)
+        output_snap["Header"].attrs["NumFilesPerSnapshot"][0] = nr_files
+
+        # Loop over particle types
+        for ptype in ptypes:
+
+            # Count particles of this type in this file
+            nr_particles = sum(cell_counts[ptype][cell_file_index==file_nr])
+            if nr_particles == 0:
+                continue
+            total_nr_particles = sum(cell_counts[ptype])
+
+            # Create the PartType group
+            group = output_snap.create_group(ptype)
+            for attr_name, attr_val in input_snap[ptype].attrs.items():
+                group.attrs[attr_name] = attr_val
+            group.attrs["NumberOfParticles"] = nr_particles
+            group.attrs["TotalNumberOfParticles"] = total_nr_particles
+
+            # Update header attributes for this type
+            index = int(ptype[-1])
+            assert f"PartType{index}" == ptype
+            output_snap["Header"].attrs["NumPart_ThisFile"][index] = nr_particles
+            output_snap["Header"].attrs["NumPart_Total"][index] = total_nr_particles
+            output_snap["Header"].attrs["NumPart_Total_HighWord"][index] = 0
+
+            # Update cell metadata
+            output_snap["Cells/OffsetsInFile"][ptype][...] = cell_output_offsets[ptype]
+            output_snap["Cells/Files"][ptype][...] = cell_file_index
+
+            # Copy dataset contents and attributes
+            for name in input_snap[ptype]:
+                input_dset = input_snap[ptype][name]
+                assert isinstance(input_dset, h5py.Dataset)
+                shape = list(input_dset.shape)
+                shape[0] = nr_particles
+                output_dset = output_snap[ptype].create_dataset_like(name, input_dset, shape=shape)
+                for attr_name, attr_val in input_dset.attrs.items():
+                    output_dset.attrs[attr_name] = attr_val
+                for input_offset, output_offset, count in zip(cell_input_offsets[ptype][cell_file_index==file_nr],
+                                                              cell_output_offsets[ptype][cell_file_index==file_nr],
+                                                              cell_counts[ptype][cell_file_index==file_nr]):
+                    output_dset[output_offset:output_offset+count,...] = input_dset[input_offset:input_offset+count,...]
+
+        output_snap.close()
+
+    input_snap.close()
+
+
+def hash_swift_cell_coordinates(filename):
+    """Hash the coordinates of particles in each cell in sequence. This hash
+    should not be affected by splitting a snapshot into multiple files,
+    assuming the input did not use lossy compression.
+    """
+    with h5py.File(filename, "r") as f0:
+        nr_files = f0["Header"].attrs["NumFilesPerSnapshot"][0]
+        nr_cells = f0["Cells/Centres"].shape[0]
+
+    # Get the full list of filenames
+    if nr_files == 1:
+        filenames = [filename,]
+    else:
+        m = re.match(r"^(.*)\.[0-9]+\.hdf5", filename)
+        assert m is not None
+        filenames = [f"{m.group(1)}.{file_nr}.hdf5" for file_nr in range(nr_files)]
+
+    # Open all of the files
+    snap_file = [h5py.File(filename, "r") for filename in filenames]
+
+    # For each cell, read the particle coordinates and add them to the hash
+    import hashlib
+    m = hashlib.sha256()
+    ptypes = sorted(list(snap_file[0]["Cells/Counts"]))
+    for ptype in ptypes:
+        cell_file_index = snap_file[0]["Cells/Files"][ptype][...]
+        cell_offsets = snap_file[0]["Cells/OffsetsInFile"][ptype][...]
+        cell_counts = snap_file[0]["Cells/Counts"][ptype][...]
+        all_coords = [snap_file[file_nr][ptype]["Coordinates"][...] for file_nr in range(nr_files)]
+        for cell_nr in range(nr_cells):
+            file_nr = cell_file_index[cell_nr]
+            offset = cell_offsets[cell_nr]
+            count = cell_counts[cell_nr]
+            pos = all_coords[file_nr][offset:offset+count,...]
+            m.update(pos)
+
+    for f in snap_file:
+        f.close()
+
+    return m.hexdigest()

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -96,17 +96,23 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
 
             # Copy dataset contents and attributes
             for name in input_snap[ptype]:
+                # Open and read the input dataset
                 input_dset = input_snap[ptype][name]
                 assert isinstance(input_dset, h5py.Dataset)
                 shape = list(input_dset.shape)
                 shape[0] = nr_particles
-                output_dset = output_snap[ptype].create_dataset_like(name, input_dset, shape=shape, chunks=None)
-                for attr_name, attr_val in input_dset.attrs.items():
-                    output_dset.attrs[attr_name] = attr_val
+                input_data = input_dset[...]
+                # Create and populate the output array
+                output_data = np.empty_like(input_data, shape=shape)
                 for input_offset, output_offset, count in zip(cell_input_offsets[ptype][cell_file_index==file_nr],
                                                               cell_output_offsets[ptype][cell_file_index==file_nr],
                                                               cell_counts[ptype][cell_file_index==file_nr]):
-                    output_dset[output_offset:output_offset+count,...] = input_dset[input_offset:input_offset+count,...]
+                    output_data[output_offset:output_offset+count,...] = input_data[input_offset:input_offset+count,...]
+                # Write the output dataset
+                output_dset = output_snap[ptype].create_dataset_like(name, input_dset, shape=shape, chunks=None)
+                output_dset[...] = output_data
+                for attr_name, attr_val in input_dset.attrs.items():
+                    output_dset.attrs[attr_name] = attr_val
 
         output_snap.close()
 

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -12,10 +12,30 @@ def _update_array_attribute(obj, attr_name, index, value):
 
 
 def split_swift_snapshot(template_file, nr_files, cell_file_index,
-                         output_name, cell_mask=None):
+                         output_name, cell_mask=None,
+                         write_zero_size_datasets=False):
     """
     Given a single file SWIFT snapshot at path template_file, write a new,
     multi-file snapshot by assigning cells to files using cell_file_index.
+
+    Parameters
+    ----------
+    template_file : pathlib.Path or str
+        Name of a single file Swift snapshot to use as a template
+    nr_files: int
+        The number of files to split the template snapshot into
+    cell_file_index: numpy.ndarray
+        Array with a file index to assign each cell to
+    output_name: pathlib.Path or str
+        Name of the output files. Any .X.hdf5 suffix will be replaced.
+    cell_mask: dict
+        Dict where the keys are particle type names (PartTypeX) and the
+        values are boolean masks indicating which cells to keep for that
+        particle type.
+    write_zero_size_datasets: bool
+        If False, datasets which would have zero particles are omitted
+        (as in older Swift versions). If True, all datasets are always
+        written regardless of size (current Swift behaviour).
     """
     input_snap = h5py.File(template_file, "r")
 
@@ -84,7 +104,7 @@ def split_swift_snapshot(template_file, nr_files, cell_file_index,
             output_snap["Cells/Counts"][ptype][...] = cell_counts[ptype]
 
             # If there are no particles of this type in this file, don't create the PartType group or datasets
-            if nr_particles == 0:
+            if nr_particles == 0 and not write_zero_size_datasets:
                 continue
 
             # Create the PartType group

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -211,7 +211,6 @@ def staging_dir(final_path):
     final_path.parent.mkdir(exist_ok=True)
     with TemporaryDirectory(dir=final_path.parent, prefix=f".{final_path.name}.") as tmp:
         tmp_path = Path(tmp)
-        tmp_path.mkdir(exist_ok=True)
         yield tmp_path
         tmp_path.replace(final_path)
 

--- a/pynbody/test_utils/split_swift_snapshot.py
+++ b/pynbody/test_utils/split_swift_snapshot.py
@@ -1,4 +1,7 @@
 import re
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import h5py
 import numpy as np
@@ -200,3 +203,60 @@ def hash_swift_cell_coordinates(filename, cell_mask=None):
         f.close()
 
     return m.hexdigest()
+
+
+@contextmanager
+def staging_dir(final_path):
+    final_path = Path(final_path)
+    final_path.parent.mkdir(exist_ok=True)
+    with TemporaryDirectory(dir=final_path.parent, prefix=f".{final_path.name}.") as tmp:
+        tmp_path = Path(tmp)
+        tmp_path.mkdir(exist_ok=True)
+        yield tmp_path
+        tmp_path.replace(final_path)
+
+
+def ensure_split_snapshot_exists(template_file, nr_files, output_dir,
+                                 output_name, cell_file_index,
+                                 cell_mask=None,
+                                 write_zero_size_datasets=False):
+    """
+    Ensure that the specified split snapshot exists on disk.
+
+    Parameters
+    ----------
+    template_file : pathlib.Path or str
+        Name of a single file Swift snapshot to use as a template
+    nr_files: int
+        The number of files to split the template snapshot into
+    output_dir: str or Path
+        Directory to write the new snapshot to
+    output_name: pathlib.Path or str
+        Name of the output files. Any .X.hdf5 suffix will be replaced.
+    cell_file_index: numpy.ndarray
+        Array with a file index to assign each cell to
+    cell_mask: dict
+        Dict where the keys are particle type names (PartTypeX) and the
+        values are boolean masks indicating which cells to keep for that
+        particle type.
+    write_zero_size_datasets: bool
+        If False, datasets which would have zero particles are omitted
+        (as in older Swift versions). If True, all datasets are always
+        written regardless of size (current Swift behaviour).
+
+    Returns
+    -------
+    str
+        A string which can be passed to pynbody.load() to open the snapshot.
+        This is the name of the file for single file snapshots or the name
+        minus any .X.hdf5 suffix for multi file snapshots.
+    """
+    if not Path(output_dir).exists():
+        with staging_dir(output_dir) as temp_dir:
+            split_swift_snapshot(template_file, nr_files, cell_file_index,
+                                 temp_dir / output_name, cell_mask=cell_mask,
+                                  write_zero_size_datasets=write_zero_size_datasets)
+    if nr_files > 1:
+        return str(Path(output_dir) / output_name).removesuffix(".0.hdf5")
+    else:
+        return str(Path(output_dir) / output_name)

--- a/tests/split_swift_snapshot_test.py
+++ b/tests/split_swift_snapshot_test.py
@@ -62,3 +62,8 @@ def test_split_snapshot_with_mask(tmp_path, write_zero_size_datasets):
                 assert "PartType0/Coordinates" not in f
             else:
                 assert "PartType0/Coordinates" in f
+
+    # Check the hashes of coordinates in the selected cells.
+    # The input snapshot contains all cells so we need to supply a mask.
+    assert (hash_swift_cell_coordinates(input_snapshot, cell_mask=cell_mask) ==
+            hash_swift_cell_coordinates(output_snapshot))

--- a/tests/split_swift_snapshot_test.py
+++ b/tests/split_swift_snapshot_test.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import pynbody
+from pynbody.test_utils.split_swift_snapshot import (
+    hash_swift_cell_coordinates,
+    split_swift_snapshot,
+)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def get_data():
+    pynbody.test_utils.ensure_test_data_available("swift")
+
+
+@pytest.mark.parametrize("nr_files", [1,2,3,4])
+def test_split_snapshot(tmp_path, nr_files):
+
+    # Split one of the test data snapshots across multiple files
+    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    rng = np.random.default_rng(0)
+    cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot)
+
+    # Check that each cell still contains the same particle coordinates
+    assert hash_swift_cell_coordinates(input_snapshot) == hash_swift_cell_coordinates(output_snapshot)

--- a/tests/split_swift_snapshot_test.py
+++ b/tests/split_swift_snapshot_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
 
@@ -16,14 +17,48 @@ def get_data():
 
 
 @pytest.mark.parametrize("nr_files", [1,2,3,4])
-def test_split_snapshot(tmp_path, nr_files):
+@pytest.mark.parametrize("write_zero_size_datasets", [True, False])
+def test_split_snapshot(tmp_path, nr_files, write_zero_size_datasets):
 
     # Split one of the test data snapshots across multiple files
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
     output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
     cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot)
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                         write_zero_size_datasets=write_zero_size_datasets)
 
     # Check that each cell still contains the same particle coordinates
     assert hash_swift_cell_coordinates(input_snapshot) == hash_swift_cell_coordinates(output_snapshot)
+
+
+@pytest.mark.parametrize("write_zero_size_datasets", [True, False])
+def test_split_snapshot_with_mask(tmp_path, write_zero_size_datasets):
+
+    cell_to_keep = 123
+
+    # Create mask with cells to keep
+    cell_mask = {
+        "PartType0" : np.zeros(512, dtype=bool),
+        "PartType1" : np.ones(512, dtype=bool),
+    }
+    cell_mask["PartType0"][cell_to_keep] = True # discard gas in all cells but one
+
+    # Generate the multi file snapshot
+    nr_files = 8
+    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    rng = np.random.default_rng(0)
+    cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                         cell_mask=cell_mask, write_zero_size_datasets=write_zero_size_datasets)
+
+    # Check that we're only omitting datasets where expected
+    file_with_gas = cell_file_index[cell_to_keep]
+    for file_nr in range(nr_files):
+        with h5py.File(tmp_path / f"split_snap_0150.{file_nr}.hdf5", "r") as f:
+            assert "PartType1/Coordinates" in f
+            if file_nr != file_with_gas and not write_zero_size_datasets:
+                assert "PartType0/Coordinates" not in f
+            else:
+                assert "PartType0/Coordinates" in f

--- a/tests/split_swift_snapshot_test.py
+++ b/tests/split_swift_snapshot_test.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import h5py
 import numpy as np
@@ -18,52 +19,56 @@ def get_data():
 
 @pytest.mark.parametrize("nr_files", [1,2,3,4])
 @pytest.mark.parametrize("write_zero_size_datasets", [True, False])
-def test_split_snapshot(tmp_path, nr_files, write_zero_size_datasets):
+def test_split_snapshot(nr_files, write_zero_size_datasets):
 
-    # Split one of the test data snapshots across multiple files
-    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
-    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
-    rng = np.random.default_rng(0)
-    cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
-                         write_zero_size_datasets=write_zero_size_datasets)
+    with TemporaryDirectory(dir="./testdata/SWIFT") as tmp_path:
 
-    # Check that each cell still contains the same particle coordinates
-    assert hash_swift_cell_coordinates(input_snapshot) == hash_swift_cell_coordinates(output_snapshot)
+        # Split one of the test data snapshots across multiple files
+        input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+        output_snapshot = Path(tmp_path) / "split_snap_0150.0.hdf5"
+        rng = np.random.default_rng(0)
+        cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
+        split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                             write_zero_size_datasets=write_zero_size_datasets)
+
+        # Check that each cell still contains the same particle coordinates
+        assert hash_swift_cell_coordinates(input_snapshot) == hash_swift_cell_coordinates(output_snapshot)
 
 
 @pytest.mark.parametrize("write_zero_size_datasets", [True, False])
-def test_split_snapshot_with_mask(tmp_path, write_zero_size_datasets):
+def test_split_snapshot_with_mask(write_zero_size_datasets):
 
-    cell_to_keep = 123
+    with TemporaryDirectory(dir="./testdata/SWIFT") as tmp_path:
 
-    # Create mask with cells to keep
-    cell_mask = {
-        "PartType0" : np.zeros(512, dtype=bool),
-        "PartType1" : np.ones(512, dtype=bool),
-    }
-    cell_mask["PartType0"][cell_to_keep] = True # discard gas in all cells but one
+        cell_to_keep = 123
 
-    # Generate the multi file snapshot
-    nr_files = 8
-    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
-    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
-    rng = np.random.default_rng(0)
-    cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
-                         cell_mask=cell_mask, write_zero_size_datasets=write_zero_size_datasets)
+        # Create mask with cells to keep
+        cell_mask = {
+            "PartType0" : np.zeros(512, dtype=bool),
+            "PartType1" : np.ones(512, dtype=bool),
+        }
+        cell_mask["PartType0"][cell_to_keep] = True # discard gas in all cells but one
 
-    # Check that we're only omitting datasets where expected
-    file_with_gas = cell_file_index[cell_to_keep]
-    for file_nr in range(nr_files):
-        with h5py.File(tmp_path / f"split_snap_0150.{file_nr}.hdf5", "r") as f:
-            assert "PartType1/Coordinates" in f
-            if file_nr != file_with_gas and not write_zero_size_datasets:
-                assert "PartType0/Coordinates" not in f
-            else:
-                assert "PartType0/Coordinates" in f
+        # Generate the multi file snapshot
+        nr_files = 8
+        input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+        output_snapshot = Path(tmp_path) / "split_snap_0150.0.hdf5"
+        rng = np.random.default_rng(0)
+        cell_file_index = rng.integers(nr_files, size=512) # randomly assign cells to files
+        split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                             cell_mask=cell_mask, write_zero_size_datasets=write_zero_size_datasets)
 
-    # Check the hashes of coordinates in the selected cells.
-    # The input snapshot contains all cells so we need to supply a mask.
-    assert (hash_swift_cell_coordinates(input_snapshot, cell_mask=cell_mask) ==
-            hash_swift_cell_coordinates(output_snapshot))
+        # Check that we're only omitting datasets where expected
+        file_with_gas = cell_file_index[cell_to_keep]
+        for file_nr in range(nr_files):
+            with h5py.File(Path(tmp_path) / f"split_snap_0150.{file_nr}.hdf5", "r") as f:
+                assert "PartType1/Coordinates" in f
+                if file_nr != file_with_gas and not write_zero_size_datasets:
+                    assert "PartType0/Coordinates" not in f
+                else:
+                    assert "PartType0/Coordinates" in f
+
+        # Check the hashes of coordinates in the selected cells.
+        # The input snapshot contains all cells so we need to supply a mask.
+        assert (hash_swift_cell_coordinates(input_snapshot, cell_mask=cell_mask) ==
+                hash_swift_cell_coordinates(output_snapshot))

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -311,10 +311,10 @@ def test_swift_take_region_multiple_files_and_types(test_region, multifile_with_
     assert len(f_full.families())==2
 
 
-@pytest.fixture
-def multifile_with_sparse_gas(tmp_path):
-    # Create a snapshot where only one cell (and file) has gas particles
-    nr_files = 8
+@pytest.fixture(params=[1, 8])
+def snapshot_with_sparse_gas(request, tmp_path):
+    # Create a snapshot where only one cell has gas particles
+    nr_files = request.param
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
     output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
@@ -322,12 +322,25 @@ def multifile_with_sparse_gas(tmp_path):
     gas_mask = np.zeros(512, dtype=bool)
     gas_mask[337] = True # Only keep the gas in this cell
     split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot, cell_mask={"PartType0" : gas_mask})
-    return str(output_snapshot).removesuffix(".0.hdf5")
+    if nr_files > 1:
+        return str(output_snapshot).removesuffix(".0.hdf5")
+    else:
+        return str(output_snapshot)
 
 
-def test_swift_open_snapshot_with_sparse_gas(multifile_with_sparse_gas):
-    # Check that opening a multi-file snapshot still works when some files have no gas
-    f = pynbody.load(multifile_with_sparse_gas)
+def test_swift_open_snapshot_with_sparse_gas(snapshot_with_sparse_gas):
+    f = pynbody.load(snapshot_with_sparse_gas)
     assert len(f.families())==2
-    assert len(f.dm.loadable_keys() > 1)
-    assert len(f.gas.loadable_keys() > 1)
+    assert len(f.dm.loadable_keys()) > 1
+    assert len(f.gas.loadable_keys()) > 1
+
+
+@pytest.mark.parametrize('test_region', [
+    pynbody.filt.Sphere(10., (97.795, 44.452, 26.671)), # contains gas
+    pynbody.filt.Sphere(10., (30.000, 44.452, 26.671)), # contains no gas
+])
+def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_region):
+    f = pynbody.load(snapshot_with_sparse_gas, take_region=test_region)
+    assert len(f.families())==2
+    assert len(f.dm.loadable_keys()) > 1
+    assert len(f.gas.loadable_keys()) > 1

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -329,18 +329,36 @@ def snapshot_with_sparse_gas(request, tmp_path):
 
 
 def test_swift_open_snapshot_with_sparse_gas(snapshot_with_sparse_gas):
+    # Make sure we can open a snapshot where some files have datasets
+    # which would contain zero particles and therefore might not have
+    # been written at all.
     f = pynbody.load(snapshot_with_sparse_gas)
     assert len(f.families())==2
     assert len(f.dm.loadable_keys()) > 1
     assert len(f.gas.loadable_keys()) > 1
 
 
-@pytest.mark.parametrize('test_region', [
-    pynbody.filt.Sphere(10., (97.795, 44.452, 26.671)), # contains gas
-    pynbody.filt.Sphere(10., (30.000, 44.452, 26.671)), # contains no gas
+@pytest.mark.parametrize('test_params', [
+    (pynbody.filt.Sphere(10., (97.795, 44.452, 26.671)), True),  # contains gas
+    (pynbody.filt.Sphere(10., (30.000, 44.452, 26.671)), False), # contains no gas
 ])
-def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_region):
+def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_params):
+    test_region, expect_gas = test_params
     f = pynbody.load(snapshot_with_sparse_gas, take_region=test_region)
-    assert len(f.families())==2
+
+    # The families() method only reports families with >0 particles
+    assert len(f.families()) == (2 if expect_gas else 1)
+
+    # But we should still always have gas and dm families
     assert len(f.dm.loadable_keys()) > 1
     assert len(f.gas.loadable_keys()) > 1
+
+    # We should be able to read the gas coordinates, and get an empty array
+    # if the selection does not cover the region with gas.
+    gas_pos = f.gas["pos"]
+    assert gas_pos.shape == (274,3) if expect_gas else (0,3) # cell 337 has 274 gas particles
+
+    # Check that the gas coordinates we got are correct
+    if expect_gas:
+        f_full = pynbody.load("./testdata/SWIFT/snap_0150.hdf5", take_swift_cells=(337,))
+        assert np.all(gas_pos == f_full.gas["pos"])

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -309,3 +309,25 @@ def test_swift_take_region_multiple_files_and_types(test_region, multifile_with_
     assert np.all(f[test_region]['iord'] == f_full[test_region]['iord'])
     assert len(f.families())==2
     assert len(f_full.families())==2
+
+
+@pytest.fixture
+def multifile_with_sparse_gas(tmp_path):
+    # Create a snapshot where only one cell (and file) has gas particles
+    nr_files = 8
+    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    rng = np.random.default_rng(0)
+    cell_file_index = rng.integers(nr_files, size=512)
+    gas_mask = np.zeros(512, dtype=bool)
+    gas_mask[337] = True # Only keep the gas in this cell
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot, cell_mask={"PartType0" : gas_mask})
+    return str(output_snapshot).removesuffix(".0.hdf5")
+
+
+def test_swift_open_snapshot_with_sparse_gas(multifile_with_sparse_gas):
+    # Check that opening a multi-file snapshot still works when some files have no gas
+    f = pynbody.load(multifile_with_sparse_gas)
+    assert len(f.families())==2
+    assert len(f.dm.loadable_keys() > 1)
+    assert len(f.gas.loadable_keys() > 1)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -368,3 +368,51 @@ def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_params
     if expect_gas:
         f_full = pynbody.load("./testdata/SWIFT/snap_0150.hdf5", take_swift_cells=(337,))
         assert np.all(gas_pos == f_full.gas["pos"])
+
+
+@pytest.fixture(params=[
+    (1, True),  # single file with empty gas datasets
+    (8, True),  # multi file with empty gas datasets
+])
+def snapshot_with_no_gas(request, tmp_path):
+    # Create a snapshot where the gas particle datasets exist
+    # but there are zero gas particles. This is to simulate how
+    # recent Swift versions always write out the same set of
+    # datasets in all snapshots, even if stars or black holes
+    # have not formed yet.
+    nr_files, write_zero_size_datasets = request.param
+    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    rng = np.random.default_rng(0)
+    cell_file_index = rng.integers(nr_files, size=512)
+    gas_mask = np.zeros(512, dtype=bool) # discard all gas
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                         write_zero_size_datasets=write_zero_size_datasets,
+                         cell_mask={"PartType0" : gas_mask})
+    if nr_files > 1:
+        return str(output_snapshot).removesuffix(".0.hdf5")
+    else:
+        return str(output_snapshot)
+
+
+def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
+    f = pynbody.load(snapshot_with_no_gas)
+
+    # The families() method only reports families with >0 particles
+    assert len(f.families()) == 1
+    assert len(f.dm.loadable_keys()) > 1
+
+    # Check we can read the DM particles correctly.
+    # Ordering of the cells will differ in the multi file case.
+    f_full = pynbody.load("./testdata/SWIFT/snap_0150.hdf5")
+    def sorted_dm_coords(snap):
+        order = np.argsort(snap.dm["iord"])
+        return snap.dm["pos"][order,:]
+    assert np.all(sorted_dm_coords(f) == sorted_dm_coords(f_full))
+
+    # # But we should still have gas and dm families
+    # assert len(f.gas.loadable_keys()) > 1
+
+    # # We should be able to read the gas coordinates, and get an empty array
+    # gas_pos = f.gas["pos"]
+    # assert gas_pos.shape == (0,3)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -400,7 +400,14 @@ def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
 
     # The families() method only reports families with >0 particles
     assert len(f.families()) == 1
+
+    # But we should have gas and dm families
     assert len(f.dm.loadable_keys()) > 1
+    assert len(f.gas.loadable_keys()) > 1
+
+    # We should be able to read the gas coordinates, and get an empty array
+    gas_pos = f.gas["pos"]
+    assert gas_pos.shape == (0,3)
 
     # Check we can read the DM particles correctly.
     # Ordering of the cells will differ in the multi file case.
@@ -409,10 +416,3 @@ def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
         order = np.argsort(snap.dm["iord"])
         return snap.dm["pos"][order,:]
     assert np.all(sorted_dm_coords(f) == sorted_dm_coords(f_full))
-
-    # # But we should still have gas and dm families
-    # assert len(f.gas.loadable_keys()) > 1
-
-    # # We should be able to read the gas coordinates, and get an empty array
-    # gas_pos = f.gas["pos"]
-    # assert gas_pos.shape == (0,3)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -311,17 +311,23 @@ def test_swift_take_region_multiple_files_and_types(test_region, multifile_with_
     assert len(f_full.families())==2
 
 
-@pytest.fixture(params=[1, 8])
+@pytest.fixture(params=[
+    (1, True),  # all datasets have non-zero size when nr_files==1
+    (8, True),  # multi file with all datasets present
+    (8, False), # multi file with zero sized datasets omitted
+])
 def snapshot_with_sparse_gas(request, tmp_path):
     # Create a snapshot where only one cell has gas particles
-    nr_files = request.param
+    nr_files, write_zero_size_datasets = request.param
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
     output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
     cell_file_index = rng.integers(nr_files, size=512)
     gas_mask = np.zeros(512, dtype=bool)
     gas_mask[337] = True # Only keep the gas in this cell
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot, cell_mask={"PartType0" : gas_mask})
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
+                         write_zero_size_datasets=write_zero_size_datasets,
+                         cell_mask={"PartType0" : gas_mask})
     if nr_files > 1:
         return str(output_snapshot).removesuffix(".0.hdf5")
     else:

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -11,6 +11,10 @@ import pynbody
 import pynbody.halo.velociraptor
 import pynbody.snapshot.swift
 import pynbody.test_utils
+from pynbody.test_utils.split_swift_snapshot import (
+    hash_swift_cell_coordinates,
+    split_swift_snapshot,
+)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -281,3 +285,27 @@ def test_planetary_physical_units():
           [222.85219794, 391.8567664 , 395.02856333],
           [226.0370616 , 355.54715989, 438.43730943],
           [226.19312796, 388.35465427, 347.38190241]])
+
+
+@pytest.fixture
+def multifile_with_multiple_types(tmp_path):
+    nr_files = 8
+    input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
+    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    rng = np.random.default_rng(0)
+    cell_file_index = rng.integers(nr_files, size=512)
+    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot)
+    return str(output_snapshot).removesuffix(".0.hdf5")
+
+
+@pytest.mark.parametrize('test_region',
+                         [pynbody.filt.Sphere(50., (50., 50., 50.)),
+                         pynbody.filt.Cuboid(-20.0)]) # note the cuboid test region wraps around the box
+def test_swift_take_region_multiple_files_and_types(test_region, multifile_with_multiple_types):
+    f = pynbody.load(multifile_with_multiple_types, take_region = test_region)
+    f_full = pynbody.load(multifile_with_multiple_types)
+    assert len(f_full) == 524288
+    assert len(f) < len(f_full)
+    assert np.all(f[test_region]['iord'] == f_full[test_region]['iord'])
+    assert len(f.families())==2
+    assert len(f_full.families())==2

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -364,7 +364,7 @@ def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_params
     # We should be able to read the gas coordinates, and get an empty array
     # if the selection does not cover the region with gas.
     gas_pos = f.gas["pos"]
-    assert gas_pos.shape == (274,3) if expect_gas else (0,3) # cell 337 has 274 gas particles
+    assert gas_pos.shape == ((274,3) if expect_gas else (0,3)) # cell 337 has 274 gas particles
 
     # Check that the gas coordinates we got are correct
     if expect_gas:

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -422,25 +422,48 @@ def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
     assert np.all(sorted_dm_coords(f) == sorted_dm_coords(f_full))
 
 
-@contextmanager
-def copy_test_snap():
-    with TemporaryDirectory(dir="testdata/SWIFT", prefix=f".snap_0150_copy.") as tmp:
+@pytest.fixture(scope="function")
+def copied_snapshot():
+    with TemporaryDirectory(dir="testdata/SWIFT", prefix=".snap_0150_copy.") as tmp:
         tmp_snap = Path(tmp) / "snap_0150.hdf5"
         shutil.copy("./testdata/SWIFT/snap_0150.hdf5", tmp_snap)
         yield tmp_snap
 
-def test_swift_no_number_of_fields():
+def test_swift_no_number_of_fields(copied_snapshot):
     """Check that we reject snapshots where the NumberOfFields attribute is missing"""
-    with copy_test_snap() as tmp_snap:
-        with h5py.File(tmp_snap, "r+") as f:
-            del f["PartType1"].attrs["NumberOfFields"]
-        with raises(ValueError):
-            snap = pynbody.load(tmp_snap)
+    with h5py.File(copied_snapshot, "r+") as f:
+        del f["PartType1"].attrs["NumberOfFields"]
+    with raises(ValueError):
+        snap = pynbody.load(copied_snapshot)
 
-def test_swift_wrong_number_of_fields():
+def test_swift_wrong_number_of_fields(copied_snapshot):
     """Check that we reject snapshots where the NumberOfFields attribute is wrong"""
-    with copy_test_snap() as tmp_snap:
-        with h5py.File(tmp_snap, "r+") as f:
-            f["PartType1"].attrs["NumberOfFields"] += 1
-        with raises(ValueError):
-            snap = pynbody.load(tmp_snap)
+    with h5py.File(copied_snapshot, "r+") as f:
+        f["PartType1"].attrs["NumberOfFields"] += 1
+    with raises(ValueError):
+        snap = pynbody.load(copied_snapshot)
+
+
+@pytest.mark.parametrize('metadata_change', [
+    # Dataset,                         index,   new value
+    ("Cells/Counts/PartType0",         395,     811),    # wrong total number of particles (cell 395 has 810 particles)
+    ("Cells/Files/PartType0",          5,      -1),      # negative file index for cell 5
+    ("Cells/Files/PartType0",          5,       1),      # file index too large for cell 5 (it's a single file snapshot)
+    ("Cells/OffsetsInFile/PartType1",  503,     261672), # offset+count too large (cell 503 has 473 particles, there are 262144 total)
+    ("Cells/OffsetsInFile/PartType1",  1,      -1),      # negative offset for cell 1
+])
+def test_swift_wrong_cell_metadata(copied_snapshot, metadata_change):
+    """Check that we reject snapshots where cell metadata fails consistency checks"""
+    dset, index, value = metadata_change
+
+    # Modify the cell metadata
+    with h5py.File(copied_snapshot, "r+") as f:
+        f[dset][index] = value
+
+    # Reading a region fails because the cell metadata is incorrect
+    with raises(ValueError):
+        snap = pynbody.load(copied_snapshot, take_region=pynbody.filt.Sphere(50., (50., 50., 50.)))
+
+    # Reading the full snapshot does not require the cell metadata, so it still works
+    snap = pynbody.load(copied_snapshot)
+    assert isinstance(snap, pynbody.snapshot.swift.SwiftSnap)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -487,8 +487,7 @@ def test_swift_add_field(copied_snapshot):
     snap['test_array'].write()
 
     # Check it can still be loaded
-    with pytest.warns(RuntimeWarning):
-        snap = pynbody.load(copied_snapshot)
+    snap = pynbody.load(copied_snapshot)
 
 
 def test_swift_write_array_to_region(copied_snapshot):

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -489,3 +489,14 @@ def test_swift_add_field(copied_snapshot):
     # Check it can still be loaded
     with pytest.warns(RuntimeWarning):
         snap = pynbody.load(copied_snapshot)
+
+
+def test_swift_write_array_to_region(copied_snapshot):
+
+    # Open a region in the snapshot and create a new array
+    snap = pynbody.load(copied_snapshot, take_region=pynbody.filt.Sphere(50., (50., 50., 50.)))
+    snap['test_array'] = np.random.uniform(0, 1, len(snap))
+
+    # Writing the new array should not work
+    with pytest.raises(NotImplementedError):
+        snap['test_array'].write()

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -11,10 +11,7 @@ import pynbody
 import pynbody.halo.velociraptor
 import pynbody.snapshot.swift
 import pynbody.test_utils
-from pynbody.test_utils.split_swift_snapshot import (
-    hash_swift_cell_coordinates,
-    split_swift_snapshot,
-)
+from pynbody.test_utils.split_swift_snapshot import ensure_split_snapshot_exists
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -288,15 +285,18 @@ def test_planetary_physical_units():
 
 
 @pytest.fixture
-def multifile_with_multiple_types(tmp_path):
+def multifile_with_multiple_types():
+    """
+    Split a snapshot with gas and dark matter over multiple files
+    """
     nr_files = 8
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
-    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    output_dir = "./testdata/SWIFT/multi_file_multi_type"
+    output_name = "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
     cell_file_index = rng.integers(nr_files, size=512)
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot)
-    return str(output_snapshot).removesuffix(".0.hdf5")
-
+    return ensure_split_snapshot_exists(input_snapshot, nr_files, output_dir, output_name,
+                                        cell_file_index)
 
 @pytest.mark.parametrize('test_region',
                          [pynbody.filt.Sphere(50., (50., 50., 50.)),
@@ -320,18 +320,16 @@ def snapshot_with_sparse_gas(request, tmp_path):
     # Create a snapshot where only one cell has gas particles
     nr_files, write_zero_size_datasets = request.param
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
-    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    output_dir = f"./testdata/SWIFT/sparse_gas/nfiles_{nr_files}{'_zero_size' if write_zero_size_datasets else ''}"
+    output_name = "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
     cell_file_index = rng.integers(nr_files, size=512)
     gas_mask = np.zeros(512, dtype=bool)
     gas_mask[337] = True # Only keep the gas in this cell
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
-                         write_zero_size_datasets=write_zero_size_datasets,
-                         cell_mask={"PartType0" : gas_mask})
-    if nr_files > 1:
-        return str(output_snapshot).removesuffix(".0.hdf5")
-    else:
-        return str(output_snapshot)
+    return ensure_split_snapshot_exists(input_snapshot, nr_files, output_dir,
+                                        output_name, cell_file_index,
+                                        write_zero_size_datasets=write_zero_size_datasets,
+                                        cell_mask={"PartType0" : gas_mask})
 
 
 def test_swift_open_snapshot_with_sparse_gas(snapshot_with_sparse_gas):
@@ -382,17 +380,15 @@ def snapshot_with_no_gas(request, tmp_path):
     # have not formed yet.
     nr_files, write_zero_size_datasets = request.param
     input_snapshot = "./testdata/SWIFT/snap_0150.hdf5"
-    output_snapshot = tmp_path / "split_snap_0150.0.hdf5"
+    output_dir = f"./testdata/SWIFT/no_gas/nfiles_{nr_files}{'_zero_size' if write_zero_size_datasets else ''}"
+    output_name = "split_snap_0150.0.hdf5"
     rng = np.random.default_rng(0)
     cell_file_index = rng.integers(nr_files, size=512)
     gas_mask = np.zeros(512, dtype=bool) # discard all gas
-    split_swift_snapshot(input_snapshot, nr_files, cell_file_index, output_snapshot,
-                         write_zero_size_datasets=write_zero_size_datasets,
-                         cell_mask={"PartType0" : gas_mask})
-    if nr_files > 1:
-        return str(output_snapshot).removesuffix(".0.hdf5")
-    else:
-        return str(output_snapshot)
+    return ensure_split_snapshot_exists(input_snapshot, nr_files, output_dir,
+                                        output_name, cell_file_index,
+                                        write_zero_size_datasets=write_zero_size_datasets,
+                                        cell_mask={"PartType0" : gas_mask})
 
 
 def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -478,16 +478,79 @@ def test_swift_wrong_cell_metadata(copied_snapshot, metadata_change):
     assert isinstance(snap, pynbody.snapshot.swift.SwiftSnap)
 
 
-def test_swift_add_field(copied_snapshot):
-    """Check that the snapshot is still readable if we write a new field"""
+@contextmanager
+def tmp_directory_copy(src_dir):
+    """Make a temporary copy of a directory containing snapshot files"""
+    src_dir = Path(src_dir)
+    with TemporaryDirectory(dir=src_dir.parent, prefix=f".{src_dir.name}.") as tmp_dir:
+        dest_dir = Path(tmp_dir) / src_dir.name
+        shutil.copytree(src_dir, dest_dir)
+        yield dest_dir
 
+
+@pytest.fixture
+def writable_sparse_gas(snapshot_with_sparse_gas):
+    with tmp_directory_copy(Path(snapshot_with_sparse_gas).parent) as tmp:
+        try:
+            yield tmp / Path(snapshot_with_sparse_gas).name
+        finally:
+            # Ensure HDF5 files are closed
+            import gc
+            gc.collect()
+
+
+def test_swift_add_field(writable_sparse_gas):
+    """
+    Check that the snapshot is still readable if we write a new field
+
+    Use the sparse gas fixture so we test single and multi file snapshots
+    and cases with and without zero sized datasets present.
+    """
     # Open the snapshot and write a new array
-    snap = pynbody.load(copied_snapshot)
-    snap['test_array'] = np.random.uniform(0, 1, len(snap))
+    snap = pynbody.load(writable_sparse_gas)
+    test_array = np.random.uniform(0, 1, len(snap))
+    snap['test_array'] = test_array
     snap['test_array'].write()
 
-    # Check it can still be loaded
-    snap = pynbody.load(copied_snapshot)
+    # Check it can still be loaded back in
+    snap = pynbody.load(writable_sparse_gas)
+    assert np.all(snap['test_array'] == test_array)
+
+    # Should have a new array for all groups with a ParticleIDs dataset, even
+    # if the group contains no particles.
+    for f in snap._hdf_files:
+        for group_name, group in f.items():
+            if group_name.startswith("PartType"):
+                assert "test_array" in group
+                assert group["ParticleIDs"].shape == group["test_array"].shape
+
+
+def test_swift_add_field_for_family(writable_sparse_gas):
+    """
+    Test writing a new field for one family only.
+
+    Use the sparse gas fixture so we test single and multi file snapshots
+    and cases with and without zero sized datasets present.
+    """
+    # Open the snapshot and write a new array
+    snap = pynbody.load(writable_sparse_gas)
+    test_array = np.random.uniform(0, 1, len(snap.gas))
+    snap.gas['test_array'] = test_array
+    snap.gas['test_array'].write()
+
+    # Check it can still be loaded back in
+    snap = pynbody.load(writable_sparse_gas)
+    assert np.all(snap.gas['test_array'] == test_array)
+
+    # Should have a new array for all gas groups, even if there are zero
+    # gas particles
+    for f in snap._hdf_files:
+        for group_name, group in f.items():
+            if group_name == "PartType0":
+                assert "test_array" in group
+                assert group["ParticleIDs"].shape == group["test_array"].shape
+            elif group_name.startswith("PartType"):
+                assert "test_array" not in group
 
 
 def test_swift_write_array_to_region(copied_snapshot):

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -1,5 +1,7 @@
 import shutil
+from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import h5py
 import numpy as np
@@ -418,3 +420,27 @@ def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
         order = np.argsort(snap.dm["iord"])
         return snap.dm["pos"][order,:]
     assert np.all(sorted_dm_coords(f) == sorted_dm_coords(f_full))
+
+
+@contextmanager
+def copy_test_snap():
+    with TemporaryDirectory(dir="testdata/SWIFT", prefix=f".snap_0150_copy.") as tmp:
+        tmp_snap = Path(tmp) / "snap_0150.hdf5"
+        shutil.copy("./testdata/SWIFT/snap_0150.hdf5", tmp_snap)
+        yield tmp_snap
+
+def test_swift_no_number_of_fields():
+    """Check that we reject snapshots where the NumberOfFields attribute is missing"""
+    with copy_test_snap() as tmp_snap:
+        with h5py.File(tmp_snap, "r+") as f:
+            del f["PartType1"].attrs["NumberOfFields"]
+        with raises(ValueError):
+            snap = pynbody.load(tmp_snap)
+
+def test_swift_wrong_number_of_fields():
+    """Check that we reject snapshots where the NumberOfFields attribute is wrong"""
+    with copy_test_snap() as tmp_snap:
+        with h5py.File(tmp_snap, "r+") as f:
+            f["PartType1"].attrs["NumberOfFields"] += 1
+        with raises(ValueError):
+            snap = pynbody.load(tmp_snap)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -269,7 +269,12 @@ def test_load_planetary():
           [35.47905534, 55.80711974, 68.81765962],
           [35.50355171, 60.95662443, 54.52549088]])
 
-
+def test_load_planetary_region():
+    # The planetary example is an incomplete snapshot with all cell counts
+    # equal to zero, so this should fail
+    with raises(ValueError) as excinfo:
+        f = pynbody.load("testdata/SWIFT/planetary.hdf5", take_region=pynbody.filt.Sphere(10., (60., 60., 60.)))
+    assert "No spatial index" in str(excinfo.value)
 
 def test_planetary_physical_units():
     f = pynbody.load("testdata/SWIFT/planetary.hdf5")

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 import numpy.testing as npt
 import pytest
-from pytest import raises
+from pytest import raises, warns
 
 import pynbody
 import pynbody.halo.velociraptor
@@ -446,10 +446,10 @@ def test_swift_no_number_of_fields(copied_snapshot):
         snap = pynbody.load(copied_snapshot)
 
 def test_swift_wrong_number_of_fields(copied_snapshot):
-    """Check that we reject snapshots where the NumberOfFields attribute is wrong"""
+    """Check that we warn on snapshots where the NumberOfFields attribute is wrong"""
     with h5py.File(copied_snapshot, "r+") as f:
         f["PartType1"].attrs["NumberOfFields"] += 1
-    with raises(ValueError):
+    with warns(RuntimeWarning):
         snap = pynbody.load(copied_snapshot)
 
 
@@ -476,3 +476,16 @@ def test_swift_wrong_cell_metadata(copied_snapshot, metadata_change):
     # Reading the full snapshot does not require the cell metadata, so it still works
     snap = pynbody.load(copied_snapshot)
     assert isinstance(snap, pynbody.snapshot.swift.SwiftSnap)
+
+
+def test_swift_add_field(copied_snapshot):
+    """Check that the snapshot is still readable if we write a new field"""
+
+    # Open the snapshot and write a new array
+    snap = pynbody.load(copied_snapshot)
+    snap['test_array'] = np.random.uniform(0, 1, len(snap))
+    snap['test_array'].write()
+
+    # Check it can still be loaded
+    with pytest.warns(RuntimeWarning):
+        snap = pynbody.load(copied_snapshot)

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -428,6 +428,10 @@ def copied_snapshot():
         tmp_snap = Path(tmp) / "snap_0150.hdf5"
         shutil.copy("./testdata/SWIFT/snap_0150.hdf5", tmp_snap)
         yield tmp_snap
+        # Try to ensure the snapshot is closed so we can delete the file
+        # (Windows locks files that are open)
+        import gc
+        gc.collect()
 
 def test_swift_no_number_of_fields(copied_snapshot):
     """Check that we reject snapshots where the NumberOfFields attribute is missing"""

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -337,9 +337,12 @@ def test_swift_open_snapshot_with_sparse_gas(snapshot_with_sparse_gas):
     # which would contain zero particles and therefore might not have
     # been written at all.
     f = pynbody.load(snapshot_with_sparse_gas)
-    assert len(f.families())==2
-    assert len(f.dm.loadable_keys()) > 1
-    assert len(f.gas.loadable_keys()) > 1
+    assert len(f.families()) == 2
+    assert "gas" in f.families()
+    assert "dm" in f.families()
+    for name in ("pos", "vel", "mass", "iord", "grp"):
+        assert name in f.dm.loadable_keys()
+        assert name in f.gas.loadable_keys()
 
 
 @pytest.mark.parametrize('test_params', [
@@ -353,9 +356,10 @@ def test_swift_open_region_with_sparse_gas(snapshot_with_sparse_gas, test_params
     # The families() method only reports families with >0 particles
     assert len(f.families()) == (2 if expect_gas else 1)
 
-    # But we should still always have gas and dm families
-    assert len(f.dm.loadable_keys()) > 1
-    assert len(f.gas.loadable_keys()) > 1
+    # But we should still always have gas and dm families with arrays
+    for name in ("pos", "vel", "mass", "iord", "grp"):
+        assert name in f.dm.loadable_keys()
+        assert name in f.gas.loadable_keys()
 
     # We should be able to read the gas coordinates, and get an empty array
     # if the selection does not cover the region with gas.
@@ -396,10 +400,12 @@ def test_swift_open_snapshot_with_no_gas(snapshot_with_no_gas):
 
     # The families() method only reports families with >0 particles
     assert len(f.families()) == 1
+    assert "dm" in f.families()
 
-    # But we should have gas and dm families
-    assert len(f.dm.loadable_keys()) > 1
-    assert len(f.gas.loadable_keys()) > 1
+    # But we should still always have gas and dm families with arrays
+    for name in ("pos", "vel", "mass", "iord", "grp"):
+        assert name in f.dm.loadable_keys()
+        assert name in f.gas.loadable_keys()
 
     # We should be able to read the gas coordinates, and get an empty array
     gas_pos = f.gas["pos"]


### PR DESCRIPTION
Currently the SwiftSnap snapshot class implements cutting out regions by making a temporary HDF5 file with virtual datasets which refer to the selected parts of the snapshot. This PR replaces it with an implementation based on the partial access mechanism already present in the parent GadgetHdfSnap class. The approach is to treat the `take_region` and `take_cells` parameters as alternative ways to specify the array of particle indexes which would otherwise be supplied by the `take` parameter.

The motivation for this is to make it easier to allow remote access to Swift snapshots using the hdfstream module. When the snapshot files are accessed using http we can't create a local virtual dataset that refers to them.

I'm marking this PR as a draft for now because it needs some additional tests. E.g.

  * Selecting a region from a multi-file snapshot with multiple particle types
  * Reading a multi-file snapshot where some files are missing particles of some type
  * Reading a snapshot where some particle type is present in the cell metadata but not this particular snapshot
  
Test cases can probably be set up by using the single file DM+gas snapshot from the test data as a template if we don't want to add more files to the test data.