### PR TITLE
Fix order-dependent KeyError when a family is emptied by partial loading

### DIFF
--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -585,7 +585,11 @@ class GadgetHDFSnap(SimSnap):
     def __init_loadable_keys(self):
 
         self._loadable_family_keys = {}
-        all_fams = self.families()
+        # Deliberately not self.families(), which only returns families with a non-empty slice
+        # *after* any take/region selection has been applied. A family can have a legitimate
+        # (possibly zero-length) sub-view even when none of its particles were selected, and it
+        # must still get an entry here or accessing its arrays later raises a spurious KeyError.
+        all_fams = [fam for fam, groups in self._family_to_group_map.items() if len(groups) > 0]
         if len(all_fams)==0:
             return
 

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -222,6 +222,21 @@ def test_partial_load_mass_in_header():
     assert np.allclose(f_slice['mass'],f[::2]['mass'])
 
 
+def test_partial_load_empty_family_issue_1005():
+    # Regression test for #1005: a `take` selection that excludes an entire family
+    # (here, dm) must give the same, order-independent result regardless of whether
+    # some other family's array was already read first.
+    f = pynbody.load("testdata/gadget3/snap_028_z000p000.0.hdf5", take=(0, 1, 2, 3))
+    assert f.families() == [pynbody.family.gas]
+    dm_pos = f.dm['pos']
+    assert dm_pos.shape == (0, 3)
+
+    f2 = pynbody.load("testdata/gadget3/snap_028_z000p000.0.hdf5", take=(0, 1, 2, 3))
+    gas_pos = f2.gas['pos']
+    dm_pos2 = f2.dm['pos']
+    assert gas_pos.shape == (4, 3)
+    assert dm_pos2.shape == (0, 3)
+
 def test_load_copy_issue_955(snap):
     # condition: A single-file snapshot with a PartType length greater than max_buf; 
     # select a slice across chunk boundary


### PR DESCRIPTION
## Summary

- Fixes #1005: `GadgetHdfSnap`/`SwiftSnap` raised a `KeyError` when reading an array for a family that had zero particles selected (e.g. via `take=...`), but only if that family's array hadn't already been loaded via another family first.
- Root cause: `GadgetHDFSnap.__init_loadable_keys()` built its per-family "loadable keys" table from `self.families()`, which excludes families with an empty slice *after* `take`/region selection. A family can legitimately still exist (as a zero-length sub-view) even when none of its particles were selected, but it was never given an entry in the lookup table, so `snap.dm["pos"]` (say) hit a bare `self._loadable_family_keys[fam]` `KeyError` instead of returning an empty array. Reading another (non-empty) family's array first masked the bug, because that array got promoted to a simulation-level array, and the second family's access was then satisfied by slicing it directly, bypassing the broken lookup entirely — hence the order-dependence reported in the issue.
- Fix: build the family list from `self._family_to_group_map`, which reflects the file's actual particle-type structure and is already correctly `take`-independent (it's used elsewhere in the same class for this purpose). `SwiftSnap` inherits this method unchanged, so the fix covers it too.

I reproduced the exact reported behaviour (and verified the fix) locally using a small hand-built synthetic Gadget-HDF5 file, since the real test data is hosted on OSF and isn't reachable from this sandbox.

Added `test_partial_load_empty_family_issue_1005` to `tests/gadgethdf_test.py`, reproducing the issue's exact scenario against real test data (`take=(0,1,2,3)` on `snap_028_z000p000.0.hdf5`, which selects only gas), checking both access orders give a consistent, correct `(0, 3)` array for `dm['pos']`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QefvYU5fpHxzNNFearASmT)_