### PR TITLE
Pin sphinx-book-theme to fix mobile sidebar regression on readthedocs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ tests = [
 docs = [
     "ipython>=3",
     "Sphinx>=7,<8.2.0",
-    "sphinx-book-theme",
+    # pinned: sphinx-book-theme>=1.3.0 pulls in pydata-sphinx-theme>=0.17, whose
+    # sidebar rework (executablebooks/sphinx-book-theme upstream) breaks opening
+    # the primary sidebar on mobile/narrow viewports. Unpin once that's fixed upstream.
+    "sphinx-book-theme==1.2.0",
     "sphinx-copybutton",
     "numpydoc", 
     "nbsphinx",


### PR DESCRIPTION
The docs extra left sphinx-book-theme unpinned, so readthedocs builds
pull in whatever version is current at build time. sphinx-book-theme
1.3.0 (released 2026-07-19) bumps its pydata-sphinx-theme pin from
0.16.1 to 0.17.1, whose sidebar rework breaks opening the primary
sidebar on mobile/narrow viewports. This explains why v2.4.2 (built
before the bump) is unaffected while v2.5.0 and latest are.

Pin to 1.2.0, the last version paired with pydata-sphinx-theme 0.16.1,
until the regression is fixed upstream.