### PR TITLE
Adapt GadgetHdfSnap to use the hdfstream service to access snapshots

### DIFF
--- a/.github/actions/start-hdfstream/action.yml
+++ b/.github/actions/start-hdfstream/action.yml
@@ -1,0 +1,40 @@
+name: 'Start hdfstream'
+description: 'Start the hdfstream service with a mounted directory'
+inputs:
+  data-dir:
+    description: 'Directory with the files to serve'
+    required: true
+    default: './data/'
+  virtual-prefix:
+    description: 'Virtual directory prefix to use'
+    required: true
+    default: 'Data'
+  image:
+    description: 'Server container image to use'
+    required: true
+    default: ghcr.io/jchelly/hdfstream-api:0.0.10
+runs:
+  using: "composite"
+  steps:
+    - name: Start hdfstream service with tests/data mounted
+      shell: bash
+      run: |
+        docker run -d \
+          --name hdfstream \
+          -p 8080:8080 \
+          -v ${{ inputs.data-dir }}:/opt/hdfstream/data:ro \
+          -e HDFSTREAM_PREFIX=${{ inputs.virtual-prefix }} \
+          ${{ inputs.image }}
+    - name: Wait until hdfstream service is responding
+      shell: bash
+      run: |
+        for i in {1..30}; do
+          status=$(docker inspect --format='{{.State.Health.Status}}' hdfstream)
+          if [ "$status" = "healthy" ]; then
+            echo "Service is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Service did not become healthy in time"
+        exit 1

--- a/.github/actions/stop-hdfstream/action.yml
+++ b/.github/actions/stop-hdfstream/action.yml
@@ -1,0 +1,8 @@
+name: "Stop hdfstream"
+description: "Stop and remove the hdfstream container"
+runs:
+  using: "composite"
+  steps:
+    - name: Stop the hdfstream service
+      shell: bash
+      run: docker rm -f hdfstream

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,6 +50,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install numpy==${{ matrix.numpy-version }}
+        python -m pip install hdfstream
     - name: Build and install pynbody
       run: |
         python -m pip install -v .[tests]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,6 +20,11 @@ jobs:
         os: [ubuntu-latest, windows-2025]
         python-version: ["3.12", "3.13", "3.14"]
         numpy-version: ["2.1.0", "2.5.0"]
+        include:
+          - os: ubuntu-latest
+            test_flags: "--hdfstream-server=http://localhost:8080/hdfstream"
+          - os: windows-2025
+            test_flags: ""
         exclude:
           - python-version: "3.14"
             numpy-version: "2.1.0"
@@ -70,9 +75,17 @@ jobs:
         DESTDIR=$(python -c "import pynbody ; import os ; print(os.path.dirname(pynbody.analysis.__file__))")
         cp *.npz "${DESTDIR}"
 
-    - name: Run all tests
+    - name: Start hdfstream container to serve test data
+      uses: ./.github/actions/start-hdfstream
+      if: ${{ (matrix.os == 'ubuntu-latest') }}
+      with:
+        data-dir: ./tests/testdata
+        virtual-prefix: testdata
+        image: ghcr.io/jchelly/hdfstream-api:0.0.10
+
+    - name: Run tests
       working-directory: tests
-      run: python -m pytest --ignore=testdata/ --tb=short
+      run: python -m pytest --ignore=testdata/ --tb=short ${{ matrix.test_flags }}
     # Following is temporarily necessary because of the >2.0.0rc1 numpy version
     - name: sanitize artifact name
       if: always()
@@ -85,3 +98,7 @@ jobs:
       with:
         name: ${{ env.TARGET_SANI }}
         path: tests/result*.npy
+
+    - name: Stop hdfstream container
+      uses: ./.github/actions/stop-hdfstream
+      if: ${{ (matrix.os == 'ubuntu-latest') }}

--- a/pynbody/default_config.ini
+++ b/pynbody/default_config.ini
@@ -109,6 +109,19 @@ StellarFormationTime: tform
 BHFormationTime: tform
 Potential: phi
 
+[gadgethdf]
+# Size of the HDF5 chunk cache, in bytes, used when opening gadget-like HDF5 files (including swift).
+# Simulation snapshots are often written as large compressed chunks, and HDF5 must decompress an entire
+# chunk to satisfy even a small read. If the cache cannot hold a chunk, that decompression is repeated
+# for every read, which makes partial loading extremely slow. The default of 64MB is enough to hold a
+# few chunks of a typical snapshot. Note that this is a cap rather than an allocation, and that whole-
+# chunk reads bypass the cache, so full snapshot loads are unaffected by this setting.
+chunk-cache-nbytes: 67108864
+
+# Number of slots in the HDF5 chunk cache. Should be a prime number, ideally at least ten times the
+# number of chunks that can fit in the cache.
+chunk-cache-nslots: 5051
+
 [gadgethdf-type-mapping]
 # GadgetHDF stores six different particle types (numbered 0 to 5). This specifies how they map
 # onto pynbody particle types by default. To override, you can either make your own configuration

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -42,7 +42,11 @@ def load(filename, *args, **kwargs) -> SimSnap:
     priority = kwargs.pop('priority', config['snap-class-priority'])
 
     for c in SimSnap.iter_subclasses_with_priority(priority):
-        if c._can_load(filename):
+        if "remote_dir" in kwargs:
+            if hasattr(c, "_can_load_remote") and c._can_load_remote(filename, *args, **kwargs):
+                logger.info("Loading using backend %s" % str(c))
+                return c(filename, *args, **kwargs)
+        elif c._can_load(filename):
             logger.info("Loading using backend %s" % str(c))
             return c(filename, *args, **kwargs)
 

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -43,7 +43,7 @@ def load(filename, *args, **kwargs) -> SimSnap:
 
     for c in SimSnap.iter_subclasses_with_priority(priority):
         if "remote_dir" in kwargs:
-            if hasattr(c, "_can_load_remote") and c._can_load_remote(filename, *args, **kwargs):
+            if hasattr(c, "_can_load_remote") and c._can_load_remote(filename, kwargs["remote_dir"]):
                 logger.info("Loading using backend %s" % str(c))
                 return c(filename, *args, **kwargs)
         elif c._can_load(filename):

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -1098,8 +1098,8 @@ class GadgetHDFSnap(SimSnap):
             vel_unit*units.cm/units.s, dist_unit*units.cm, mass_unit*units.g, "K"]]
 
     @classmethod
-    def _test_for_hdf5_key(cls, f):
-        with h5py.File(f, "r") as h5test:
+    def _test_for_hdf5_key(cls, f, method):
+        with method.File(f, "r") as h5test:
             test_key = cls._readable_hdf5_test_key
             found = False
             if test_key[-1]=="?":
@@ -1128,29 +1128,27 @@ class GadgetHDFSnap(SimSnap):
         return f.with_suffix(".0.hdf5")
 
     @classmethod
-    def _can_load(cls, f):
-        if hasattr(h5py, "is_hdf5"):
-            if h5py.is_hdf5(f):
-                return cls._test_for_hdf5_key(f)
-            elif h5py.is_hdf5(cls._guess_file_ending(f)):
-                return cls._test_for_hdf5_key(cls._guess_file_ending(f))
+    def _can_load_local_or_remote(cls, f, method):
+        if hasattr(method, "is_hdf5"):
+            if method.is_hdf5(f):
+                return cls._test_for_hdf5_key(f, method)
+            elif method.is_hdf5(cls._guess_file_ending(f)):
+                return cls._test_for_hdf5_key(cls._guess_file_ending(f), method)
             else:
                 return False
         else:
-            if "hdf5" in f:
+            if "hdf5" in f and method is h5py:
                 warnings.warn(
                     "It looks like you're trying to load HDF5 files, but python's HDF support (h5py module) is missing.", RuntimeWarning)
             return False
 
     @classmethod
-    def _can_load_remote(cls, f, *args, **kwargs):
-        remote_dir = kwargs.get("remote_dir")
-        if (hdfstream is None) or (remote_dir is None):
-            return False
-        for filename in (f, cls._guess_file_ending(f)):
-            if filename in remote_dir and remote_dir[filename].is_hdf5():
-                return cls._readable_hdf5_test_key in remote_dir[filename]
-        return False
+    def _can_load(cls, f):
+        return cls._can_load_local_or_remote(f, h5py)
+
+    @classmethod
+    def _can_load_remote(cls, f, remote_dir):
+        return cls._can_load_local_or_remote(f, remote_dir)
 
     def _init_properties(self):
         atr = self._get_hdf_header_attrs()

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -118,6 +118,12 @@ class _GadgetHdfMultiFileManager:
             assert filename0 == self._filenames[0]
             self._cache_file(0, file0)
 
+    def max_buf(self):
+        if self._remote_dir is not None:
+            return (2 << 63) # don't chunk http requests
+        else:
+            return _max_buf
+
     def _open_file(self, filename, mode):
         if self._remote_dir is None:
             return _open_hdf_file(filename, mode)
@@ -418,7 +424,7 @@ class HDFArrayLoader:
     def __init_load_map(self, take = None):
         """ Set up family slice and particle count for loading """
 
-        self._load_control = chunk.LoadControl(self._file_ptype_slice, _max_buf, take) # use HDF groups type instead of family type here
+        self._load_control = chunk.LoadControl(self._file_ptype_slice, self._hdf_files.max_buf(), take) # use HDF groups type instead of family type here
         self._family_slice_to_load = {}
         self._num_particles_to_load = self._load_control.mem_num_particles
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -128,6 +128,8 @@ class _GadgetHdfMultiFileManager:
         if self._remote_dir is None:
             return _open_hdf_file(filename, mode)
         else:
+            if mode != "r":
+                raise NotImplementedError("Unable to open remote files in writable mode!")
             return self._remote_dir[filename]
 
     def _is_hdf5(self, filename, *args, **kwargs):

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -219,7 +219,7 @@ class _HDFFileIterator:
         self._hdf_file_iterator = hdf_file_iterator
         self.current_hdf_file = None
         self.file_index = -1
-        self.particle_offset = 0 
+        self.particle_offset = 0
         self.select_file(0)
 
     def select_file(self, offset):
@@ -235,7 +235,7 @@ class _HDFArrayFiller:
     """A helper class to fill a pynbody array from an HDF5 dataset."""
 
     def __init__(self, sim_array_to_fill = None, hdf_dataset = None):
-        
+
         # default element size for simulation arrays
         self.sim_element_size = 1 if sim_array_to_fill is None else self._get_element_size(sim_array_to_fill)
         self.file_element_size = 1 if hdf_dataset is None else self._get_element_size(hdf_dataset)
@@ -245,7 +245,7 @@ class _HDFArrayFiller:
         """Update the element size for the simulation array."""
         self.sim_element_size = self._get_element_size(sim_array_to_fill)
         self._update_scaling_factor()
-    
+
     def _update_file_element_size(self, hdf_dataset):
         """Update the element size for the HDF5 dataset."""
         self.file_element_size = self._get_element_size(hdf_dataset)
@@ -294,18 +294,32 @@ class _HDFArrayFiller:
                 return slice(source_sel[0], source_sel[-1] + 1)
         return source_sel
 
-    def _fill_from_fancy_index(self, sim_array_to_fill, hdf_dataset, source_sel):
-        """Fill array from a non-contiguous (fancy) index."""
+    def _get_data_to_fill_local(self, sim_array_to_fill, hdf_dataset, source_sel):
+        """Read the selected elements from a local HDF5 file"""
         id_min, id_max = source_sel[0], source_sel[-1]
         num_read = id_max - id_min + 1
         indices_in_read_chunk = source_sel - id_min
-
         contiguous_hdf_slice = self._get_contiguous_hdf_slice(id_min, id_max)
-
         data_chunk_from_hdf = hdf_dataset[contiguous_hdf_slice]
         data_chunk_from_hdf = data_chunk_from_hdf.reshape(num_read, *sim_array_to_fill.shape[1:])
+        return data_chunk_from_hdf[indices_in_read_chunk]
 
-        final_data_to_fill = data_chunk_from_hdf[indices_in_read_chunk]
+    def _get_data_to_fill_remote(self, sim_array_to_fill, hdf_dataset, source_sel):
+        """Read the selected elements from a remote file using the hdfstream module"""
+        if self.need_rescale:
+            flat_index = (self.scale_factor * np.asarray(source_sel)[:,None] + np.arange(self.scale_factor, dtype=int)).flatten()
+            flat_data = hdf_dataset[flat_index]
+            final_data_to_fill = flat_data.reshape((len(source_sel),self.scaling_factor))
+        else:
+            final_data_to_fill = hdf_dataset[source_sel,...]
+        return final_data_to_fill
+
+    def _fill_from_fancy_index(self, sim_array_to_fill, hdf_dataset, source_sel):
+        """Fill array from a non-contiguous (fancy) index."""
+        if hdfstream is not None and isinstance(hdf_dataset, hdfstream.RemoteDataset):
+            final_data_to_fill = self._get_data_to_fill_remote(sim_array_to_fill, hdf_dataset, source_sel)
+        else:
+            final_data_to_fill = self._get_data_to_fill_local(sim_array_to_fill, hdf_dataset, source_sel)
 
         if sim_array_to_fill.shape == final_data_to_fill.shape:
             sim_array_to_fill[:] = final_data_to_fill
@@ -314,7 +328,7 @@ class _HDFArrayFiller:
 
     def _fill_from_slice(self, sim_array_to_fill, hdf_dataset, source_sel):
         """Fill array from a contiguous slice."""
-        
+
         if self.need_rescale:
             source_sel = self._get_contiguous_hdf_slice(source_sel.start, source_sel.stop - 1)
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
     h5py = None
 
+try:
+    import hdfstream
+except ImportError:
+    hdfstream = None
+
 _default_type_map = {}
 for x in family.family_names():
     try:
@@ -94,16 +99,17 @@ class _GadgetHdfMultiFileManager:
     _size_from_hdf5_key = "ParticleIDs"
     _subgroup_name = None
 
-    def __init__(self, filename, mode='r') :
+    def __init__(self, filename, mode='r', remote_dir=None):
         filename = str(filename)
         self._mode = mode
         self._open_files = {}
-        if h5py.is_hdf5(filename):
+        self._remote_dir = remote_dir
+        if self._is_hdf5(filename):
             self._filenames = [filename]
             self._numfiles = 1
         else:
             filename0 = self._make_filename_for_cpu(filename, 0)
-            file0 = _open_hdf5_file(filename0, mode)
+            file0 = self._open_file(filename0, mode)
             self._numfiles = self._get_num_files(file0)
             if hasattr(self._numfiles, "__len__"):
                 assert len(self._numfiles) == 1
@@ -111,6 +117,18 @@ class _GadgetHdfMultiFileManager:
             self._filenames = [self._make_filename_for_cpu(filename, i) for i in range(self._numfiles)]
             assert filename0 == self._filenames[0]
             self._cache_file(0, file0)
+
+    def _open_file(self, filename, mode):
+        if self._remote_dir is None:
+            return _open_hdf_file(filename, mode)
+        else:
+            return self._remote_dir[filename]
+
+    def _is_hdf5(self, filename, *args, **kwargs):
+        if self._remote_dir is None:
+            return h5py.is_hdf5(filename)
+        else:
+            return self._remote_dir.is_hdf5(filename)
 
     def _get_num_files(self, first_file):
         return first_file[self._nfiles_groupname].attrs[self._nfiles_attrname]
@@ -130,7 +148,7 @@ class _GadgetHdfMultiFileManager:
     def __iter__(self) :
         for i in range(self._numfiles) :
             if i not in self._open_files:
-                self._cache_file(i, _open_hdf5_file(self._filenames[i], self._mode))
+                self._cache_file(i, self._open_file(self._filenames[i], self._mode))
             yield self._open_files[i]
 
     def __getitem__(self, i) :
@@ -533,7 +551,7 @@ class GadgetHDFSnap(SimSnap):
 
     _units_need_hubble_factors = True
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, remote_dir=None, **kwargs):
         """Initialise a Gadget HDF snapshot.
 
         Spanned files are supported. To load a range of files ``snap.0.hdf5``, ``snap.1.hdf5``, ... ``snap.n.hdf5``,
@@ -544,7 +562,7 @@ class GadgetHDFSnap(SimSnap):
 
         self._filename = filename
 
-        self._init_hdf_filemanager(filename)
+        self._init_hdf_filemanager(filename, remote_dir=remote_dir)
 
         self._translate_array_name = namemapper.AdaptiveNameMapper(self._namemapper_config_section,
                                                                    return_all_format_names=True) # required for swift
@@ -604,8 +622,8 @@ class GadgetHDFSnap(SimSnap):
     def _get_hdf_unit_attrs(self):
         return self._hdf_files.get_unit_attrs()
 
-    def _init_hdf_filemanager(self, filename):
-        self._hdf_files = self._multifile_manager_class(filename)
+    def _init_hdf_filemanager(self, filename, **kwargs):
+        self._hdf_files = self._multifile_manager_class(filename, **kwargs)
 
     def __init_loadable_keys(self):
 
@@ -1101,6 +1119,16 @@ class GadgetHDFSnap(SimSnap):
                 warnings.warn(
                     "It looks like you're trying to load HDF5 files, but python's HDF support (h5py module) is missing.", RuntimeWarning)
             return False
+
+    @classmethod
+    def _can_load_remote(cls, f, *args, **kwargs):
+        remote_dir = kwargs.get("remote_dir")
+        if (hdfstream is None) or (remote_dir is None):
+            return False
+        for filename in (f, cls._guess_file_ending(f)):
+            if filename in remote_dir and remote_dir[filename].is_hdf5():
+                return cls._readable_hdf5_test_key in remote_dir[filename]
+        return False
 
     def _init_properties(self):
         atr = self._get_hdf_header_attrs()

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -49,6 +49,10 @@ for hdf_groups in _default_type_map.values():
 
 _max_buf = 1024 * 512 # max_chunk for chunk.LoadControl
 
+# HDF5 chunk cache to use when opening files; see _open_hdf_file below
+_chunk_cache_nbytes = int(config_parser.get('gadgethdf', 'chunk-cache-nbytes'))
+_chunk_cache_nslots = int(config_parser.get('gadgethdf', 'chunk-cache-nslots'))
+
 class _DummyHDFData:
 
     """A stupid class to allow emulation of mass arrays for particles
@@ -72,6 +76,18 @@ class _DummyHDFData:
         target[:] = self.value
 
 
+def _open_hdf_file(filename, mode='r'):
+    """Open an HDF5 file with a chunk cache large enough for partial reads to be efficient.
+
+    Snapshots are routinely written as compressed chunks that are megabytes in size, sometimes spanning
+    an entire dataset. If the chunk cache (1MB by default) is smaller than one chunk, HDF5 re-reads and
+    re-decompresses the whole chunk for *every* partial read, so partial loading becomes orders of
+    magnitude slower than reading the entire file. Note that HDF5 allocates cache lazily, so a generous
+    limit costs nothing when reads are sequential.
+    """
+    return h5py.File(filename, mode, rdcc_nbytes=_chunk_cache_nbytes, rdcc_nslots=_chunk_cache_nslots)
+
+
 class _GadgetHdfMultiFileManager:
     _nfiles_groupname = "Header"
     _nfiles_attrname = "NumFilesPerSnapshot"
@@ -85,7 +101,7 @@ class _GadgetHdfMultiFileManager:
             self._filenames = [filename]
             self._numfiles = 1
         else:
-            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
+            h1 = _open_hdf_file(self._make_filename_for_cpu(filename, 0), mode)
             self._numfiles = self._get_num_files(h1)
             if hasattr(self._numfiles, "__len__"):
                 assert len(self._numfiles) == 1
@@ -106,7 +122,7 @@ class _GadgetHdfMultiFileManager:
     def __iter__(self) :
         for i in range(self._numfiles) :
             if i not in self._open_files:
-                self._open_files[i] = h5py.File(self._filenames[i], self._mode)
+                self._open_files[i] = _open_hdf_file(self._filenames[i], self._mode)
                 if self._subgroup_name is not None:
                     self._open_files[i] = self._open_files[i][self._subgroup_name]
 

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -10,9 +10,9 @@ from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
-    def __init__(self, filename, mode='r', take_swift_cells=None, take_region=None):
+    def __init__(self, filename, mode='r', take_swift_cells=None, take_region=None, **kwargs):
 
-        super().__init__(filename, mode)
+        super().__init__(filename, mode, **kwargs)
 
         if take_swift_cells is not None and take_region is not None:
             raise ValueError("Either take_swift_cells or take_region must be specified, not both")
@@ -184,7 +184,7 @@ class SwiftSnap(GadgetHDFSnap):
 
     _namemapper_config_section = 'swift-name-mapping'
 
-    def __init__(self, filename, take_swift_cells=None, take_region=None):
+    def __init__(self, filename, take_swift_cells=None, take_region=None, **kwargs):
         """Initialise a SWIFT snapshot.
 
         Extra parameters can be passed to the multi file manager by
@@ -193,10 +193,11 @@ class SwiftSnap(GadgetHDFSnap):
         """
         self._take_swift_cells = take_swift_cells
         self._take_region = take_region
-        super().__init__(filename)
+        super().__init__(filename, **kwargs)
 
-    def _init_hdf_filemanager(self, filename):
-        self._hdf_files = self._multifile_manager_class(filename, take_swift_cells=self._take_swift_cells, take_region=self._take_region)
+    def _init_hdf_filemanager(self, filename, **kwargs):
+        self._hdf_files = self._multifile_manager_class(filename, take_swift_cells=self._take_swift_cells,
+                                                        take_region=self._take_region, **kwargs)
 
     def _get_take_parameter(self, **kwargs):
         return self._hdf_files.get_take_parameter(list(self._families_ordered()), self._family_to_group_map)

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 
 from .. import halo, units, util
-from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
+from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager, _open_hdf_file
 
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
@@ -85,7 +85,7 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
                 target_group = hdf_vfile.create_group(group_name)
                 self._make_hdf_group_with_slicing(source_groups, source_slices, target_group)
 
-        self._hdf_vfile = h5py.File(name=tmpfile_path, mode='r')
+        self._hdf_vfile = _open_hdf_file(tmpfile_path, mode='r')
         self._finalizer = weakref.finalize(self, self._finalize, self._hdf_vfile, temp_dir_path)
 
     @classmethod
@@ -104,28 +104,56 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
         return source_groups, source_slices
 
     def _generate_groups_and_slices_from_cells(self, group_name, take_cells):
-        # we get the cell info from the first file, and assume it's consistent between files
-        offsets = self[0]['Cells']['OffsetsInFile'][group_name]
-        lens = self[0]['Cells']['Counts'][group_name]
-        file_responsible = self[0]['Cells']['Files'][group_name]
+        # we get the cell info from the first file, and assume it's consistent between files.
+        # Read it into memory in one go; indexing the hdf5 datasets cell-by-cell is very slow.
+        offsets = self[0]['Cells']['OffsetsInFile'][group_name][:]
+        lens = self[0]['Cells']['Counts'][group_name][:]
+        file_responsible = self[0]['Cells']['Files'][group_name][:]
 
-        # First, make a map from the file ID to the slices to be taken from that file
-        file_id_to_slices_map = {}
-        for cell in take_cells:
-            if file_responsible[cell] not in file_id_to_slices_map:
-                file_id_to_slices_map[file_responsible[cell]] = []
-            sl = slice(offsets[cell], offsets[cell] + lens[cell])
-            file_id_to_slices_map[file_responsible[cell]].append(sl)
+        take_cells = np.asarray(take_cells)
+        files_for_take_cells = file_responsible[take_cells]
 
-        # Now, reformat everything into the format expected by _make_hdf_group_with_slicing
         source_slices = []
         source_groups = []
 
-        for file_id in sorted(list(file_id_to_slices_map)):
-            source_groups.append(self[file_id][group_name])
-            source_slices.append(sorted(file_id_to_slices_map[file_id]))
+        for file_id in np.unique(files_for_take_cells):
+            cells_this_file = take_cells[files_for_take_cells == file_id]
+            slices_this_file = self._coalesce_cells_into_slices(offsets[cells_this_file], lens[cells_this_file])
+            if len(slices_this_file) == 0:
+                continue
+            source_groups.append(self[int(file_id)][group_name])
+            source_slices.append(slices_this_file)
 
         return source_groups, source_slices
+
+    @staticmethod
+    def _coalesce_cells_into_slices(offsets, lens):
+        """Convert per-cell offsets and lengths into a minimal list of ascending, non-adjacent slices.
+
+        Merging cells that are adjacent on disk is essential for performance: reading from an HDF5 virtual
+        dataset costs a roughly constant overhead for each mapping that is touched, so the number of
+        mappings, rather than the amount of data, dominates the time taken to load a partially-loaded
+        snapshot. Cells are normally stored in cell order, so taking a contiguous range of cells collapses
+        to a single mapping.
+        """
+        order = np.argsort(offsets)
+        offsets = np.asarray(offsets)[order]
+        ends = offsets + np.asarray(lens)[order]
+
+        non_empty = ends > offsets
+        offsets, ends = offsets[non_empty], ends[non_empty]
+
+        if len(offsets) == 0:
+            return []
+
+        # a new slice starts wherever a cell does not begin exactly where the previous one ended
+        starts_new_slice = np.ones(len(offsets), dtype=bool)
+        starts_new_slice[1:] = offsets[1:] != ends[:-1]
+
+        slice_starts = np.where(starts_new_slice)[0]
+        slice_ends = np.append(slice_starts[1:], len(offsets)) - 1
+
+        return [slice(int(offsets[start]), int(ends[end])) for start, end in zip(slice_starts, slice_ends)]
 
     def _make_hdf_group_with_slicing(self, source_groups, source_slices, target_group):
         total_len = 0

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -299,16 +299,7 @@ class SwiftSnap(GadgetHDFSnap):
         Here we check that we have the expected number of keys (given by the
         NumberOfFields attribute) and assume that they're all datasets.
         """
-        if "NumberOfFields" in group.attrs:
-            if group.attrs["NumberOfFields"][0] == len(group):
-                return list(group.keys())
-            else:
-                # NumberOfFields can be wrong if we wrote a new field to the snapshot, for example.
-                warnings.warn(f"The NumberOfFields attribute of group {group.name} does not match the number of keys in the group",
-                              RuntimeWarning)
-                return GadgetHDFSnap._get_hdf_allarray_keys(group)
-        else:
-            raise ValueError(f"The expected NumberOfFields attribute of group {group.name} is not present")
+        return list(group.keys())
 
     def write_array(self, *args, **kwargs):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+try:
+    import hdfstream
+except ImportError:
+    hdfstream = None
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--hdfstream-server", type=str, default=None, help="hdfstream server URL for the test"
+    )
+    parser.addoption(
+        "--no-verify-cert", action="store_true", default=False, help="Don't verify SSL certificates if set"
+    )
+    parser.addoption(
+        "--testdata-prefix", type=str, default="/", help="Location of pynbody testdata dir on the server"
+    )
+
+@pytest.fixture(scope="module", params=[False, True])
+def load_kwargs(request):
+    if request.param:
+        # This is a remote file test. Get the server URL.
+        server = request.config.getoption("--hdfstream-server")
+        if server is None:
+            pytest.skip("hdfstream server URL not specified")
+        # Check we have the client module
+        if hdfstream is None:
+            pytest.skip("hdfstream client module not available")
+        # We might not have a valid certificate in development builds of the server
+        hdfstream.verify_cert(not request.config.getoption("--no-verify-cert"))
+        # Pynbody test data might be in a subdirectory on the server
+        prefix = request.config.getoption("--testdata-prefix")
+        # Open and return the remote directory
+        return {"remote_dir" : hdfstream.open(server, prefix)}
+    else:
+        # This is a local file test, so no extra args are needed
+        return {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,10 @@ def load_kwargs(request):
         server = request.config.getoption("--hdfstream-server")
         if server is None:
             pytest.skip("hdfstream server URL not specified")
-        # Check we have the client module
+        # Check we have the client module. If a server is specified but the
+        # client module is not present, tests should fail rather than skip.
         if hdfstream is None:
-            pytest.skip("hdfstream client module not available")
+            raise RuntimeError("Server URL was specified but the hdfstream module could not be imported")
         # We might not have a valid certificate in development builds of the server
         hdfstream.verify_cert(not request.config.getoption("--no-verify-cert"))
         # Pynbody test data might be in a subdirectory on the server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,23 +16,43 @@ def pytest_addoption(parser):
         "--testdata-prefix", type=str, default="/", help="Location of pynbody testdata dir on the server"
     )
 
+
+def _open_remote_dir(request):
+    """
+    Open the remote directory with the test data
+    """
+    # Get the server URL.
+    server = request.config.getoption("--hdfstream-server")
+    if server is None:
+        pytest.skip("hdfstream server URL not specified")
+    # Check we have the client module. If a server is specified but the
+    # client module is not present, tests should fail rather than skip.
+    if hdfstream is None:
+        raise RuntimeError("Server URL was specified but the hdfstream module could not be imported")
+    # We might not have a valid certificate in development builds of the server
+    hdfstream.verify_cert(not request.config.getoption("--no-verify-cert"))
+    # Pynbody test data might be in a subdirectory on the server
+    prefix = request.config.getoption("--testdata-prefix")
+    # Open and return the remote directory
+    return hdfstream.open(server, prefix)
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def remote_kwargs(request):
+    """
+    Returns the keyword args for load() to open a remote file.
+    """
+    return {"remote_dir" : _open_remote_dir(request)}
+
+
 @pytest.fixture(scope="module", params=[False, True])
 def load_kwargs(request):
+    """
+    This fixture can be used to repeat tests on local and remote files.
+    """
     if request.param:
-        # This is a remote file test. Get the server URL.
-        server = request.config.getoption("--hdfstream-server")
-        if server is None:
-            pytest.skip("hdfstream server URL not specified")
-        # Check we have the client module. If a server is specified but the
-        # client module is not present, tests should fail rather than skip.
-        if hdfstream is None:
-            raise RuntimeError("Server URL was specified but the hdfstream module could not be imported")
-        # We might not have a valid certificate in development builds of the server
-        hdfstream.verify_cert(not request.config.getoption("--no-verify-cert"))
-        # Pynbody test data might be in a subdirectory on the server
-        prefix = request.config.getoption("--testdata-prefix")
-        # Open and return the remote directory
-        return {"remote_dir" : hdfstream.open(server, prefix)}
+        # This is a remote file test
+        return {"remote_dir" : _open_remote_dir(request)}
     else:
         # This is a local file test, so no extra args are needed
         return {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def _open_remote_dir(request):
     return hdfstream.open(server, prefix)
 
 
-@pytest.fixture(scope="module", params=[False, True])
+@pytest.fixture(scope="module")
 def remote_kwargs(request):
     """
     Returns the keyword args for load() to open a remote file.

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -260,7 +260,7 @@ def test_remote_open(remote_kwargs):
     # Open the same file through the server and check we didn't just open the local file again
     remote_snap = pynbody.load(filename, **remote_kwargs)
     import hdfstream
-    assert isinstance(local_snap._hdf_files[0], hdfstream.RemoteFile)
+    assert isinstance(remote_snap._hdf_files[0], hdfstream.RemoteFile)
 
     # Compare file contents
     assert local_snap.families() == remote_snap.families()

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -245,3 +245,27 @@ def test_load_copy_issue_955(snap):
 
     snap_cop = snap[boundary_slice].load_copy()
     assert (snap_cop['iord'] == snap[boundary_slice]['iord']).all()
+
+
+def test_remote_open(remote_kwargs):
+    """
+    Try opening local and remote versions of the same file
+    """
+    filename = "testdata/gadget3/data/snapshot_103/snap_103.hdf5"
+
+    # Open the local HDF5 file
+    local_snap = pynbody.load(filename)
+    assert isinstance(local_snap._hdf_files[0], h5py.File)
+
+    # Open the same file through the server and check we didn't just open the local file again
+    remote_snap = pynbody.load(filename, **remote_kwargs)
+    import hdfstream
+    assert isinstance(local_snap._hdf_files[0], hdfstream.RemoteFile)
+
+    # Compare file contents
+    assert local_snap.families() == remote_snap.families()
+    assert local_snap.loadable_keys() == remote_snap.loadable_keys()
+    for fam in local_snap.families():
+        assert local_snap[fam].loadable_keys() == remote_snap[fam].loadable_keys()
+        assert np.all(local_snap[fam]["pos"] == remote_snap[fam]["pos"])
+        assert np.all(local_snap[fam]["iord"] == remote_snap[fam]["iord"])

--- a/tests/gadgethdf_test.py
+++ b/tests/gadgethdf_test.py
@@ -247,12 +247,13 @@ def test_load_copy_issue_955(snap):
     assert (snap_cop['iord'] == snap[boundary_slice]['iord']).all()
 
 
-def test_remote_open(remote_kwargs):
+@pytest.mark.parametrize('filename',
+                         ["testdata/gadget3/data/snapshot_103/snap_103.hdf5",
+                          "testdata/gadget3/snap_028_z000p000.0.hdf5"])
+def test_remote_open(remote_kwargs, filename):
     """
     Try opening local and remote versions of the same file
     """
-    filename = "testdata/gadget3/data/snapshot_103/snap_103.hdf5"
-
     # Open the local HDF5 file
     local_snap = pynbody.load(filename)
     assert isinstance(local_snap._hdf_files[0], h5py.File)
@@ -263,9 +264,11 @@ def test_remote_open(remote_kwargs):
     assert isinstance(remote_snap._hdf_files[0], hdfstream.RemoteFile)
 
     # Compare file contents
+    assert len(local_snap) == len(remote_snap)
     assert local_snap.families() == remote_snap.families()
     assert local_snap.loadable_keys() == remote_snap.loadable_keys()
     for fam in local_snap.families():
+        assert len(local_snap[fam]) == len(remote_snap[fam])
         assert local_snap[fam].loadable_keys() == remote_snap[fam].loadable_keys()
         assert np.all(local_snap[fam]["pos"] == remote_snap[fam]["pos"])
         assert np.all(local_snap[fam]["iord"] == remote_snap[fam]["iord"])

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -22,12 +22,12 @@ def get_data():
     pynbody.test_utils.ensure_test_data_available("swift_isolated")
     pynbody.test_utils.ensure_test_data_available("swift_planetary")
 
-def test_load_identifies_swift():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_load_identifies_swift(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
 
-def test_swift_properties():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_properties(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert np.allclose(f.properties['a'], 0.38234515)
     assert np.allclose(f.properties['z'], 1.61543791)
@@ -41,15 +41,15 @@ def test_swift_properties():
     # units, which is inconsistent with what swift actually outputs.
     assert np.allclose(f.properties['time'].in_units("s"), 1.28661456e17)
 
-def test_swift_noncosmological():
-    f = pynbody.load("testdata/SWIFT/isolated_0008.hdf5")
+def test_swift_noncosmological(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/isolated_0008.hdf5", **load_kwargs)
     assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert (f['pos'].units / pynbody.units.Unit("cm")).is_dimensionless()
 
 
 
-def test_swift_arrays():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_arrays(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert np.allclose(f.dm['pos'].units.ratio("Mpc a", **f.conversion_context()), 1.0)
     assert np.allclose(f.dm['vel'].units.ratio("km s^-1", **f.conversion_context()), 1.0)
     # the reason the following isn't exactly 1.0 is because our solar mass is slightly different to swift's
@@ -80,28 +80,28 @@ def _assert_multifile_contents_is_sensible(f):
                                                        [83.46050257, 20.91647755, 116.546989],
                                                        [125.83232028, 49.9732396, 72.2264199]]))
 
-def test_swift_multifile_with_vds():
-    f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5")
+def test_swift_multifile_with_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5", **load_kwargs)
     assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f._hdf_files) == 1
     assert f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
 
 
-def test_swift_multifile_without_vds():
-    f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000")
+def test_swift_multifile_without_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000", **load_kwargs)
     assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f._hdf_files) == 10
     assert not f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
 
-def test_swift_singlefile_is_not_vds():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_singlefile_is_not_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert not f._hdf_files.is_virtual()
 
-def test_swift_singlefile_partial_loading():
+def test_swift_singlefile_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5",
-                     take_swift_cells=[5,15,20,25])
+                     take_swift_cells=[5,15,20,25], **load_kwargs)
     assert len(f.dm) == 1849
     assert len(f.gas) == 1882
     assert (f.dm['iord'][::100] == [ 16468,   9172,  41176,  49874,   9342,  10234,  33908,  25852,
@@ -111,9 +111,9 @@ def test_swift_singlefile_partial_loading():
                                      26367,  2503, 26825, 10827, 59463, 26703, 51909, 27927, 12057,
                                      36761]).all()
 
-def test_swift_multifile_partial_loading():
+def test_swift_multifile_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0,5,20,200])
+                     take_swift_cells=[0,5,20,200], **load_kwargs)
 
     assert len(f) == 2048
 
@@ -140,22 +140,22 @@ def test_swift_multifile_partial_loading():
                           [ 16.59894837,  36.67247821,  85.82433427],
                           [  9.79404938,  52.28051827,  81.30710868]])
 
-def test_swift_multifile_partial_loading_order_insensitive():
+def test_swift_multifile_partial_loading_order_insensitive(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0, 5, 20, 200])
+                     take_swift_cells=[0, 5, 20, 200], **load_kwargs)
     f2 = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0, 5, 20, 200][::-1])
+                     take_swift_cells=[0, 5, 20, 200][::-1], **load_kwargs)
     assert (f['iord'] == f2['iord']).all()
 
-def test_swift_vds_partial_loading():
+def test_swift_vds_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5", # <-- VDS file
-                     take_swift_cells=[0,5,20,200])
+                     take_swift_cells=[0,5,20,200], **load_kwargs)
     f2 = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                      take_swift_cells=[0, 5, 20, 200][::-1])
+                      take_swift_cells=[0, 5, 20, 200][::-1], **load_kwargs)
     assert (f['iord'] == f2['iord']).all()
 
-def test_swift_fof_groups():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_fof_groups(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     h = f.halos(priority = ['HaloNumberCatalogue'])
 
     with raises(KeyError):
@@ -167,26 +167,26 @@ def test_swift_fof_groups():
 
     assert len(h) < 1000
 
-def test_swift_dtypes():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_dtypes(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert np.issubdtype(f['iord'].dtype, np.integer)
     assert np.issubdtype(f['pos'].dtype, np.floating)
 
 @pytest.mark.parametrize('test_region',
                          [pynbody.filt.Sphere(50., (50., 50., 50.)),
                          pynbody.filt.Cuboid(-20.0)]) # note the cuboid test region wraps around the box
-def test_swift_take_geometric_region(test_region):
+def test_swift_take_geometric_region(test_region, load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5",
-                     take_region = test_region)
+                     take_region = test_region, **load_kwargs)
 
-    f_full = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+    f_full = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert len(f) < len(f_full)
 
     assert np.all(f[test_region]['iord'] == f_full[test_region]['iord'])
 
-def test_swift_scalefactor_in_units():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_scalefactor_in_units(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     # naively, one would assume cm^2 s^-2, but actual units header says 1e10 a^2 cm^2 s^-2
     # So this tests pynbody respects that. Note that we don't give the scalefactor context,
@@ -246,14 +246,14 @@ def swift_snap_with_alternate_mass_naming():
     # clean up
     shutil.rmtree(tempdir)
 
-def test_alternate_mass_file(swift_snap_with_alternate_mass_naming):
+def test_alternate_mass_file(swift_snap_with_alternate_mass_naming, load_kwargs):
     f = pynbody.load(swift_snap_with_alternate_mass_naming)
-    f1 = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+    f1 = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert np.allclose(f['mass'], f1['mass'])
 
-def test_load_planetary():
-    f = pynbody.load("testdata/SWIFT/planetary.hdf5")
+def test_load_planetary(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/planetary.hdf5", **load_kwargs)
     assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f) == 1000
     assert len(f.gas) == 1000
@@ -276,8 +276,8 @@ def test_load_planetary_region():
         f = pynbody.load("testdata/SWIFT/planetary.hdf5", take_region=pynbody.filt.Sphere(10., (60., 60., 60.)))
     assert "No spatial index" in str(excinfo.value)
 
-def test_planetary_physical_units():
-    f = pynbody.load("testdata/SWIFT/planetary.hdf5")
+def test_planetary_physical_units(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/planetary.hdf5", **load_kwargs)
     f.physical_units('1e3 km')
     npt.assert_allclose(f['pos'][::100], [[ 64.96079021, 468.85991433, 313.24147579],
           [159.25107139, 424.78484083, 381.50705574],

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -137,6 +137,33 @@ def test_swift_multifile_partial_loading():
                           [ 16.59894837,  36.67247821,  85.82433427],
                           [  9.79404938,  52.28051827,  81.30710868]])
 
+def test_coalesce_cells_into_slices():
+    """Cells that are adjacent on disk must be merged into a single slice.
+
+    Each slice becomes a mapping in the virtual dataset, and reading from a virtual dataset costs a
+    roughly fixed overhead per mapping touched, so failing to merge makes partial loads very slow."""
+    coalesce = pynbody.snapshot.swift.SwiftMultiFileManager._coalesce_cells_into_slices
+
+    # a contiguous run of cells becomes a single slice, whatever order it is presented in
+    assert coalesce(np.array([0, 10, 25]), np.array([10, 15, 5])) == [slice(0, 30)]
+    assert coalesce(np.array([25, 0, 10]), np.array([5, 10, 15])) == [slice(0, 30)]
+
+    # gaps are respected
+    assert coalesce(np.array([0, 10, 40]), np.array([10, 15, 5])) == [slice(0, 25), slice(40, 45)]
+
+    # empty cells neither generate slices nor break up a run
+    assert coalesce(np.array([0, 10, 10]), np.array([10, 0, 15])) == [slice(0, 25)]
+    assert coalesce(np.array([0, 10]), np.array([0, 0])) == []
+
+
+def test_partial_loading_uses_minimal_virtual_mappings():
+    """Check contiguous cells result in a single mapping per array; see test_coalesce_cells_into_slices"""
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", take_swift_cells=np.arange(0, 256))
+    for group_name in ('PartType0', 'PartType1'):
+        dataset = f._hdf_files._hdf_vfile[group_name]['ParticleIDs']
+        assert len(dataset.virtual_sources()) == 1
+
+
 def test_swift_multifile_partial_loading_order_insensitive():
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
                      take_swift_cells=[0, 5, 20, 200])

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -438,20 +438,6 @@ def copied_snapshot():
         import gc
         gc.collect()
 
-def test_swift_no_number_of_fields(copied_snapshot):
-    """Check that we reject snapshots where the NumberOfFields attribute is missing"""
-    with h5py.File(copied_snapshot, "r+") as f:
-        del f["PartType1"].attrs["NumberOfFields"]
-    with raises(ValueError):
-        snap = pynbody.load(copied_snapshot)
-
-def test_swift_wrong_number_of_fields(copied_snapshot):
-    """Check that we warn on snapshots where the NumberOfFields attribute is wrong"""
-    with h5py.File(copied_snapshot, "r+") as f:
-        f["PartType1"].attrs["NumberOfFields"] += 1
-    with warns(RuntimeWarning):
-        snap = pynbody.load(copied_snapshot)
-
 
 @pytest.mark.parametrize('metadata_change', [
     # Dataset,                         index,   new value


### PR DESCRIPTION
This is another iteration on remote access to snapshots (see #1007 and #924). It's simpler now that the new SwiftSnap implementation (#1003) has been merged in.

  * `pynbody.load()` now takes an optional `remote_dir` parameter which can be set to a `hdfstream.RemoteDirectory` object to open a snapshot on the server
  * `GadgetHdfSnap` and sub-classes have a `_can_load_remote` method which checks if they can load the specified file from the server 
  * Files are opened through `GadgetHdfSnap._open_file()`, which knows whether to use h5py or hdfstream
  * An alternate implementation of `_fill_from_fancy_index` is used for remote files because we can send a list of slices to the server and get an array back
  * Some of the SWIFT tests are repeated on remote files, but not those that require writing new snapshots 

I've merged in the chunk cache change from #1008 because that also affects how files are opened.

With this implementation it's possible to open Gadget HDF5 and SWIFT snapshots on the server and to cut out regions from SWIFT snapshots. Cut out functionality for EAGLE could be added later.