### PR TITLE
Enhance partial loading performance with HDF5 chunk cache configuration

### DIFF
--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -109,6 +109,19 @@ StellarFormationTime: tform
 BHFormationTime: tform
 Potential: phi
 
+[gadgethdf]
+# Size of the HDF5 chunk cache, in bytes, used when opening gadget-like HDF5 files (including swift).
+# Simulation snapshots are often written as large compressed chunks, and HDF5 must decompress an entire
+# chunk to satisfy even a small read. If the cache cannot hold a chunk, that decompression is repeated
+# for every read, which makes partial loading extremely slow. The default of 64MB is enough to hold a
+# few chunks of a typical snapshot. Note that this is a cap rather than an allocation, and that whole-
+# chunk reads bypass the cache, so full snapshot loads are unaffected by this setting.
+chunk-cache-nbytes: 67108864
+
+# Number of slots in the HDF5 chunk cache. Should be a prime number, ideally at least ten times the
+# number of chunks that can fit in the cache.
+chunk-cache-nslots: 5051
+
 [gadgethdf-type-mapping]
 # GadgetHDF stores six different particle types (numbered 0 to 5). This specifies how they map
 # onto pynbody particle types by default. To override, you can either make your own configuration

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -49,6 +49,10 @@ for hdf_groups in _default_type_map.values():
 
 _max_buf = 1024 * 512 # max_chunk for chunk.LoadControl
 
+# HDF5 chunk cache to use when opening files; see _open_hdf_file below
+_chunk_cache_nbytes = int(config_parser.get('gadgethdf', 'chunk-cache-nbytes'))
+_chunk_cache_nslots = int(config_parser.get('gadgethdf', 'chunk-cache-nslots'))
+
 class _DummyHDFData:
 
     """A stupid class to allow emulation of mass arrays for particles
@@ -72,6 +76,18 @@ class _DummyHDFData:
         target[:] = self.value
 
 
+def _open_hdf_file(filename, mode='r'):
+    """Open an HDF5 file with a chunk cache large enough for partial reads to be efficient.
+
+    Snapshots are routinely written as compressed chunks that are megabytes in size, sometimes spanning
+    an entire dataset. If the chunk cache (1MB by default) is smaller than one chunk, HDF5 re-reads and
+    re-decompresses the whole chunk for *every* partial read, so partial loading becomes orders of
+    magnitude slower than reading the entire file. Note that HDF5 allocates cache lazily, so a generous
+    limit costs nothing when reads are sequential.
+    """
+    return h5py.File(filename, mode, rdcc_nbytes=_chunk_cache_nbytes, rdcc_nslots=_chunk_cache_nslots)
+
+
 class _GadgetHdfMultiFileManager:
     _nfiles_groupname = "Header"
     _nfiles_attrname = "NumFilesPerSnapshot"
@@ -85,7 +101,7 @@ class _GadgetHdfMultiFileManager:
             self._filenames = [filename]
             self._numfiles = 1
         else:
-            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
+            h1 = _open_hdf_file(self._make_filename_for_cpu(filename, 0), mode)
             self._numfiles = self._get_num_files(h1)
             if hasattr(self._numfiles, "__len__"):
                 assert len(self._numfiles) == 1
@@ -106,7 +122,7 @@ class _GadgetHdfMultiFileManager:
     def __iter__(self) :
         for i in range(self._numfiles) :
             if i not in self._open_files:
-                self._open_files[i] = h5py.File(self._filenames[i], self._mode)
+                self._open_files[i] = _open_hdf_file(self._filenames[i], self._mode)
                 if self._subgroup_name is not None:
                     self._open_files[i] = self._open_files[i][self._subgroup_name]
 

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 
 from .. import halo, units, util
-from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
+from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager, _open_hdf_file
 
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
@@ -85,7 +85,7 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 target_group = hdf_vfile.create_group(group_name)
                 self._make_hdf_group_with_slicing(source_groups, source_slices, target_group)
 
-        self._hdf_vfile = h5py.File(name=tmpfile_path, mode='r')
+        self._hdf_vfile = _open_hdf_file(tmpfile_path, mode='r')
         self._finalizer = weakref.finalize(self, self._finalize, self._hdf_vfile, temp_dir_path)
 
     @classmethod
@@ -104,28 +104,56 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
         return source_groups, source_slices
 
     def _generate_groups_and_slices_from_cells(self, group_name, take_cells):
-        # we get the cell info from the first file, and assume it's consistent between files
-        offsets = self[0]['Cells']['OffsetsInFile'][group_name]
-        lens = self[0]['Cells']['Counts'][group_name]
-        file_responsible = self[0]['Cells']['Files'][group_name]
+        # we get the cell info from the first file, and assume it's consistent between files.
+        # Read it into memory in one go; indexing the hdf5 datasets cell-by-cell is very slow.
+        offsets = self[0]['Cells']['OffsetsInFile'][group_name][:]
+        lens = self[0]['Cells']['Counts'][group_name][:]
+        file_responsible = self[0]['Cells']['Files'][group_name][:]
 
-        # First, make a map from the file ID to the slices to be taken from that file
-        file_id_to_slices_map = {}
-        for cell in take_cells:
-            if file_responsible[cell] not in file_id_to_slices_map:
-                file_id_to_slices_map[file_responsible[cell]] = []
-            sl = slice(offsets[cell], offsets[cell] + lens[cell])
-            file_id_to_slices_map[file_responsible[cell]].append(sl)
+        take_cells = np.asarray(take_cells)
+        files_for_take_cells = file_responsible[take_cells]
 
-        # Now, reformat everything into the format expected by _make_hdf_group_with_slicing
         source_slices = []
         source_groups = []
 
-        for file_id in sorted(list(file_id_to_slices_map)):
-            source_groups.append(self[file_id][group_name])
-            source_slices.append(sorted(file_id_to_slices_map[file_id]))
+        for file_id in np.unique(files_for_take_cells):
+            cells_this_file = take_cells[files_for_take_cells == file_id]
+            slices_this_file = self._coalesce_cells_into_slices(offsets[cells_this_file], lens[cells_this_file])
+            if len(slices_this_file) == 0:
+                continue
+            source_groups.append(self[int(file_id)][group_name])
+            source_slices.append(slices_this_file)
 
         return source_groups, source_slices
+
+    @staticmethod
+    def _coalesce_cells_into_slices(offsets, lens):
+        """Convert per-cell offsets and lengths into a minimal list of ascending, non-adjacent slices.
+
+        Merging cells that are adjacent on disk is essential for performance: reading from an HDF5 virtual
+        dataset costs a roughly constant overhead for each mapping that is touched, so the number of
+        mappings, rather than the amount of data, dominates the time taken to load a partially-loaded
+        snapshot. Cells are normally stored in cell order, so taking a contiguous range of cells collapses
+        to a single mapping.
+        """
+        order = np.argsort(offsets)
+        offsets = np.asarray(offsets)[order]
+        ends = offsets + np.asarray(lens)[order]
+
+        non_empty = ends > offsets
+        offsets, ends = offsets[non_empty], ends[non_empty]
+
+        if len(offsets) == 0:
+            return []
+
+        # a new slice starts wherever a cell does not begin exactly where the previous one ended
+        starts_new_slice = np.ones(len(offsets), dtype=bool)
+        starts_new_slice[1:] = offsets[1:] != ends[:-1]
+
+        slice_starts = np.where(starts_new_slice)[0]
+        slice_ends = np.append(slice_starts[1:], len(offsets)) - 1
+
+        return [slice(int(offsets[start]), int(ends[end])) for start, end in zip(slice_starts, slice_ends)]
 
     def _make_hdf_group_with_slicing(self, source_groups, source_slices, target_group):
         total_len = 0

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -137,6 +137,33 @@ def test_swift_multifile_partial_loading():
                           [ 16.59894837,  36.67247821,  85.82433427],
                           [  9.79404938,  52.28051827,  81.30710868]])
 
+def test_coalesce_cells_into_slices():
+    """Cells that are adjacent on disk must be merged into a single slice.
+
+    Each slice becomes a mapping in the virtual dataset, and reading from a virtual dataset costs a
+    roughly fixed overhead per mapping touched, so failing to merge makes partial loads very slow."""
+    coalesce = pynbody.snapshot.swift.SwiftMultiFileManager._coalesce_cells_into_slices
+
+    # a contiguous run of cells becomes a single slice, whatever order it is presented in
+    assert coalesce(np.array([0, 10, 25]), np.array([10, 15, 5])) == [slice(0, 30)]
+    assert coalesce(np.array([25, 0, 10]), np.array([5, 10, 15])) == [slice(0, 30)]
+
+    # gaps are respected
+    assert coalesce(np.array([0, 10, 40]), np.array([10, 15, 5])) == [slice(0, 25), slice(40, 45)]
+
+    # empty cells neither generate slices nor break up a run
+    assert coalesce(np.array([0, 10, 10]), np.array([10, 0, 15])) == [slice(0, 25)]
+    assert coalesce(np.array([0, 10]), np.array([0, 0])) == []
+
+
+def test_partial_loading_uses_minimal_virtual_mappings():
+    """Check contiguous cells result in a single mapping per array; see test_coalesce_cells_into_slices"""
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", take_swift_cells=np.arange(0, 256))
+    for group_name in ('PartType0', 'PartType1'):
+        dataset = f._hdf_files._hdf_vfile[group_name]['ParticleIDs']
+        assert len(dataset.virtual_sources()) == 1
+
+
 def test_swift_multifile_partial_loading_order_insensitive():
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
                      take_swift_cells=[0, 5, 20, 200])


### PR DESCRIPTION
I am seeing very poor performance when loading part of a SWIFT file. This PR addresses the issue.

- Added configuration options for HDF5 chunk cache size and slots in default_config.ini.
- Implemented a custom _open_hdf_file function to optimize file opening with chunk caching.
- Updated SwiftMultiFileManager to utilize the new chunk cache settings for efficient partial reads.
- Introduced a coalesce_cells_into_slices method to minimize virtual mappings for contiguous cells.
- Added tests to verify the effectiveness of the new optimizations.

@jchelly I am not sure how this interacts with your #1003.  Likely it removes the need for some of these optimisations - but perhaps not all. Your comments would be very welcome!