### PR TITLE
Add user-defined pairwise SPH operations to KDTree

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -69,6 +69,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_array
 
-__version__ = '2.5.0'
+__version__ = '2.6.0'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -29,6 +29,21 @@ KDNode = np.dtype([
     ('pUpper', np.intp)
 ])
 
+def _scatter_add(out, index, contrib):
+    """Perform ``out[index] += contrib``, summing over repeated indices.
+
+    ``np.add.at`` would do this, but is very slow; ``out[index] += contrib``
+    is wrong, since it keeps only one contribution per repeated index.
+    """
+    npart = out.shape[0]
+    if out.ndim == 1:
+        out += np.bincount(index, weights=contrib, minlength=npart)
+    else:
+        for k in range(out.shape[1]):
+            out[:, k] += np.bincount(index, weights=contrib[..., k],
+                                     minlength=npart)
+
+
 class KDTree:
     """KDTree can be used for smoothing, interpolating and geometrical queries.
 
@@ -75,6 +90,12 @@ class KDTree:
     PROPID_QTYDISP_ND = 6
     PROPID_QTYDIV  = 7
     PROPID_QTYCURL = 8
+
+    PAIR_MODE_GATHER = 0
+    PAIR_MODE_SYMMETRIC = 1
+
+    _pair_modes = {'gather': PAIR_MODE_GATHER,
+                   'symmetric': PAIR_MODE_SYMMETRIC}
 
     def __init__(self, pos, mass, leafsize=32, boxsize=None, num_threads=None, shared_mem=False):
         """Create a KDTree
@@ -331,7 +352,31 @@ class KDTree:
             used. For more information see the documentation for :class:`pynbody.sph.kernels.create_kernel`.
         """
         from ..sph import kernels
-        self._kernel_id = kernels.create_kernel(kernel).get_c_kernel_id()
+        self._kernel = kernels.create_kernel(kernel)
+        self._kernel_id = self._kernel.get_c_kernel_id()
+
+    @property
+    def kernel(self):
+        """The SPH kernel currently in use by this tree.
+
+        .. versionadded:: 2.6.0
+
+        This is the same kernel object that the C++ smoothing routines are
+        using, so evaluating it from python (via
+        :meth:`~pynbody.sph.kernels.KernelBase.value` and
+        :meth:`~pynbody.sph.kernels.KernelBase.gradient`) is guaranteed to be
+        consistent with results from e.g. :meth:`sph_mean` or the ``rho``
+        array. This is what makes it possible to write a
+        :meth:`pair_reduce` callback without re-deriving the kernel
+        normalisation by hand.
+
+        See :meth:`set_kernel` to change it.
+        """
+        if getattr(self, '_kernel', None) is None:
+            # e.g. a tree restored by deserialize, which only stores the id
+            from ..sph import kernels
+            self._kernel = kernels.create_kernel_from_c_id(self._kernel_id)
+        return self._kernel
 
 
 
@@ -373,6 +418,231 @@ class KDTree:
         finally:
             # Free C-structures memory
             kdmain.nn_stop(self.kdtree, smx)
+
+    def pair_blocks(self, mode='symmetric', blocksize=1<<18):
+        r"""Iterate over neighbour pairs, in blocks, as flat numpy arrays.
+
+        .. versionadded:: 2.6.0
+
+        This is the low-level primitive underlying :meth:`pair_reduce`. Use it
+        directly when you want to do something with the pairs other than sum
+        over them.
+
+        Each iteration yields a tuple ``(i, j, dx, r)`` of arrays with the same
+        leading length ``nblock <= blocksize``:
+
+        =======  ======================  ==================================
+        name     shape / dtype           meaning
+        =======  ======================  ==================================
+        ``i``    ``(nblock,)`` intp      index of the first particle of each pair
+        ``j``    ``(nblock,)`` intp      index of the second particle of each pair
+        ``dx``   ``(nblock, 3)`` f8      periodic-wrapped ``pos[j] - pos[i]``
+        ``r``    ``(nblock,)`` f8        ``|dx|``, always strictly positive
+        =======  ======================  ==================================
+
+        Note that ``i`` and ``j`` are *arrays* of particle indices, one entry
+        per pair, so per-particle quantities are used via fancy indexing, e.g.
+        ``rho[i]`` is the density of the first particle of each pair.
+
+        Smoothing lengths are taken from the ``smooth`` array currently
+        associated with the tree, so accessing ``f['smooth']`` (or ``f['rho']``)
+        before calling this is what fixes the pair set.
+
+        Parameters
+        ----------
+        mode : str
+            Which pairs to generate.
+
+            * ``'symmetric'`` (default): every unordered pair with
+              :math:`r < \max(2 h_i, 2 h_j)`, exactly once, canonicalised so
+              that ``i < j``. This is what SPH operators involving both
+              smoothing lengths require, such as artificial viscosity or
+              conduction.
+            * ``'gather'``: every ordered pair with :math:`r < 2 h_i`. Both
+              ``(a, b)`` and ``(b, a)`` appear when each lies inside the
+              other's kernel. This is the neighbour set used by the density
+              estimate and by :meth:`sph_mean`.
+
+        blocksize : int
+            Maximum number of pairs per block. Blocks are arbitrary cuts of a
+            single stream of pairs, so a given particle's pairs will in general
+            straddle a block boundary. Larger blocks amortise the per-block
+            numpy overhead at the cost of memory; in practice throughput is
+            insensitive to this over a wide range, so the default is chosen to
+            keep the buffers small.
+
+        Yields
+        ------
+        tuple
+            ``(i, j, dx, r)`` as described above. The arrays are read-only, and
+            are not reused between blocks.
+
+        Examples
+        --------
+        Counting the neighbours of each particle:
+
+        >>> counts = np.zeros(len(f), dtype=int)
+        >>> for i, j, dx, r in f.kdtree.pair_blocks(mode='gather'):
+        ...     counts += np.bincount(i, minlength=len(f))
+
+        """
+        if mode not in self._pair_modes:
+            raise ValueError("Unknown pair iteration mode %r; should be one of %s"
+                             % (mode, sorted(self._pair_modes)))
+
+        blocksize = int(blocksize)
+        if blocksize < 1:
+            raise ValueError("blocksize must be at least 1")
+
+        if self.get_array_ref('smooth') is None:
+            raise ValueError("No smoothing lengths are associated with this "
+                             "KDTree; access the 'smooth' array of your "
+                             "snapshot before generating pairs")
+
+        # validation above happens eagerly, rather than on first iteration
+        return self._pair_blocks_generator(self._pair_modes[mode], blocksize)
+
+    def _pair_blocks_generator(self, mode_id, blocksize):
+        # nsmooth only sizes the neighbour buffer; the pair set itself is
+        # determined by the smoothing lengths
+        nsmooth = min(int(config['sph']['smooth-particles']), len(self._pos))
+        boxsize = -1.0 if self.boxsize is None else float(self.boxsize)
+
+        context = kdmain.pair_start(self.kdtree, mode_id, blocksize, nsmooth,
+                                    boxsize)
+        try:
+            while True:
+                block = kdmain.pair_next(self.kdtree, context)
+                if block is None:
+                    break
+                yield block
+        finally:
+            kdmain.pair_stop(self.kdtree, context)
+
+    def pair_reduce(self, func, mode='symmetric', blocksize=1<<18,
+                    dtype=np.float64):
+        r"""Accumulate a user-supplied pairwise function over all neighbour pairs.
+
+        .. versionadded:: 2.6.0
+
+        This lets arbitrary pairwise SPH operations be expressed without a
+        python-level loop over particles. The neighbour search runs in C++,
+        while ``func`` is called once per block of pairs and works on flat
+        numpy arrays.
+
+        The result is an array ``out`` with
+
+        .. math::
+
+            \mathrm{out}[a] = \sum_{\mathrm{pairs}\ (a, j)} c_i
+                            + \sum_{\mathrm{pairs}\ (i, a)} c_j
+
+        where :math:`(c_i, c_j)` is what ``func`` returned for each pair.
+
+        Parameters
+        ----------
+        func : callable
+            Called as ``func(i, j, dx, r)`` with one block of pairs at a time;
+            see :meth:`pair_blocks` for the meaning and shapes of the
+            arguments. Per-particle quantities are reached by closing over them
+            and indexing with ``i`` or ``j``.
+
+            It must return either
+
+            * a single array, of shape ``(nblock,)`` or ``(nblock, k)``, whose
+              values are accumulated at ``i``; or
+            * a tuple ``(contrib_i, contrib_j)`` of two such arrays, which are
+              accumulated at ``i`` and at ``j`` respectively.
+
+            The trailing shape is fixed by the first block and may not vary.
+
+            ``func`` must be a pure function of its arguments: it must not
+            mutate them, carry state between calls, or assume anything about
+            which pairs are grouped into a block. In particular it cannot
+            perform a reduction over all of a particle's neighbours, since they
+            need not all be present in the same block; compute such quantities
+            in a separate pass first.
+
+        mode : str
+            ``'symmetric'`` (default) or ``'gather'``; see :meth:`pair_blocks`.
+
+        blocksize : int
+            Maximum number of pairs handed to ``func`` at once.
+
+        dtype : numpy dtype
+            Data type of the output array.
+
+        Returns
+        -------
+        numpy.ndarray
+            Shape ``(N,)`` or ``(N, k)``, where ``N`` is the number of
+            particles in the tree.
+
+        Notes
+        -----
+        In ``'symmetric'`` mode each pair is visited exactly once and both ends
+        are accumulated from that single visit. Returning an antisymmetric
+        contribution ``(m[j] * c, -m[i] * c)`` therefore conserves
+        :math:`\sum_a m_a\, \mathrm{out}[a]` to roundoff as an algebraic
+        identity, rather than approximately.
+
+        Examples
+        --------
+        SPH artificial conduction, which requires both smoothing lengths and so
+        uses the symmetric pair set:
+
+        >>> m, rho, p, u, h = (f.g[k] for k in ('mass','rho','p','u','smooth'))
+        >>> W = f.g.kdtree.kernel
+        >>> def conduction(i, j, dx, r):
+        ...     mu = np.einsum('kl,kl->k', f.g['vel'][j] - f.g['vel'][i], dx) / r
+        ...     v_d = 0.5 * (np.abs(mu)
+        ...                  + np.sqrt(2 * np.abs(p[i] - p[j]) / (rho[i] + rho[j])))
+        ...     # note gradient() is dW/dr, which is negative; the usual form of
+        ...     # this equation is written in terms of its magnitude
+        ...     g = -(W.gradient(r, h[i]) / rho[i] + W.gradient(r, h[j]) / rho[j])
+        ...     c = v_d * (u[j] - u[i]) * g
+        ...     return m[j] * c, -m[i] * c
+        >>> du_dt = f.g.kdtree.pair_reduce(conduction)
+
+        The returned contributions are antisymmetric, so this conserves energy
+        exactly; ``(m * du_dt).sum()`` vanishes to roundoff.
+
+        """
+        npart = len(self._pos)
+        out = None
+        trailing = None
+
+        for i, j, dx, r in self.pair_blocks(mode=mode, blocksize=blocksize):
+            result = func(i, j, dx, r)
+            if isinstance(result, tuple):
+                contrib_i, contrib_j = result
+            else:
+                contrib_i, contrib_j = result, None
+
+            contrib_i = np.asarray(contrib_i)
+
+            if len(contrib_i) != len(i):
+                raise ValueError("pair_reduce callback returned %d values for "
+                                 "a block of %d pairs"
+                                 % (len(contrib_i), len(i)))
+
+            if trailing is None:
+                trailing = contrib_i.shape[1:]
+                out = np.zeros((npart,) + trailing, dtype=dtype)
+            elif contrib_i.shape[1:] != trailing:
+                raise ValueError("pair_reduce callback returned trailing shape "
+                                 "%s, but the first block gave %s"
+                                 % (contrib_i.shape[1:], trailing))
+
+            _scatter_add(out, i, contrib_i)
+            if contrib_j is not None:
+                _scatter_add(out, j, np.asarray(contrib_j))
+
+        if out is None:
+            # no pairs at all, so the trailing shape was never established
+            out = np.zeros(npart, dtype=dtype)
+
+        return out
 
     def sph_mean(self, array, nsmooth=64):
         r"""Calculate the SPH mean of a simulation array.

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -454,14 +454,23 @@ class KDTree:
             Which pairs to generate.
 
             * ``'symmetric'`` (default): every unordered pair with
-              :math:`r < \max(2 h_i, 2 h_j)`, exactly once, canonicalised so
-              that ``i < j``. This is what SPH operators involving both
+              :math:`r \leq \max(2 h_i, 2 h_j)`, exactly once, canonicalised
+              so that ``i < j``. This is what SPH operators involving both
               smoothing lengths require, such as artificial viscosity or
               conduction.
-            * ``'gather'``: every ordered pair with :math:`r < 2 h_i`. Both
+            * ``'gather'``: every ordered pair with :math:`r \leq 2 h_i`. Both
               ``(a, b)`` and ``(b, a)`` appear when each lies inside the
               other's kernel. This is the neighbour set used by the density
               estimate and by :meth:`sph_mean`.
+
+            The boundary is inclusive, matching the neighbour search used by
+            the density estimate, so that a gather over ``nSmooth`` neighbours
+            really does yield ``nSmooth`` of them. This is worth noting because
+            :math:`r = 2h` is not a rare edge case: smoothing lengths are half
+            the distance to the nth neighbour, so exactly one neighbour of
+            every particle sits on the boundary. Nothing physical depends on
+            which side they fall, since both :math:`W` and :math:`dW/dr` vanish
+            there.
 
         blocksize : int
             Maximum number of pairs per block. Blocks are arbitrary cuts of a
@@ -570,7 +579,9 @@ class KDTree:
             Maximum number of pairs handed to ``func`` at once.
 
         dtype : numpy dtype
-            Data type of the output array.
+            Data type of the output array. Accumulation is always performed in
+            double precision, and the result converted on return, so that the
+            answer does not depend on ``blocksize``.
 
         Returns
         -------
@@ -628,7 +639,11 @@ class KDTree:
 
             if trailing is None:
                 trailing = contrib_i.shape[1:]
-                out = np.zeros((npart,) + trailing, dtype=dtype)
+                # Accumulate in float64 whatever the requested output type:
+                # np.bincount produces float64, and casting each block down to
+                # an integer dtype as it arrived would truncate the partial
+                # sums independently, making the result depend on blocksize.
+                out = np.zeros((npart,) + trailing, dtype=np.float64)
             elif contrib_i.shape[1:] != trailing:
                 raise ValueError("pair_reduce callback returned trailing shape "
                                  "%s, but the first block gave %s"
@@ -640,9 +655,9 @@ class KDTree:
 
         if out is None:
             # no pairs at all, so the trailing shape was never established
-            out = np.zeros(npart, dtype=dtype)
+            return np.zeros(npart, dtype=dtype)
 
-        return out
+        return out.astype(dtype, copy=False)
 
     def sph_mean(self, array, nsmooth=64):
         r"""Calculate the SPH mean of a simulation array.

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -40,6 +40,10 @@ PyObject *nn_rewind(PyObject *self, PyObject *args);
 
 PyObject *populate(PyObject *self, PyObject *args);
 
+PyObject *pair_start(PyObject *self, PyObject *args);
+PyObject *pair_next(PyObject *self, PyObject *args);
+PyObject *pair_stop(PyObject *self, PyObject *args);
+
 PyObject *domain_decomposition(PyObject *self, PyObject *args);
 PyObject *set_arrayref(PyObject *self, PyObject *args);
 PyObject *get_arrayref(PyObject *self, PyObject *args);
@@ -81,6 +85,10 @@ static PyMethodDef kdmain_methods[] = {
      "domain_decomposition"},
 
     {"populate", populate, METH_VARARGS, "populate"},
+
+    {"pair_start", pair_start, METH_VARARGS, "pair_start"},
+    {"pair_next", pair_next, METH_VARARGS, "pair_next"},
+    {"pair_stop", pair_stop, METH_VARARGS, "pair_stop"},
 
     {NULL, NULL, 0, NULL}};
 
@@ -805,6 +813,151 @@ template <typename Tf, typename Tq> struct typed_populate {
   }
 };
 
+/*==========================================================================*/
+/* pair_start / pair_next / pair_stop                                       */
+/*                                                                          */
+/* Stream neighbour pairs back to python in blocks of flat numpy arrays.    */
+/*==========================================================================*/
+template <typename T> struct typed_pair_start {
+  static PyObject *call(PyObject *self, PyObject *args) {
+    PyObject *kdobj;
+    int mode;
+    npy_intp blocksize;
+    int nSmooth;
+    double period;
+
+    if (!PyArg_ParseTuple(args, "Oinid", &kdobj, &mode, &blocksize, &nSmooth,
+                          &period))
+      return nullptr;
+
+    KDContext *kd = static_cast<KDContext *>(PyCapsule_GetPointer(kdobj, NULL));
+    if (kd == nullptr) {
+      PyErr_SetString(PyExc_ValueError, "Invalid KDContext object");
+      return nullptr;
+    }
+
+    if (mode != PAIR_MODE_GATHER && mode != PAIR_MODE_SYMMETRIC) {
+      PyErr_SetString(PyExc_ValueError, "Unknown pair iteration mode");
+      return nullptr;
+    }
+
+    if (blocksize < 1) {
+      PyErr_SetString(PyExc_ValueError, "blocksize must be at least 1");
+      return nullptr;
+    }
+
+    if (checkArray<T>((PyObject *)kd->pNumpySmooth, "smooth"))
+      return nullptr;
+
+    if (period <= 0)
+      period = std::numeric_limits<double>::max();
+
+    SmoothingContext<T> *smx = smInit<T>(kd, nSmooth, static_cast<T>(period));
+    if (smx == nullptr)
+      return nullptr; // smInit sets the error message
+    smx->warnings = false;
+
+    auto pc = new PairContext<T>(smx, blocksize, mode);
+
+    return PyCapsule_New(pc, NULL, NULL);
+  }
+};
+
+template <typename T> struct typed_pair_next {
+  static PyObject *call(PyObject *self, PyObject *args) {
+    PyObject *kdobj, *pcobj;
+
+    if (!PyArg_ParseTuple(args, "OO", &kdobj, &pcobj))
+      return nullptr;
+
+    auto pc = static_cast<PairContext<T> *>(PyCapsule_GetPointer(pcobj, NULL));
+    if (pc == nullptr) {
+      PyErr_SetString(PyExc_ValueError, "Invalid pair iteration context");
+      return nullptr;
+    }
+
+    Py_BEGIN_ALLOW_THREADS;
+    smFillPairBlock<T>(pc);
+    Py_END_ALLOW_THREADS;
+
+    if (pc->smx->warnings) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "Buffer overflow while gathering neighbour pairs. This "
+                      "probably means some smoothing lengths are very large "
+                      "compared to the typical particle separation.");
+      return nullptr;
+    }
+
+    npy_intp n = static_cast<npy_intp>(pc->outI.size());
+    if (n == 0) {
+      // the fill loop only stops early when the buffer is full, so an empty
+      // block means every particle has been walked
+      Py_INCREF(Py_None);
+      return Py_None;
+    }
+
+    npy_intp dims1[1] = {n};
+    npy_intp dims2[2] = {n, 3};
+
+    PyObject *arI = PyArray_SimpleNew(1, dims1, NPY_INTP);
+    PyObject *arJ = PyArray_SimpleNew(1, dims1, NPY_INTP);
+    PyObject *arDx = PyArray_SimpleNew(2, dims2, NPY_DOUBLE);
+    PyObject *arR = PyArray_SimpleNew(1, dims1, NPY_DOUBLE);
+
+    if (arI == nullptr || arJ == nullptr || arDx == nullptr || arR == nullptr) {
+      Py_XDECREF(arI);
+      Py_XDECREF(arJ);
+      Py_XDECREF(arDx);
+      Py_XDECREF(arR);
+      return nullptr;
+    }
+
+    std::copy(pc->outI.begin(), pc->outI.end(),
+              static_cast<npy_intp *>(PyArray_DATA((PyArrayObject *)arI)));
+    std::copy(pc->outJ.begin(), pc->outJ.end(),
+              static_cast<npy_intp *>(PyArray_DATA((PyArrayObject *)arJ)));
+    std::copy(pc->outDx.begin(), pc->outDx.end(),
+              static_cast<double *>(PyArray_DATA((PyArrayObject *)arDx)));
+    std::copy(pc->outR.begin(), pc->outR.end(),
+              static_cast<double *>(PyArray_DATA((PyArrayObject *)arR)));
+
+    // the callback must not be able to corrupt what it is handed
+    PyArray_CLEARFLAGS((PyArrayObject *)arI, NPY_ARRAY_WRITEABLE);
+    PyArray_CLEARFLAGS((PyArrayObject *)arJ, NPY_ARRAY_WRITEABLE);
+    PyArray_CLEARFLAGS((PyArrayObject *)arDx, NPY_ARRAY_WRITEABLE);
+    PyArray_CLEARFLAGS((PyArrayObject *)arR, NPY_ARRAY_WRITEABLE);
+
+    PyObject *result = PyTuple_Pack(4, arI, arJ, arDx, arR);
+
+    // PyTuple_Pack takes its own references
+    Py_DECREF(arI);
+    Py_DECREF(arJ);
+    Py_DECREF(arDx);
+    Py_DECREF(arR);
+
+    return result;
+  }
+};
+
+template <typename T> struct typed_pair_stop {
+  static PyObject *call(PyObject *self, PyObject *args) {
+    PyObject *kdobj, *pcobj;
+
+    if (!PyArg_ParseTuple(args, "OO", &kdobj, &pcobj))
+      return nullptr;
+
+    auto pc = static_cast<PairContext<T> *>(PyCapsule_GetPointer(pcobj, NULL));
+    if (pc == nullptr) {
+      PyErr_SetString(PyExc_ValueError, "Invalid pair iteration context");
+      return nullptr;
+    }
+    delete pc; // also deletes the owned SmoothingContext
+
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+};
+
 template <template <typename, typename> class func>
 PyObject *type_dispatcher_2(PyObject *self, PyObject *args) {
   PyObject *kdobj = PyTuple_GetItem(args, 0);
@@ -879,4 +1032,16 @@ PyObject *populate(PyObject *self, PyObject *args) {
 
 PyObject *particles_in_sphere(PyObject *self, PyObject *args) {
   return type_dispatcher_2<typed_particles_in_sphere>(self, args);
+}
+
+PyObject *pair_start(PyObject *self, PyObject *args) {
+  return type_dispatcher_1<typed_pair_start>(self, args);
+}
+
+PyObject *pair_next(PyObject *self, PyObject *args) {
+  return type_dispatcher_1<typed_pair_next>(self, args);
+}
+
+PyObject *pair_stop(PyObject *self, PyObject *args) {
+  return type_dispatcher_1<typed_pair_stop>(self, args);
 }

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -31,6 +31,8 @@ public:
   npy_intp nListSize;
   std::vector<T> fList;
   std::vector<npy_intp> pList;
+  std::vector<T> dxList; // 3 entries per neighbour: the periodic-wrapped
+                         // displacement from the search centre to the neighbour
 
   npy_intp pin = 0, pi = 0, pNext = 0; // particle indices for distributed loops (TODO: rationalise)
   npy_intp nCurrent = 0; // particle indices for distributed loops (TODO: rationalise)
@@ -49,6 +51,7 @@ public:
 
   SmoothingContext(KDContext* kd, npy_intp nSmooth, T fPeriod[3]) : kd(kd), nSmooth(nSmooth), fPeriod{fPeriod[0], fPeriod[1], fPeriod[2]},
       nListSize(nSmooth + RESMOOTH_SAFE), fList(nListSize), pList(nListSize),
+      dxList(3 * nListSize),
       pMutex(std::make_shared<std::mutex>()),
       priorityQueue(std::make_unique<PriorityQueue<T>>(nSmooth, kd->nActive)) {
 
@@ -56,7 +59,8 @@ public:
 
   SmoothingContext(const SmoothingContext<T> &copy) : kd(copy.kd), nSmooth(copy.nSmooth),
       fPeriod{copy.fPeriod[0], copy.fPeriod[1], copy.fPeriod[2]},
-      nListSize(copy.nListSize), fList(nListSize), pList(nListSize), pMutex(copy.pMutex),
+      nListSize(copy.nListSize), fList(nListSize), pList(nListSize),
+      dxList(3 * nListSize), pMutex(copy.pMutex),
       smx_global(const_cast<SmoothingContext<T>*>(&copy)),
       priorityQueue(std::make_unique<PriorityQueue<T>>(nSmooth, kd->nActive)),
       pKernel(copy.pKernel) { }
@@ -244,6 +248,7 @@ void smBallSearch(SmoothingContext<T> *smx, T *ri) {
 
 template<typename T>
 inline npy_intp smBallGatherStoreResultInList(SmoothingContext<T>* smx, T fDist2,
+                                              T dx, T dy, T dz,
                                               npy_intp particleIndex,
                                               npy_intp foundIndex) {
   smx->result->push_back(smx->kd->particleOffsets[particleIndex]);
@@ -252,6 +257,7 @@ inline npy_intp smBallGatherStoreResultInList(SmoothingContext<T>* smx, T fDist2
 
 template<typename T>
 inline npy_intp smBallGatherStoreResultInSmx(SmoothingContext<T>* smx, T fDist2,
+                                             T dx, T dy, T dz,
                                              npy_intp particleIndex,
                                              npy_intp foundIndex) {
   if (foundIndex >= smx->nListSize) {
@@ -263,12 +269,18 @@ inline npy_intp smBallGatherStoreResultInSmx(SmoothingContext<T>* smx, T fDist2,
   }
   smx->fList[foundIndex] = fDist2;
   smx->pList[foundIndex] = particleIndex;
+  // smBallGather computes (search centre - neighbour); store the displacement
+  // pointing from the search centre towards the neighbour instead.
+  smx->dxList[3 * foundIndex + 0] = -dx;
+  smx->dxList[3 * foundIndex + 1] = -dy;
+  smx->dxList[3 * foundIndex + 2] = -dz;
   return foundIndex + 1;
 }
 
 
 template <typename T,
-          npy_intp (*storeResultFunction)(SmoothingContext<T> *, T, npy_intp, npy_intp)>
+          npy_intp (*storeResultFunction)(SmoothingContext<T> *, T, T, T, T,
+                                          npy_intp, npy_intp)>
 npy_intp smBallGather(SmoothingContext<T> * smx, T fBall2, T *ri) {
   /* Gather all particles within the specified radius, using the storeResultFunction callback
    * to store the results. */
@@ -308,7 +320,7 @@ npy_intp smBallGather(SmoothingContext<T> * smx, T fBall2, T *ri) {
         dz = sz - GET2<T>(kd->pNumpyPos, p[pj], 2);
         fDist2 = dx * dx + dy * dy + dz * dz;
         if (fDist2 <= fBall2) {
-          nCnt = storeResultFunction(smx, fDist2, pj, nCnt);
+          nCnt = storeResultFunction(smx, fDist2, dx, dy, dz, pj, nCnt);
         }
       }
     }
@@ -326,6 +338,147 @@ npy_intp smBallGather(SmoothingContext<T> * smx, T fBall2, T *ri) {
 
 template <typename T>
 PyObject *getReturnParticleList(SmoothingContext<T> * smx);
+
+
+#define PAIR_MODE_GATHER 0
+#define PAIR_MODE_SYMMETRIC 1
+
+template <typename T>
+class PairContext {
+  /* Iteration state for streaming neighbour pairs back to python in blocks.
+   *
+   * Pairs are produced by walking each particle in turn and ball-gathering its
+   * own kernel volume, exactly as the density calculation does. In 'gather'
+   * mode every ordered pair (a, b) with r < 2 h_a is emitted. In 'symmetric'
+   * mode each unordered pair is emitted exactly once, canonicalised to i < j,
+   * using a purely local test: while walking particle a and finding neighbour
+   * b, emit iff (a < b) or (r >= 2 h_b). In the latter case b's own walk will
+   * not find a, so nobody else will emit the pair; in the former case the two
+   * walks would both find it, and the lower index breaks the tie. This needs
+   * no communication between walks and no global de-duplication.
+   */
+public:
+  SmoothingContext<T> *smx; // owned
+  npy_intp blocksize;
+  int mode;
+
+  npy_intp nextParticle;    // next particle (in tree order) to be walked
+  npy_intp pendingParticle; // particle whose neighbour list we are part-way through
+  npy_intp pendingCount;    // number of neighbours found for it
+  npy_intp pendingIndex;    // how far through that neighbour list we have got
+  bool havePending;
+
+  std::vector<npy_intp> outI, outJ;
+  std::vector<double> outDx, outR;
+
+  PairContext(SmoothingContext<T> *smx, npy_intp blocksize, int mode)
+      : smx(smx), blocksize(blocksize), mode(mode), nextParticle(0),
+        pendingParticle(0), pendingCount(0), pendingIndex(0),
+        havePending(false) {
+    outI.reserve(blocksize);
+    outJ.reserve(blocksize);
+    outDx.reserve(3 * blocksize);
+    outR.reserve(blocksize);
+  }
+
+  ~PairContext() { delete smx; }
+};
+
+
+template <typename T>
+void smFillPairBlock(PairContext<T> *pc) {
+  SmoothingContext<T> *smx = pc->smx;
+  KDContext *kd = smx->kd;
+
+  pc->outI.clear();
+  pc->outJ.clear();
+  pc->outDx.clear();
+  pc->outR.clear();
+
+  while (static_cast<npy_intp>(pc->outI.size()) < pc->blocksize) {
+
+    if (!pc->havePending) {
+      if (pc->nextParticle >= kd->nActive)
+        break; // every particle has been walked
+      pc->pendingParticle = pc->nextParticle++;
+
+      npy_intp ia = kd->particleOffsets[pc->pendingParticle];
+      T hi = GET<T>(kd->pNumpySmooth, ia);
+      T ri[3];
+      for (int k = 0; k < 3; ++k)
+        ri[k] = GET2<T>(kd->pNumpyPos, ia, k);
+
+      // Search slightly beyond 2h. Membership is decided below on r itself
+      // rather than on r^2, and the two can disagree by an ulp; widening here
+      // guarantees no candidate is discarded before that exact test is
+      // applied. Surplus candidates are then filtered out.
+      T fBall2Search = 4 * hi * hi;
+      fBall2Search *= (1 + 16 * std::numeric_limits<T>::epsilon());
+
+      pc->pendingCount =
+          smBallGather<T, smBallGatherStoreResultInSmx>(smx, fBall2Search, ri);
+      pc->pendingIndex = 0;
+      pc->havePending = true;
+
+      if (smx->warnings)
+        return; // neighbour buffer overflowed; caller raises
+    }
+
+    npy_intp ia = kd->particleOffsets[pc->pendingParticle];
+    double hi = static_cast<double>(GET<T>(kd->pNumpySmooth, ia));
+
+    while (pc->pendingIndex < pc->pendingCount &&
+           static_cast<npy_intp>(pc->outI.size()) < pc->blocksize) {
+      npy_intp k = pc->pendingIndex++;
+      npy_intp jb = kd->particleOffsets[smx->pList[k]];
+
+      if (jb == ia)
+        continue; // no self-pairs
+
+      // Membership is tested on r, not r^2, and inclusively. Smoothing lengths
+      // are defined as half the distance to the nth neighbour, so r == 2h is
+      // hit exactly for one neighbour of every particle; deciding on r^2, or
+      // excluding the boundary, would strand those pairs on the wrong side by
+      // an ulp. The inclusive test matches smBallGather, so a gather over
+      // nSmooth neighbours really does yield nSmooth of them.
+      double r = sqrt(static_cast<double>(smx->fList[k]));
+      if (!(r <= 2.0 * hi))
+        continue;
+
+      npy_intp emitI = ia, emitJ = jb;
+      bool flip = false;
+
+      if (pc->mode == PAIR_MODE_SYMMETRIC && ia > jb) {
+        double hj = static_cast<double>(GET<T>(kd->pNumpySmooth, jb));
+        if (r <= 2.0 * hj)
+          continue; // jb's own walk finds ia, and will emit the pair
+        emitI = jb;
+        emitJ = ia;
+        flip = true;
+      }
+
+      double d0 = static_cast<double>(smx->dxList[3 * k + 0]);
+      double d1 = static_cast<double>(smx->dxList[3 * k + 1]);
+      double d2 = static_cast<double>(smx->dxList[3 * k + 2]);
+      if (flip) {
+        // dx must always point from the emitted i towards the emitted j
+        d0 = -d0;
+        d1 = -d1;
+        d2 = -d2;
+      }
+
+      pc->outI.push_back(emitI);
+      pc->outJ.push_back(emitJ);
+      pc->outDx.push_back(d0);
+      pc->outDx.push_back(d1);
+      pc->outDx.push_back(d2);
+      pc->outR.push_back(r);
+    }
+
+    if (pc->pendingIndex >= pc->pendingCount)
+      pc->havePending = false;
+  }
+}
 
 
 template <typename T>

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -252,7 +252,11 @@ inline npy_intp smBallGatherStoreResultInList(SmoothingContext<T>* smx, T fDist2
                                               npy_intp particleIndex,
                                               npy_intp foundIndex) {
   smx->result->push_back(smx->kd->particleOffsets[particleIndex]);
-  return particleIndex + 1;
+  // smBallGather treats the return value as the next write position, so it
+  // must count results found, not particles scanned. Callers of this variant
+  // read smx->result and discard the count, so this has never mattered in
+  // practice, but the inconsistency is a trap for any future caller.
+  return foundIndex + 1;
 }
 
 template<typename T>
@@ -349,13 +353,14 @@ class PairContext {
    *
    * Pairs are produced by walking each particle in turn and ball-gathering its
    * own kernel volume, exactly as the density calculation does. In 'gather'
-   * mode every ordered pair (a, b) with r < 2 h_a is emitted. In 'symmetric'
+   * mode every ordered pair (a, b) with r <= 2 h_a is emitted. In 'symmetric'
    * mode each unordered pair is emitted exactly once, canonicalised to i < j,
    * using a purely local test: while walking particle a and finding neighbour
-   * b, emit iff (a < b) or (r >= 2 h_b). In the latter case b's own walk will
+   * b, emit iff (a < b) or (r > 2 h_b). In the latter case b's own walk will
    * not find a, so nobody else will emit the pair; in the former case the two
-   * walks would both find it, and the lower index breaks the tie. This needs
-   * no communication between walks and no global de-duplication.
+   * walks would both find it, and the lower index breaks the tie. Note that
+   * equality, r == 2 h_b, therefore falls to b's walk rather than a's. This
+   * needs no communication between walks and no global de-duplication.
    */
 public:
   SmoothingContext<T> *smx; // owned

--- a/pynbody/sph/__init__.py
+++ b/pynbody/sph/__init__.py
@@ -15,6 +15,14 @@ The :func:`to_3d_grid` function can be used to create a 3D grid of interpolated 
 functionality is also a thin wrapper around the :func:`~pynbody.sph.renderers.make_render_pipeline` function and
 its associated classes in the :mod:`~pynbody.sph.renderers` module.
 
+Underlying all of the above is the :class:`~pynbody.kdtree.KDTree`, which finds the neighbours and provides the
+lower-level SPH operations themselves, such as :meth:`~pynbody.kdtree.KDTree.sph_mean` and
+:meth:`~pynbody.kdtree.KDTree.sph_divergence`. It also supports user-defined SPH operations, which are not
+otherwise available in pynbody: :meth:`~pynbody.kdtree.KDTree.pair_reduce` accumulates an arbitrary pairwise
+function over neighbour pairs, so that operations such as artificial viscosity or conduction can be expressed
+without a python-level loop over particles. For finer control, :meth:`~pynbody.kdtree.KDTree.pair_blocks` exposes
+the neighbour pairs themselves.
+
 """
 
 import copy

--- a/pynbody/sph/kernels.hpp
+++ b/pynbody/sph/kernels.hpp
@@ -106,8 +106,13 @@ namespace kernels
       if (r < 1e-24)
         r = 1e-24;
 
+      // The 21/16 prefactor must match the one in operator() above: callers
+      // (smDivQty, smCurlQty) multiply both by the same 1/(pi h^n) factor, so
+      // the value and its derivative have to carry the same normalisation.
+      // d/dq [ (1-q/2)^4 (2q+1) ] = -5 q (1-q/2)^3
       if (q < 2.0)
-        rs = -5.0 * q * (1.0 - 0.5 * q) * (1.0 - 0.5 * q) * (1.0 - 0.5 * q) / r;
+        rs = -(21.0 / 16.0) * 5.0 * q * (1.0 - 0.5 * q) * (1.0 - 0.5 * q) *
+             (1.0 - 0.5 * q) / r;
       else
         rs = 0.0;
 

--- a/pynbody/sph/kernels.py
+++ b/pynbody/sph/kernels.py
@@ -40,8 +40,71 @@ class KernelBase:
         return samples
 
     def get_value(self, d, h=1) -> float:
-        """Get the value of the kernel for a given smoothing length."""
+        """Get the value of the kernel for a given smoothing length.
+
+        Here ``d`` is the separation *in units of the smoothing length*, i.e.
+        ``d = r/h``. For a vectorised version taking the separation directly,
+        see :meth:`value`.
+        """
         raise NotImplementedError("Subclasses must implement this method")
+
+    def value(self, r, h):
+        r"""Get the kernel :math:`W(r, h)`, vectorised over ``r`` and ``h``.
+
+        .. versionadded:: 2.6.0
+
+        Unlike :meth:`get_value`, this takes the separation ``r`` directly
+        rather than ``r/h``, and both arguments may be arrays. This is the
+        form needed when evaluating a kernel for a list of particle pairs,
+        e.g. inside a callback passed to
+        :meth:`pynbody.kdtree.KDTree.pair_reduce`.
+
+        Parameters
+        ----------
+        r : array_like
+            Separation between particles.
+        h : array_like
+            Smoothing length. The kernel has support out to ``r = 2h``.
+
+        Returns
+        -------
+        numpy.ndarray
+            The kernel value, normalised such that
+            :math:`4\pi \int W(r, h) r^2 dr = 1`.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def gradient(self, r, h):
+        r"""Get :math:`dW/dr`, vectorised over ``r`` and ``h``.
+
+        .. versionadded:: 2.6.0
+
+        This is the radial derivative of :meth:`value`, and is negative on
+        :math:`0 < r < 2h`. The full gradient with respect to the position of
+        particle :math:`i` is
+
+        .. math::
+
+            \nabla_i W(|x_i - x_j|, h) = \frac{dW}{dr} \frac{x_i - x_j}{r}
+
+        Parameters
+        ----------
+        r : array_like
+            Separation between particles.
+        h : array_like
+            Smoothing length.
+
+        Returns
+        -------
+        numpy.ndarray
+            The radial derivative of the kernel.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @staticmethod
+    def _as_arrays(r, h):
+        return (np.asarray(r, dtype=np.float64),
+                np.asarray(h, dtype=np.float64))
 
     def projection(self) -> KernelBase:
         """Return a 2D projection of this kernel"""
@@ -70,6 +133,22 @@ class CubicSplineKernel(KernelBase):
 
         return f / (np.pi * h ** 3)
 
+    def value(self, r, h):
+        r, h = self._as_arrays(r, h)
+        q = r / h
+        f = np.where(q < 1.0,
+                     1.0 - 1.5 * q ** 2 + 0.75 * q ** 3,
+                     0.25 * np.clip(2.0 - q, 0.0, None) ** 3)
+        return f / (np.pi * h ** 3)
+
+    def gradient(self, r, h):
+        r, h = self._as_arrays(r, h)
+        q = r / h
+        df = np.where(q < 1.0,
+                      -3.0 * q + 2.25 * q ** 2,
+                      -0.75 * np.clip(2.0 - q, 0.0, None) ** 2)
+        return df / (np.pi * h ** 4)
+
     @classmethod
     def get_c_kernel_id(cls):
         return 0
@@ -84,6 +163,19 @@ class WendlandC2Kernel(KernelBase):
             f = 0
 
         return (21. * f) / (16. * np.pi * h ** 3)
+
+    def value(self, r, h):
+        r, h = self._as_arrays(r, h)
+        q = r / h
+        t = np.clip(1.0 - 0.5 * q, 0.0, None)
+        return 21.0 * t ** 4 * (2.0 * q + 1.0) / (16.0 * np.pi * h ** 3)
+
+    def gradient(self, r, h):
+        # d/dq [ (1-q/2)^4 (2q+1) ] = -5 q (1-q/2)^3
+        r, h = self._as_arrays(r, h)
+        q = r / h
+        t = np.clip(1.0 - 0.5 * q, 0.0, None)
+        return -21.0 * 5.0 * q * t ** 3 / (16.0 * np.pi * h ** 4)
 
     @classmethod
     def get_c_kernel_id(cls):
@@ -109,6 +201,25 @@ class Kernel2D(KernelBase):
 
     def __hash__(self):
         return hash((self.__class__, self.k_orig))
+
+
+def create_kernel_from_c_id(kernel_id: int) -> KernelBase:
+    """Create a kernel object from the integer id used by the C++ code.
+
+    .. versionadded:: 2.6.0
+
+    This is the inverse of :meth:`KernelBase.get_c_kernel_id`, and is used to
+    recover a python-side kernel from a :class:`pynbody.kdtree.KDTree` whose
+    kernel was set from a serialized state.
+    """
+    for subclass in KernelBase.__subclasses__():
+        try:
+            if subclass.get_c_kernel_id() == kernel_id:
+                return subclass()
+        except (NotImplementedError, TypeError):
+            # e.g. Kernel2D, which has no C counterpart
+            continue
+    raise ValueError("No kernel corresponds to C kernel id %r" % kernel_id)
 
 
 def create_kernel(spec) -> KernelBase:

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -2,32 +2,34 @@
 
 These cover:
 
-  * ``KDTree.pair_blocks(mode, blocksize)`` -- iterate over neighbour pairs in
-    blocks, as flat numpy arrays;
-  * ``KDTree.pair_reduce(func, mode, blocksize, dtype)`` -- accumulate a
-    user-supplied pairwise function over those pairs;
-  * ``KernelBase.value(r, h)`` / ``KernelBase.gradient(r, h)`` -- vectorised
-    kernel evaluation, and ``KDTree.kernel`` to reach the kernel the tree is
-    actually using.
+  * :meth:`pynbody.kdtree.KDTree.pair_blocks` -- iterating over neighbour
+    pairs in blocks, as flat numpy arrays;
+  * :meth:`pynbody.kdtree.KDTree.pair_reduce` -- accumulating a user-supplied
+    pairwise function over those pairs;
+  * :meth:`pynbody.sph.kernels.KernelBase.value` and
+    :meth:`~pynbody.sph.kernels.KernelBase.gradient` -- vectorised kernel
+    evaluation, and :attr:`pynbody.kdtree.KDTree.kernel` to reach the kernel
+    the tree is actually using.
 
 Together these let a user express operations such as SPH artificial viscosity
-and artificial conduction without a Python-level loop over ``KDTree.nn()``.
+and artificial conduction without a python-level loop over ``KDTree.nn()``.
 
-Most tests run against two implementations, selected by the ``pair_api``
-fixture:
+Most tests run against two implementations, supplied by the ``pairs`` fixture,
+which maps a snapshot onto an object exposing the pair API:
 
-  ``reference``  a brute-force O(N^2) implementation, defined in this file.
-                 It *is* the specification of the pair set and of the
-                 accumulation.
-  ``kdtree``     the real ``KDTree`` methods, backed by the C++ tree walk.
+  ``reference``  :class:`ReferencePairs`, a brute-force O(N^2) implementation
+                 defined in this file. It is the specification of both the
+                 pair set and the accumulation, and knows nothing of the
+                 KDTree.
+  ``kdtree``     the snapshot's own ``kdtree``, backed by the C++ tree walk.
 
-Applying identical assertions to both is what checks the C++ implementation
-against the reference; :func:`test_matches_reference_pair_set` and friends
-additionally compare the two head-to-head.
+:class:`ReferencePairs` mirrors the KDTree methods signature-for-signature, so
+applying one test body to both is what checks the C++ implementation against
+the specification.
 
-The pair-set tests deliberately do not depend on the kernel API (they use a
-reference kernel defined here), and the kernel tests do not depend on the pair
-API, so that a failure points at one thing or the other.
+The pair-set tests deliberately avoid the kernel API, using a reference kernel
+defined here, and the kernel tests avoid the pair API, so that a failure points
+at one thing or the other.
 """
 
 import numpy as np
@@ -60,64 +62,69 @@ def _boxsize_of(f):
     return float(boxsize)
 
 
-def _reference_all_pairs(pos, h, boxsize, mode):
-    """Brute-force enumeration of the pair set, O(N^2).
-
-    ``symmetric`` yields each unordered pair ``{a, b}`` with
-    ``r <= max(2h_a, 2h_b)`` exactly once, canonicalised to ``i < j``.
-    ``gather`` yields each ordered pair ``(a, b)`` with ``r <= 2h_a``.
-
-    The boundary is inclusive, matching smBallGather. Note that ``r == 2h``
-    occurs by construction, since h is half the distance to the nth
-    neighbour, so pairs sitting exactly on it are not a rare edge case.
-    """
-    if mode not in ('symmetric', 'gather'):
-        raise ValueError(f"unknown mode {mode!r}")
-
-    i_list, j_list, dx_list = [], [], []
-
-    for a in range(len(pos)):
-        dx = _minimum_image(pos - pos[a], boxsize)
-        r = np.sqrt(np.einsum('kl,kl->k', dx, dx))
-
-        if mode == 'symmetric':
-            within = r <= np.maximum(2.0 * h[a], 2.0 * h)
-            within[:a + 1] = False          # each unordered pair once, i < j
-        else:
-            within = r <= 2.0 * h[a]
-            within[a] = False               # no self-pairs
-
-        b = np.flatnonzero(within)
-        i_list.append(np.full(len(b), a, dtype=np.int64))
-        j_list.append(b.astype(np.int64))
-        dx_list.append(dx[b])
-
-    return (np.concatenate(i_list), np.concatenate(j_list),
-            np.concatenate(dx_list))
-
-
-def _scatter_add(out, idx, contrib):
-    """``out[idx] += contrib``, summing over repeated entries of ``idx``."""
+def _scatter_add(out, index, contrib):
+    """``out[index] += contrib``, summing over repeated entries of ``index``."""
     npart = out.shape[0]
     if out.ndim == 1:
-        out += np.bincount(idx, weights=contrib, minlength=npart)
+        out += np.bincount(index, weights=contrib, minlength=npart)
     else:
         for k in range(out.shape[1]):
-            out[:, k] += np.bincount(idx, weights=contrib[:, k],
+            out[:, k] += np.bincount(index, weights=contrib[:, k],
                                      minlength=npart)
 
 
-class ReferenceImplementation:
-    """Brute-force implementation of the proposed API."""
+class ReferencePairs:
+    """Brute-force stand-in for the pair methods of :class:`pynbody.kdtree.KDTree`.
 
-    name = 'reference'
+    Every candidate pair is enumerated directly, so this depends on nothing but
+    the positions and smoothing lengths -- in particular, not on the KDTree.
+    The method signatures match KDTree's, so a single test body can exercise
+    either implementation.
+    """
 
-    @staticmethod
-    def pair_blocks(f, mode='symmetric', blocksize=1 << 20):
-        i_all, j_all, dx_all = _reference_all_pairs(
-            np.asarray(f['pos'], dtype=np.float64),
-            np.asarray(f['smooth'], dtype=np.float64),
-            _boxsize_of(f), mode)
+    def __init__(self, f):
+        self._npart = len(f)
+        self._pos = np.asarray(f['pos'], dtype=np.float64)
+        self._h = np.asarray(f['smooth'], dtype=np.float64)
+        self._boxsize = _boxsize_of(f)
+
+    def _all_pairs(self, mode):
+        """Enumerate the whole pair set, O(N^2).
+
+        ``symmetric`` gives each unordered pair ``{a, b}`` with
+        ``r <= max(2h_a, 2h_b)`` once, canonicalised to ``i < j``; ``gather``
+        gives each ordered pair ``(a, b)`` with ``r <= 2h_a``.
+
+        The boundary is inclusive, matching smBallGather. Note ``r == 2h``
+        arises by construction, h being half the distance to the nth
+        neighbour, so pairs sitting exactly on it are not a rare edge case.
+        """
+        if mode not in ('symmetric', 'gather'):
+            raise ValueError(f"unknown mode {mode!r}")
+
+        i_list, j_list, dx_list = [], [], []
+
+        for a in range(self._npart):
+            dx = _minimum_image(self._pos - self._pos[a], self._boxsize)
+            r = np.sqrt(np.einsum('kl,kl->k', dx, dx))
+
+            if mode == 'symmetric':
+                within = r <= np.maximum(2.0 * self._h[a], 2.0 * self._h)
+                within[:a + 1] = False      # each unordered pair once, i < j
+            else:
+                within = r <= 2.0 * self._h[a]
+                within[a] = False           # no self-pairs
+
+            b = np.flatnonzero(within)
+            i_list.append(np.full(len(b), a, dtype=np.int64))
+            j_list.append(b.astype(np.int64))
+            dx_list.append(dx[b])
+
+        return (np.concatenate(i_list), np.concatenate(j_list),
+                np.concatenate(dx_list))
+
+    def pair_blocks(self, mode='symmetric', blocksize=1 << 18):
+        i_all, j_all, dx_all = self._all_pairs(mode)
 
         for s in range(0, len(i_all), blocksize):
             sl = slice(s, s + blocksize)
@@ -127,57 +134,33 @@ class ReferenceImplementation:
                 arr.flags.writeable = False
             yield i, j, dx, r
 
-    @classmethod
-    def pair_reduce(cls, f, func, mode='symmetric', blocksize=1 << 20,
+    def pair_reduce(self, func, mode='symmetric', blocksize=1 << 18,
                     dtype=np.float64):
-        out = np.zeros(len(f), dtype=dtype)
+        out = np.zeros(self._npart, dtype=dtype)
         trailing = None
 
-        for i, j, dx, r in cls.pair_blocks(f, mode, blocksize):
-            res = func(i, j, dx, r)
-            ci, cj = res if isinstance(res, tuple) else (res, None)
-            ci = np.asarray(ci)
+        for i, j, dx, r in self.pair_blocks(mode, blocksize):
+            result = func(i, j, dx, r)
+            contrib_i, contrib_j = (result if isinstance(result, tuple)
+                                    else (result, None))
+            contrib_i = np.asarray(contrib_i)
 
-            if len(ci) != len(i):
-                raise ValueError("callback returned %d values for a block of "
-                                 "%d pairs" % (len(ci), len(i)))
             if trailing is None:
-                trailing = ci.shape[1:]
-                out = np.zeros((len(f),) + trailing, dtype=dtype)
-            elif ci.shape[1:] != trailing:
-                raise ValueError("callback returned trailing shape %s; the "
-                                 "first block gave %s"
-                                 % (ci.shape[1:], trailing))
+                trailing = contrib_i.shape[1:]
+                out = np.zeros((self._npart,) + trailing, dtype=dtype)
 
-            _scatter_add(out, i, ci)
-            if cj is not None:
-                _scatter_add(out, j, np.asarray(cj))
+            _scatter_add(out, i, contrib_i)
+            if contrib_j is not None:
+                _scatter_add(out, j, np.asarray(contrib_j))
 
         return out
 
 
-class KDTreeImplementation:
-    """The proposed KDTree methods."""
-
-    name = 'kdtree'
-
-    @staticmethod
-    def pair_blocks(f, mode='symmetric', blocksize=1 << 20):
-        f.build_tree()
-        return f.kdtree.pair_blocks(mode=mode, blocksize=blocksize)
-
-    @staticmethod
-    def pair_reduce(f, func, mode='symmetric', blocksize=1 << 20,
-                    dtype=np.float64):
-        f.build_tree()
-        return f.kdtree.pair_reduce(func, mode=mode, blocksize=blocksize,
-                                    dtype=dtype)
-
-
 # Reference cubic spline, matching pynbody's normalisation:
 #     W(r, h) = f(r/h) / (pi h^3),  support at r = 2h
-# Used by the cross-checks against pynbody's own C++ density and divergence, so
-# that those tests exercise the pair set rather than the proposed kernel API.
+# The cross-checks against pynbody's own C++ density and divergence use these
+# rather than KernelBase.value/gradient, so that they test the pair set and the
+# accumulation without also depending on the kernel API.
 
 def _reference_kernel_value(r, h):
     q = np.asarray(r, dtype=np.float64) / h
@@ -198,10 +181,12 @@ def _reference_kernel_gradient(r, h):
 # Fixtures
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(params=[ReferenceImplementation, KDTreeImplementation],
-                ids=lambda impl: impl.name)
-def pair_api(request):
-    return request.param
+@pytest.fixture(params=['reference', 'kdtree'])
+def pairs(request):
+    """Map a snapshot onto an object exposing ``pair_blocks``/``pair_reduce``."""
+    if request.param == 'reference':
+        return ReferencePairs
+    return lambda f: f.kdtree
 
 
 @pytest.fixture
@@ -244,8 +229,8 @@ def _collect(blocks):
 
 
 def _pair_keys(i, j):
-    """A sorted key per pair, for order-insensitive comparison of pair sets."""
-    return np.sort(i.astype(np.int64) * (1 << 32) + j.astype(np.int64))
+    """One integer key per pair, for order-insensitive comparison."""
+    return i.astype(np.int64) * (1 << 32) + j.astype(np.int64)
 
 
 #: Pairs closer than this (relative) to the r == 2h boundary are treated as
@@ -278,9 +263,9 @@ def _away_from_boundary(i, j, r, h, mode, rtol=BOUNDARY_RTOL):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_shapes_and_dtypes(pair_api, snap, mode):
+def test_pair_blocks_shapes_and_dtypes(pairs, snap, mode):
     seen_any = False
-    for i, j, dx, r in pair_api.pair_blocks(snap, mode=mode, blocksize=500):
+    for i, j, dx, r in pairs(snap).pair_blocks(mode=mode, blocksize=500):
         seen_any = True
         nblock = len(i)
         assert nblock <= 500
@@ -294,50 +279,51 @@ def test_pair_blocks_shapes_and_dtypes(pair_api, snap, mode):
 
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_r_is_consistent_with_dx(pair_api, snap, mode):
+def test_pair_blocks_r_is_consistent_with_dx(pairs, snap, mode):
     """``r`` must be exactly ``|dx|``, so the callback may use either."""
-    _, _, dx, r = _collect(pair_api.pair_blocks(snap, mode=mode))
+    _, _, dx, r = _collect(pairs(snap).pair_blocks(mode=mode))
     npt.assert_allclose(r, np.sqrt(np.einsum('kl,kl->k', dx, dx)), rtol=1e-14)
 
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_excludes_self_pairs(pair_api, snap, mode):
-    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode=mode))
+def test_pair_blocks_excludes_self_pairs(pairs, snap, mode):
+    i, j, _, r = _collect(pairs(snap).pair_blocks(mode=mode))
     assert (i != j).all()
     assert (r > 0).all(), "with self-pairs excluded, r is never zero"
 
 
-def test_pair_blocks_arrays_are_read_only(pair_api, snap):
+def test_pair_blocks_arrays_are_read_only(pairs, snap):
     """The callback must not be able to corrupt pynbody's internal buffers."""
-    for block in pair_api.pair_blocks(snap):
+    for block in pairs(snap).pair_blocks():
         for name, arr in zip(('i', 'j', 'dx', 'r'), block):
             assert not arr.flags.writeable, f"{name} should be read-only"
         break
 
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_blocksize_is_respected(pair_api, snap, mode):
+def test_pair_blocks_blocksize_is_respected(pairs, snap, mode):
     sizes = [len(b[0]) for b in
-             pair_api.pair_blocks(snap, mode=mode, blocksize=137)]
+             pairs(snap).pair_blocks(mode=mode, blocksize=137)]
     assert len(sizes) > 1, "test is only meaningful with several blocks"
     assert max(sizes) <= 137
 
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_invariant_to_blocksize(pair_api, snap, mode):
+def test_pair_blocks_invariant_to_blocksize(pairs, snap, mode):
     """Blocking is an implementation detail; the pair set cannot depend on it."""
-    i1, j1, _, r1 = _collect(pair_api.pair_blocks(snap, mode=mode,
-                                                  blocksize=1 << 20))
-    i2, j2, _, r2 = _collect(pair_api.pair_blocks(snap, mode=mode,
-                                                  blocksize=97))
-    npt.assert_array_equal(_pair_keys(i1, j1), _pair_keys(i2, j2))
+    i1, j1, _, r1 = _collect(pairs(snap).pair_blocks(mode=mode,
+                                                     blocksize=1 << 20))
+    i2, j2, _, r2 = _collect(pairs(snap).pair_blocks(mode=mode, blocksize=97))
+
+    npt.assert_array_equal(np.sort(_pair_keys(i1, j1)),
+                           np.sort(_pair_keys(i2, j2)))
     npt.assert_allclose(np.sort(r1), np.sort(r2), rtol=1e-14)
 
 
-def test_pair_blocks_is_deterministic(pair_api, snap):
+def test_pair_blocks_is_deterministic(pairs, snap):
     """Same tree and blocksize => identical blocks, so results are reproducible."""
-    first = list(pair_api.pair_blocks(snap, blocksize=311))
-    second = list(pair_api.pair_blocks(snap, blocksize=311))
+    first = list(pairs(snap).pair_blocks(blocksize=311))
+    second = list(pairs(snap).pair_blocks(blocksize=311))
 
     assert len(first) == len(second)
     for block1, block2 in zip(first, second):
@@ -350,18 +336,17 @@ def test_pair_blocks_is_deterministic(pair_api, snap):
 # ---------------------------------------------------------------------------
 
 def _assert_pair_set_matches_reference(f, i, j, r, mode):
-    """Compare a pair set to the brute-force reference, away from the boundary."""
+    """Compare a pair set against the brute-force reference, off the boundary."""
     h = np.asarray(f['smooth'], dtype=np.float64)
-    pos = np.asarray(f['pos'], dtype=np.float64)
-
-    exp_i, exp_j, exp_dx = _reference_all_pairs(pos, h, _boxsize_of(f), mode)
-    exp_r = np.sqrt(np.einsum('kl,kl->k', exp_dx, exp_dx))
+    exp_i, exp_j, _, exp_r = _collect(ReferencePairs(f).pair_blocks(mode=mode))
 
     got = _away_from_boundary(i, j, r, h, mode)
     expected = _away_from_boundary(exp_i, exp_j, exp_r, h, mode)
 
-    npt.assert_array_equal(_pair_keys(i[got], j[got]),
-                           _pair_keys(exp_i[expected], exp_j[expected]))
+    npt.assert_array_equal(np.sort(_pair_keys(i[got], j[got])),
+                           np.sort(_pair_keys(exp_i[expected],
+                                              exp_j[expected])))
+    npt.assert_allclose(np.sort(r[got]), np.sort(exp_r[expected]), rtol=1e-12)
 
     # Each particle contributes at most one boundary pair, namely its own nth
     # neighbour, which is what defines its smoothing length. Anything much
@@ -373,9 +358,9 @@ def _assert_pair_set_matches_reference(f, i, j, r, mode):
         % ((~got).sum(), len(i), len(f)))
 
 
-def test_symmetric_mode_pair_set(pair_api, snap):
+def test_symmetric_mode_pair_set(pairs, snap):
     """symmetric mode == {a<b : r <= max(2h_a, 2h_b)}, each pair exactly once."""
-    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+    i, j, _, r = _collect(pairs(snap).pair_blocks(mode='symmetric'))
 
     assert (i < j).all(), "symmetric pairs must be canonicalised to i < j"
     keys = _pair_keys(i, j)
@@ -384,9 +369,9 @@ def test_symmetric_mode_pair_set(pair_api, snap):
     _assert_pair_set_matches_reference(snap, i, j, r, 'symmetric')
 
 
-def test_gather_mode_pair_set(pair_api, snap):
+def test_gather_mode_pair_set(pairs, snap):
     """gather mode == ordered pairs {(a,b) : r <= 2h_a}."""
-    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='gather'))
+    i, j, _, r = _collect(pairs(snap).pair_blocks(mode='gather'))
 
     h = np.asarray(snap['smooth'], dtype=np.float64)
     assert (r <= 2.0 * h[i] * (1 + 1e-12)).all(), \
@@ -395,35 +380,34 @@ def test_gather_mode_pair_set(pair_api, snap):
     _assert_pair_set_matches_reference(snap, i, j, r, 'gather')
 
 
-def test_the_two_modes_cover_the_same_unordered_pairs(pair_api, snap):
-    gi, gj, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
-    si, sj, _, _ = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+def test_the_two_modes_cover_the_same_unordered_pairs(pairs, snap):
+    gi, gj, _, _ = _collect(pairs(snap).pair_blocks(mode='gather'))
+    si, sj, _, _ = _collect(pairs(snap).pair_blocks(mode='symmetric'))
 
     gather_unordered = set(zip(np.minimum(gi, gj).tolist(),
                                np.maximum(gi, gj).tolist()))
     assert gather_unordered == set(zip(si.tolist(), sj.tolist()))
 
 
-def test_gather_mode_visits_some_pairs_from_only_one_side(pair_api, snap):
-    """Where h_a << h_b, (a,b) is a gather pair but (b,a) is not."""
-    gi, gj, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
+def test_the_two_modes_differ_where_smoothing_lengths_differ(pairs, snap):
+    """Check this snapshot can actually tell the two searches apart.
+
+    Where ``h_a << h_b``, the pair is inside b's kernel but not a's. Such pairs
+    are reached from one side only in gather mode, and are exactly what a
+    symmetric search must find but a gather search would miss. Without any of
+    them present, the mode tests above would pass vacuously.
+    """
+    gi, gj, _, _ = _collect(pairs(snap).pair_blocks(mode='gather'))
     ordered = set(zip(gi.tolist(), gj.tolist()))
+    assert sum(1 for (a, b) in ordered if (b, a) not in ordered) > 0, \
+        "no singly-counted gather pairs in this snapshot"
 
-    one_sided = sum(1 for (a, b) in ordered if (b, a) not in ordered)
-    assert one_sided > 0, "expected at least one singly-counted gather pair"
-
-
-def test_symmetric_mode_includes_pairs_reachable_only_from_the_larger_h(
-        pair_api, snap):
-    """The point of symmetric mode: pairs with r > 2h_i but r < 2h_j."""
-    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+    i, j, _, r = _collect(pairs(snap).pair_blocks(mode='symmetric'))
     h = np.asarray(snap['smooth'], dtype=np.float64)
-
     one_sided = ((r > 2.0 * h[i]) & (r < 2.0 * h[j])) | \
                 ((r > 2.0 * h[j]) & (r < 2.0 * h[i]))
-    assert one_sided.sum() > 0, (
-        "no one-sided pairs in this snapshot, so the test cannot tell a "
-        "symmetric search from a gather search")
+    assert one_sided.sum() > 0, \
+        "no pairs reachable only from the larger smoothing length"
 
 
 # ---------------------------------------------------------------------------
@@ -431,10 +415,9 @@ def test_symmetric_mode_includes_pairs_reachable_only_from_the_larger_h(
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_pair_blocks_displacement_is_minimum_image(pair_api, periodic_snap,
-                                                   mode):
+def test_pair_blocks_displacement_is_minimum_image(pairs, periodic_snap, mode):
     """``dx`` must be wrapped; computing ``pos[j]-pos[i]`` by hand is wrong."""
-    i, j, dx, r = _collect(pair_api.pair_blocks(periodic_snap, mode=mode))
+    i, j, dx, r = _collect(pairs(periodic_snap).pair_blocks(mode=mode))
     boxsize = _boxsize_of(periodic_snap)
     pos = np.asarray(periodic_snap['pos'], dtype=np.float64)
 
@@ -443,10 +426,10 @@ def test_pair_blocks_displacement_is_minimum_image(pair_api, periodic_snap,
     assert (np.abs(dx) <= boxsize / 2 + 1e-12).all()
 
 
-def test_pair_blocks_finds_pairs_across_the_periodic_boundary(pair_api,
+def test_pair_blocks_finds_pairs_across_the_periodic_boundary(pairs,
                                                               periodic_snap):
     """Some pairs must have an unwrapped separation of nearly a box length."""
-    i, j, _, r = _collect(pair_api.pair_blocks(periodic_snap))
+    i, j, _, r = _collect(pairs(periodic_snap).pair_blocks())
     pos = np.asarray(periodic_snap['pos'], dtype=np.float64)
     d = pos[j] - pos[i]
     unwrapped = np.sqrt(np.einsum('kl,kl->k', d, d))
@@ -459,17 +442,17 @@ def test_pair_blocks_finds_pairs_across_the_periodic_boundary(pair_api,
 # pair_reduce: accumulation semantics
 # ---------------------------------------------------------------------------
 
-def test_pair_reduce_counts_pairs_per_particle(pair_api, snap):
+def test_pair_reduce_counts_pairs_per_particle(pairs, snap):
     """A callback returning 1.0 counts pairs, i.e. repeated indices sum.
 
     This is the ``np.bincount`` versus ``out[i] += c`` trap: the latter keeps
     only one contribution per particle per block.
     """
-    counts = pair_api.pair_reduce(
-        snap, lambda i, j, dx, r: (np.ones(len(i)), np.ones(len(j))),
+    counts = pairs(snap).pair_reduce(
+        lambda i, j, dx, r: (np.ones(len(i)), np.ones(len(j))),
         mode='symmetric', blocksize=97)
 
-    i, j, _, _ = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+    i, j, _, _ = _collect(pairs(snap).pair_blocks(mode='symmetric'))
     expected = (np.bincount(i, minlength=len(snap))
                 + np.bincount(j, minlength=len(snap)))
 
@@ -477,33 +460,33 @@ def test_pair_reduce_counts_pairs_per_particle(pair_api, snap):
     assert counts.sum() == 2 * len(i)
 
 
-def test_pair_reduce_single_return_accumulates_at_i_only(pair_api, snap):
+def test_pair_reduce_single_return_accumulates_at_i_only(pairs, snap):
     """Returning one array rather than a tuple means 'accumulate at i'."""
-    at_i = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i)),
-                                mode='gather')
-    i, _, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
+    at_i = pairs(snap).pair_reduce(lambda i, j, dx, r: np.ones(len(i)),
+                                   mode='gather')
+    i, _, _, _ = _collect(pairs(snap).pair_blocks(mode='gather'))
     npt.assert_array_equal(at_i, np.bincount(i, minlength=len(snap)))
 
 
-def test_pair_reduce_output_shape_scalar_and_vector(pair_api, snap):
+def test_pair_reduce_output_shape_scalar_and_vector(pairs, snap):
     m = np.asarray(snap['mass'], dtype=np.float64)
 
-    scalar = pair_api.pair_reduce(snap, lambda i, j, dx, r: m[j] / r)
+    scalar = pairs(snap).pair_reduce(lambda i, j, dx, r: m[j] / r)
     assert scalar.shape == (len(snap),)
 
-    vector = pair_api.pair_reduce(
-        snap, lambda i, j, dx, r: (m[j] / r ** 3)[:, None] * dx)
+    vector = pairs(snap).pair_reduce(
+        lambda i, j, dx, r: (m[j] / r ** 3)[:, None] * dx)
     assert vector.shape == (len(snap), 3)
 
 
-def test_pair_reduce_output_covers_every_particle(pair_api, snap):
+def test_pair_reduce_output_covers_every_particle(pairs, snap):
     """Output is always length N, whatever the pair distribution."""
-    out = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.zeros(len(i)))
+    out = pairs(snap).pair_reduce(lambda i, j, dx, r: np.zeros(len(i)))
     assert out.shape == (len(snap),)
     npt.assert_array_equal(out, 0.0)
 
 
-def test_pair_reduce_invariant_to_blocksize(pair_api, snap):
+def test_pair_reduce_invariant_to_blocksize(pairs, snap):
     """A particle's pairs straddle block boundaries; that must not matter."""
     m = np.asarray(snap['mass'], dtype=np.float64)
     u = np.asarray(snap['u'], dtype=np.float64)
@@ -512,14 +495,14 @@ def test_pair_reduce_invariant_to_blocksize(pair_api, snap):
         c = m[j] * (u[j] - u[i]) / r
         return c, -c
 
-    npt.assert_allclose(pair_api.pair_reduce(snap, func, blocksize=1 << 20),
-                        pair_api.pair_reduce(snap, func, blocksize=53),
+    npt.assert_allclose(pairs(snap).pair_reduce(func, blocksize=1 << 20),
+                        pairs(snap).pair_reduce(func, blocksize=53),
                         rtol=1e-12)
 
 
-def test_pair_reduce_dtype_is_respected(pair_api, snap):
-    out = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i)),
-                               dtype=np.float32)
+def test_pair_reduce_dtype_is_respected(pairs, snap):
+    out = pairs(snap).pair_reduce(lambda i, j, dx, r: np.ones(len(i)),
+                                  dtype=np.float32)
     assert out.dtype == np.float32
 
 
@@ -527,7 +510,7 @@ def test_pair_reduce_dtype_is_respected(pair_api, snap):
 # pair_reduce: the conservation property that motivates the design
 # ---------------------------------------------------------------------------
 
-def test_antisymmetric_reduction_conserves_exactly(pair_api, snap):
+def test_antisymmetric_reduction_conserves_exactly(pairs, snap):
     """An antisymmetric callback conserves energy to roundoff, by construction.
 
     Because each unordered pair is visited once and both ends are accumulated
@@ -545,14 +528,14 @@ def test_antisymmetric_reduction_conserves_exactly(pair_api, snap):
         c = v_d * (u[j] - u[i]) * g
         return m[j] * c, -m[i] * c
 
-    du_dt = pair_api.pair_reduce(snap, conduction_like, mode='symmetric')
+    du_dt = pairs(snap).pair_reduce(conduction_like, mode='symmetric')
 
     terms = m * du_dt
     residual = np.abs(terms.sum()) / np.abs(terms).sum()
     assert residual < 1e-13, f"energy residual {residual:.3e} is too large"
 
 
-def test_symmetric_reduction_of_positive_definite_term_stays_positive(pair_api,
+def test_symmetric_reduction_of_positive_definite_term_stays_positive(pairs,
                                                                       snap):
     """The viscous form is positive definite; that must survive the reduction."""
     m = np.asarray(snap['mass'], dtype=np.float64)
@@ -564,31 +547,29 @@ def test_symmetric_reduction_of_positive_definite_term_stays_positive(pair_api,
         c = mu ** 2 * (1.0 / h[i] ** 4 + 1.0 / h[j] ** 4)
         return m[j] * c, m[i] * c
 
-    assert (pair_api.pair_reduce(snap, viscosity_like) >= 0).all()
+    assert (pairs(snap).pair_reduce(viscosity_like) >= 0).all()
 
 
 # ---------------------------------------------------------------------------
-# pair_reduce cross-checked against pynbody's existing C++ SPH operations.
-# These use the reference kernel, so they test the pair set and the
-# accumulation rather than the proposed kernel API.
+# pair_reduce cross-checked against pynbody's existing C++ SPH operations
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("snap_name", ['snap', 'periodic_snap'])
-def test_pair_reduce_reproduces_density(pair_api, request, snap_name):
+def test_pair_reduce_reproduces_density(pairs, request, snap_name):
     """rho_i = sum_j m_j W(r, h_i), including the self-contribution."""
     f = request.getfixturevalue(snap_name)
     m = np.asarray(f['mass'], dtype=np.float64)
     h = np.asarray(f['smooth'], dtype=np.float64)
 
-    rho = pair_api.pair_reduce(
-        f, lambda i, j, dx, r: m[j] * _reference_kernel_value(r, h[i]),
+    rho = pairs(f).pair_reduce(
+        lambda i, j, dx, r: m[j] * _reference_kernel_value(r, h[i]),
         mode='gather')
     rho += m * _reference_kernel_value(np.zeros(len(f)), h)
 
     npt.assert_allclose(rho, np.asarray(f['rho'], dtype=np.float64), rtol=1e-9)
 
 
-def test_pair_reduce_reproduces_sph_divergence(pair_api, snap):
+def test_pair_reduce_reproduces_sph_divergence(pairs, snap):
     """Reproduce KDTree.sph_divergence, which uses the m_j/rho_j gather form.
 
         div v_i = sum_j (m_j/rho_j) (v_j - v_i) . grad_i W(r, h_i)
@@ -604,7 +585,7 @@ def test_pair_reduce_reproduces_sph_divergence(pair_api, snap):
         dv_dot_dx = np.einsum('kl,kl->k', vel[j] - vel[i], dx)
         return -(m[j] / rho[j]) * dv_dot_dx * _reference_kernel_gradient(r, h[i]) / r
 
-    div = pair_api.pair_reduce(snap, divergence, mode='gather')
+    div = pairs(snap).pair_reduce(divergence, mode='gather')
     expected = np.asarray(snap.kdtree.sph_divergence(
         snap['vel'], pynbody.config['sph']['smooth-particles']))
 
@@ -614,22 +595,6 @@ def test_pair_reduce_reproduces_sph_divergence(pair_api, snap):
 # ---------------------------------------------------------------------------
 # Head-to-head comparison of the two implementations
 # ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
-def test_matches_reference_pair_set(snap, mode):
-    h = np.asarray(snap['smooth'], dtype=np.float64)
-
-    ri, rj, _, rr = _collect(ReferenceImplementation.pair_blocks(snap,
-                                                                 mode=mode))
-    ki, kj, _, kr = _collect(KDTreeImplementation.pair_blocks(snap, mode=mode))
-
-    ref_ok = _away_from_boundary(ri, rj, rr, h, mode)
-    kd_ok = _away_from_boundary(ki, kj, kr, h, mode)
-
-    npt.assert_array_equal(_pair_keys(ri[ref_ok], rj[ref_ok]),
-                           _pair_keys(ki[kd_ok], kj[kd_ok]))
-    npt.assert_allclose(np.sort(rr[ref_ok]), np.sort(kr[kd_ok]), rtol=1e-12)
-
 
 @pytest.mark.parametrize("mode", ['symmetric', 'gather'])
 def test_boundary_disagreements_carry_no_kernel_weight(snap, mode):
@@ -642,85 +607,77 @@ def test_boundary_disagreements_carry_no_kernel_weight(snap, mode):
     h = np.asarray(snap['smooth'], dtype=np.float64)
     kernel = snap.kdtree.kernel
 
-    ri, rj, _, rr = _collect(ReferenceImplementation.pair_blocks(snap,
-                                                                 mode=mode))
-    ki, kj, _, kr = _collect(KDTreeImplementation.pair_blocks(snap, mode=mode))
+    reference = _collect(ReferencePairs(snap).pair_blocks(mode=mode))
+    kdtree = _collect(snap.kdtree.pair_blocks(mode=mode))
 
-    ref_keys = _pair_keys(ri, rj)
-    kd_keys = _pair_keys(ki, kj)
-    disputed = np.setxor1d(ref_keys, kd_keys)
+    keys = [_pair_keys(i, j) for i, j, _, _ in (reference, kdtree)]
+    disputed = np.setxor1d(*keys)
 
     if len(disputed) == 0:
         pytest.skip("the two implementations agree exactly on this snapshot")
 
-    # locate the disputed pairs in whichever set contains them
-    for keys, i, j, r in ((ref_keys, ri, rj, rr), (kd_keys, ki, kj, kr)):
-        order = np.argsort(i.astype(np.int64) * (1 << 32) + j.astype(np.int64))
-        i, j, r = i[order], j[order], r[order]
-        sel = np.isin(keys, disputed)
+    for key, (i, j, _, r) in zip(keys, (reference, kdtree)):
+        sel = np.isin(key, disputed)
         if not sel.any():
             continue
 
-        threshold = _boundary_threshold(i[sel], j[sel], h, mode)
-        npt.assert_allclose(r[sel], threshold, rtol=1e-12)
+        npt.assert_allclose(r[sel], _boundary_threshold(i[sel], j[sel], h, mode),
+                            rtol=1e-12)
 
         # both the kernel and its gradient vanish there, for either smoothing
         for h_side in (h[i[sel]], h[j[sel]]):
-            weight = np.abs(kernel.value(r[sel], h_side))
-            grad = np.abs(kernel.gradient(r[sel], h_side))
-            assert (weight[r[sel] >= 2 * h_side] == 0).all()
-            assert (grad[r[sel] >= 2 * h_side] == 0).all()
+            outside = r[sel] >= 2 * h_side
+            assert (kernel.value(r[sel], h_side)[outside] == 0).all()
+            assert (kernel.gradient(r[sel], h_side)[outside] == 0).all()
 
 
-def test_matches_reference_reduction(snap):
-    """A realistic kernel-weighted sum agrees exactly, boundary notwithstanding."""
-    m = np.asarray(snap['mass'], dtype=np.float64)
-    u = np.asarray(snap['u'], dtype=np.float64)
-    h = np.asarray(snap['smooth'], dtype=np.float64)
-    kernel = snap.kdtree.kernel
+@pytest.mark.parametrize("snap_name", ['snap', 'periodic_snap'])
+def test_matches_reference_reduction(request, snap_name):
+    """Realistic kernel-weighted sums agree, boundary ambiguity notwithstanding.
 
-    def func(i, j, dx, r):
-        # as in any real SPH sum, the kernel gradient multiplies every term,
-        # so pairs sitting on r == 2h contribute exactly zero
+    As in any real SPH sum the kernel gradient multiplies every term, so pairs
+    sitting on r == 2h contribute exactly zero and the comparison is exact.
+    """
+    f = request.getfixturevalue(snap_name)
+    m = np.asarray(f['mass'], dtype=np.float64)
+    h = np.asarray(f['smooth'], dtype=np.float64)
+    kernel = f.kdtree.kernel
+
+    def scalar(i, j, dx, r):
         g = kernel.gradient(r, h[i]) + kernel.gradient(r, h[j])
-        c = (u[j] - u[i]) * g
+        c = (h[j] - h[i]) * g
         return m[j] * c, -m[i] * c
 
-    npt.assert_allclose(ReferenceImplementation.pair_reduce(snap, func),
-                        KDTreeImplementation.pair_reduce(snap, func),
-                        rtol=1e-11)
-
-
-def test_matches_reference_in_periodic_box(periodic_snap):
-    m = np.asarray(periodic_snap['mass'], dtype=np.float64)
-    h = np.asarray(periodic_snap['smooth'], dtype=np.float64)
-    kernel = periodic_snap.kdtree.kernel
-
-    def func(i, j, dx, r):
+    def vector(i, j, dx, r):
         g = kernel.gradient(r, h[i]) + kernel.gradient(r, h[j])
         c = (m[j] * g / r)[:, None] * dx
         return c, -(m[i] / m[j])[:, None] * c
 
-    npt.assert_allclose(
-        ReferenceImplementation.pair_reduce(periodic_snap, func),
-        KDTreeImplementation.pair_reduce(periodic_snap, func), rtol=1e-11)
+    for func in (scalar, vector):
+        npt.assert_allclose(ReferencePairs(f).pair_reduce(func),
+                            f.kdtree.pair_reduce(func), rtol=1e-11)
 
 
 # ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
 
-def test_unknown_mode_raises(pair_api, snap):
+def test_unknown_mode_raises(snap):
     with pytest.raises(ValueError):
-        list(pair_api.pair_blocks(snap, mode='not-a-mode'))
+        snap.kdtree.pair_blocks(mode='not-a-mode')
 
 
-def test_callback_returning_wrong_length_raises(pair_api, snap):
+def test_invalid_blocksize_raises(snap):
     with pytest.raises(ValueError):
-        pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i) + 1))
+        snap.kdtree.pair_blocks(blocksize=0)
 
 
-def test_callback_returning_inconsistent_shape_raises(pair_api, snap):
+def test_callback_returning_wrong_length_raises(snap):
+    with pytest.raises(ValueError):
+        snap.kdtree.pair_reduce(lambda i, j, dx, r: np.ones(len(i) + 1))
+
+
+def test_callback_returning_inconsistent_shape_raises(snap):
     """The trailing shape is fixed by the first block and may not change."""
     state = {'n': 0}
 
@@ -729,7 +686,7 @@ def test_callback_returning_inconsistent_shape_raises(pair_api, snap):
         return np.ones(len(i)) if state['n'] == 1 else np.ones((len(i), 3))
 
     with pytest.raises(ValueError):
-        pair_api.pair_reduce(snap, wobbly, blocksize=53)
+        snap.kdtree.pair_reduce(wobbly, blocksize=53)
 
 
 # ---------------------------------------------------------------------------
@@ -791,7 +748,7 @@ def test_kernel_vanishes_outside_support():
 
 
 def test_kernel_agrees_with_the_reference_cubic_spline():
-    """Ties the proposed kernel API to the normalisation assumed above."""
+    """Tie the kernel API to the normalisation assumed by the cross-checks."""
     kernel = pynbody.sph.kernels.create_kernel('CubicSplineKernel')
     r = np.linspace(0.0, 2.5, 60)
     h = 1.15

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -1,0 +1,874 @@
+"""Tests for user-defined pairwise SPH operations.
+
+These cover:
+
+  * ``KDTree.pair_blocks(mode, blocksize)`` -- iterate over neighbour pairs in
+    blocks, as flat numpy arrays;
+  * ``KDTree.pair_reduce(func, mode, blocksize, dtype)`` -- accumulate a
+    user-supplied pairwise function over those pairs;
+  * ``KernelBase.value(r, h)`` / ``KernelBase.gradient(r, h)`` -- vectorised
+    kernel evaluation, and ``KDTree.kernel`` to reach the kernel the tree is
+    actually using.
+
+Together these let a user express operations such as SPH artificial viscosity
+and artificial conduction without a Python-level loop over ``KDTree.nn()``.
+
+Most tests run against two implementations, selected by the ``pair_api``
+fixture:
+
+  ``reference``  a brute-force O(N^2) implementation, defined in this file.
+                 It *is* the specification of the pair set and of the
+                 accumulation.
+  ``kdtree``     the real ``KDTree`` methods, backed by the C++ tree walk.
+
+Applying identical assertions to both is what checks the C++ implementation
+against the reference; :func:`test_matches_reference_pair_set` and friends
+additionally compare the two head-to-head.
+
+The pair-set tests deliberately do not depend on the kernel API (they use a
+reference kernel defined here), and the kernel tests do not depend on the pair
+API, so that a failure points at one thing or the other.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pynbody
+
+_trapezoid = getattr(np, 'trapezoid', None) or np.trapz
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation: this defines the semantics that the C++
+# implementation must reproduce.
+# ---------------------------------------------------------------------------
+
+def _minimum_image(dx, boxsize):
+    if boxsize is None:
+        return dx
+    return dx - boxsize * np.round(dx / boxsize)
+
+
+def _boxsize_of(f):
+    """Mirror of SimSnap._get_boxsize_for_kdtree, returning None if infinite."""
+    boxsize = f.properties.get('boxsize', None)
+    if not boxsize:
+        return None
+    if pynbody.units.is_unit_like(boxsize):
+        return float(boxsize.in_units(f['pos'].units))
+    return float(boxsize)
+
+
+def _reference_all_pairs(pos, h, boxsize, mode):
+    """Brute-force enumeration of the pair set, O(N^2).
+
+    ``symmetric`` yields each unordered pair ``{a, b}`` with
+    ``r <= max(2h_a, 2h_b)`` exactly once, canonicalised to ``i < j``.
+    ``gather`` yields each ordered pair ``(a, b)`` with ``r <= 2h_a``.
+
+    The boundary is inclusive, matching smBallGather. Note that ``r == 2h``
+    occurs by construction, since h is half the distance to the nth
+    neighbour, so pairs sitting exactly on it are not a rare edge case.
+    """
+    if mode not in ('symmetric', 'gather'):
+        raise ValueError(f"unknown mode {mode!r}")
+
+    i_list, j_list, dx_list = [], [], []
+
+    for a in range(len(pos)):
+        dx = _minimum_image(pos - pos[a], boxsize)
+        r = np.sqrt(np.einsum('kl,kl->k', dx, dx))
+
+        if mode == 'symmetric':
+            within = r <= np.maximum(2.0 * h[a], 2.0 * h)
+            within[:a + 1] = False          # each unordered pair once, i < j
+        else:
+            within = r <= 2.0 * h[a]
+            within[a] = False               # no self-pairs
+
+        b = np.flatnonzero(within)
+        i_list.append(np.full(len(b), a, dtype=np.int64))
+        j_list.append(b.astype(np.int64))
+        dx_list.append(dx[b])
+
+    return (np.concatenate(i_list), np.concatenate(j_list),
+            np.concatenate(dx_list))
+
+
+def _scatter_add(out, idx, contrib):
+    """``out[idx] += contrib``, summing over repeated entries of ``idx``."""
+    npart = out.shape[0]
+    if out.ndim == 1:
+        out += np.bincount(idx, weights=contrib, minlength=npart)
+    else:
+        for k in range(out.shape[1]):
+            out[:, k] += np.bincount(idx, weights=contrib[:, k],
+                                     minlength=npart)
+
+
+class ReferenceImplementation:
+    """Brute-force implementation of the proposed API."""
+
+    name = 'reference'
+
+    @staticmethod
+    def pair_blocks(f, mode='symmetric', blocksize=1 << 20):
+        i_all, j_all, dx_all = _reference_all_pairs(
+            np.asarray(f['pos'], dtype=np.float64),
+            np.asarray(f['smooth'], dtype=np.float64),
+            _boxsize_of(f), mode)
+
+        for s in range(0, len(i_all), blocksize):
+            sl = slice(s, s + blocksize)
+            i, j, dx = i_all[sl], j_all[sl], dx_all[sl]
+            r = np.sqrt(np.einsum('kl,kl->k', dx, dx))
+            for arr in (i, j, dx, r):
+                arr.flags.writeable = False
+            yield i, j, dx, r
+
+    @classmethod
+    def pair_reduce(cls, f, func, mode='symmetric', blocksize=1 << 20,
+                    dtype=np.float64):
+        out = np.zeros(len(f), dtype=dtype)
+        trailing = None
+
+        for i, j, dx, r in cls.pair_blocks(f, mode, blocksize):
+            res = func(i, j, dx, r)
+            ci, cj = res if isinstance(res, tuple) else (res, None)
+            ci = np.asarray(ci)
+
+            if len(ci) != len(i):
+                raise ValueError("callback returned %d values for a block of "
+                                 "%d pairs" % (len(ci), len(i)))
+            if trailing is None:
+                trailing = ci.shape[1:]
+                out = np.zeros((len(f),) + trailing, dtype=dtype)
+            elif ci.shape[1:] != trailing:
+                raise ValueError("callback returned trailing shape %s; the "
+                                 "first block gave %s"
+                                 % (ci.shape[1:], trailing))
+
+            _scatter_add(out, i, ci)
+            if cj is not None:
+                _scatter_add(out, j, np.asarray(cj))
+
+        return out
+
+
+class KDTreeImplementation:
+    """The proposed KDTree methods."""
+
+    name = 'kdtree'
+
+    @staticmethod
+    def pair_blocks(f, mode='symmetric', blocksize=1 << 20):
+        f.build_tree()
+        return f.kdtree.pair_blocks(mode=mode, blocksize=blocksize)
+
+    @staticmethod
+    def pair_reduce(f, func, mode='symmetric', blocksize=1 << 20,
+                    dtype=np.float64):
+        f.build_tree()
+        return f.kdtree.pair_reduce(func, mode=mode, blocksize=blocksize,
+                                    dtype=dtype)
+
+
+# Reference cubic spline, matching pynbody's normalisation:
+#     W(r, h) = f(r/h) / (pi h^3),  support at r = 2h
+# Used by the cross-checks against pynbody's own C++ density and divergence, so
+# that those tests exercise the pair set rather than the proposed kernel API.
+
+def _reference_kernel_value(r, h):
+    q = np.asarray(r, dtype=np.float64) / h
+    f = np.where(q < 1, 1 - 1.5 * q ** 2 + 0.75 * q ** 3,
+                 0.25 * np.clip(2 - q, 0, None) ** 3)
+    return f / (np.pi * np.asarray(h, dtype=np.float64) ** 3)
+
+
+def _reference_kernel_gradient(r, h):
+    """dW/dr, negative on (0, 2h)."""
+    q = np.asarray(r, dtype=np.float64) / h
+    df = np.where(q < 1, -3 * q + 2.25 * q ** 2,
+                  -0.75 * np.clip(2 - q, 0, None) ** 2)
+    return df / (np.pi * np.asarray(h, dtype=np.float64) ** 4)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(params=[ReferenceImplementation, KDTreeImplementation],
+                ids=lambda impl: impl.name)
+def pair_api(request):
+    return request.param
+
+
+@pytest.fixture
+def snap():
+    """A small non-periodic snapshot, with smoothing lengths already fixed."""
+    npart = 400
+    f = pynbody.new(gas=npart)
+    np.random.seed(1337)
+    f['pos'] = np.random.normal(scale=10.0, size=(npart, 3))
+    f['mass'] = np.random.uniform(0.5, 1.5, size=npart)
+    f['vel'] = np.random.normal(size=(npart, 3))
+    f['u'] = np.random.uniform(1.0, 2.0, size=npart)
+    f['smooth']  # force calculation now, so h is constant through the test
+    return f
+
+
+@pytest.fixture
+def periodic_snap():
+    """A periodic snapshot with plenty of boundary-straddling pairs."""
+    npart = 600
+    f = pynbody.new(gas=npart)
+    np.random.seed(1338)
+    f['pos'] = np.random.uniform(-0.5, 0.5, size=(npart, 3))
+    f['mass'] = np.random.uniform(0.5, 1.5, size=npart)
+    f.properties['boxsize'] = 1.0
+    f['smooth']
+
+    # minimum-image is only well defined while kernels are smaller than the box
+    assert (2 * np.asarray(f['smooth'])).max() < 0.5
+    return f
+
+
+def _collect(blocks):
+    """Concatenate an iterator of pair blocks into single arrays."""
+    parts = list(blocks)
+    if not parts:
+        return (np.empty(0, np.int64), np.empty(0, np.int64),
+                np.empty((0, 3)), np.empty(0))
+    return tuple(np.concatenate([p[k] for p in parts]) for k in range(4))
+
+
+def _pair_keys(i, j):
+    """A sorted key per pair, for order-insensitive comparison of pair sets."""
+    return np.sort(i.astype(np.int64) * (1 << 32) + j.astype(np.int64))
+
+
+#: Pairs closer than this (relative) to the r == 2h boundary are treated as
+#: ambiguous when comparing two implementations. Smoothing lengths are defined
+#: as half the distance to the nth neighbour, so r == 2h is hit exactly for one
+#: neighbour of every particle. Two independent floating-point evaluations of
+#: that same distance -- the C++ tree walk and numpy's einsum -- differ in the
+#: last bit, so membership on the boundary is not reproducible between them.
+#: It is also physically irrelevant, since W and dW/dr both vanish at r == 2h;
+#: :func:`test_boundary_disagreements_carry_no_kernel_weight` asserts exactly
+#: that, so nothing is being swept under the carpet here.
+BOUNDARY_RTOL = 1e-12
+
+
+def _boundary_threshold(i, j, h, mode):
+    """The value of r at which each pair enters or leaves the pair set."""
+    if mode == 'gather':
+        return 2.0 * h[i]
+    return np.maximum(2.0 * h[i], 2.0 * h[j])
+
+
+def _away_from_boundary(i, j, r, h, mode, rtol=BOUNDARY_RTOL):
+    """Mask selecting pairs whose membership is unambiguous."""
+    threshold = _boundary_threshold(i, j, h, mode)
+    return np.abs(r - threshold) > rtol * threshold
+
+
+# ---------------------------------------------------------------------------
+# pair_blocks: what the callback receives
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_shapes_and_dtypes(pair_api, snap, mode):
+    seen_any = False
+    for i, j, dx, r in pair_api.pair_blocks(snap, mode=mode, blocksize=500):
+        seen_any = True
+        nblock = len(i)
+        assert nblock <= 500
+        assert i.shape == (nblock,) and j.shape == (nblock,)
+        assert dx.shape == (nblock, 3)
+        assert r.shape == (nblock,)
+        assert np.issubdtype(i.dtype, np.integer)
+        assert np.issubdtype(j.dtype, np.integer)
+        assert dx.dtype == np.float64 and r.dtype == np.float64
+    assert seen_any, "no pairs were generated at all"
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_r_is_consistent_with_dx(pair_api, snap, mode):
+    """``r`` must be exactly ``|dx|``, so the callback may use either."""
+    _, _, dx, r = _collect(pair_api.pair_blocks(snap, mode=mode))
+    npt.assert_allclose(r, np.sqrt(np.einsum('kl,kl->k', dx, dx)), rtol=1e-14)
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_excludes_self_pairs(pair_api, snap, mode):
+    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode=mode))
+    assert (i != j).all()
+    assert (r > 0).all(), "with self-pairs excluded, r is never zero"
+
+
+def test_pair_blocks_arrays_are_read_only(pair_api, snap):
+    """The callback must not be able to corrupt pynbody's internal buffers."""
+    for block in pair_api.pair_blocks(snap):
+        for name, arr in zip(('i', 'j', 'dx', 'r'), block):
+            assert not arr.flags.writeable, f"{name} should be read-only"
+        break
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_blocksize_is_respected(pair_api, snap, mode):
+    sizes = [len(b[0]) for b in
+             pair_api.pair_blocks(snap, mode=mode, blocksize=137)]
+    assert len(sizes) > 1, "test is only meaningful with several blocks"
+    assert max(sizes) <= 137
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_invariant_to_blocksize(pair_api, snap, mode):
+    """Blocking is an implementation detail; the pair set cannot depend on it."""
+    i1, j1, _, r1 = _collect(pair_api.pair_blocks(snap, mode=mode,
+                                                  blocksize=1 << 20))
+    i2, j2, _, r2 = _collect(pair_api.pair_blocks(snap, mode=mode,
+                                                  blocksize=97))
+    npt.assert_array_equal(_pair_keys(i1, j1), _pair_keys(i2, j2))
+    npt.assert_allclose(np.sort(r1), np.sort(r2), rtol=1e-14)
+
+
+def test_pair_blocks_is_deterministic(pair_api, snap):
+    """Same tree and blocksize => identical blocks, so results are reproducible."""
+    first = list(pair_api.pair_blocks(snap, blocksize=311))
+    second = list(pair_api.pair_blocks(snap, blocksize=311))
+
+    assert len(first) == len(second)
+    for block1, block2 in zip(first, second):
+        for arr1, arr2 in zip(block1, block2):
+            npt.assert_array_equal(arr1, arr2)
+
+
+# ---------------------------------------------------------------------------
+# pair_blocks: which pairs are in the set
+# ---------------------------------------------------------------------------
+
+def _assert_pair_set_matches_reference(f, i, j, r, mode):
+    """Compare a pair set to the brute-force reference, away from the boundary."""
+    h = np.asarray(f['smooth'], dtype=np.float64)
+    pos = np.asarray(f['pos'], dtype=np.float64)
+
+    exp_i, exp_j, exp_dx = _reference_all_pairs(pos, h, _boxsize_of(f), mode)
+    exp_r = np.sqrt(np.einsum('kl,kl->k', exp_dx, exp_dx))
+
+    got = _away_from_boundary(i, j, r, h, mode)
+    expected = _away_from_boundary(exp_i, exp_j, exp_r, h, mode)
+
+    npt.assert_array_equal(_pair_keys(i[got], j[got]),
+                           _pair_keys(exp_i[expected], exp_j[expected]))
+
+    # Each particle contributes at most one boundary pair, namely its own nth
+    # neighbour, which is what defines its smoothing length. Anything much
+    # beyond that would mean the disagreement is systematic rather than a
+    # last-bit tie.
+    assert (~got).sum() <= 2 * len(f), (
+        "%d of %d pairs sit on the 2h boundary, with only %d particles; that "
+        "is more than the one-per-particle expected from the definition of h"
+        % ((~got).sum(), len(i), len(f)))
+
+
+def test_symmetric_mode_pair_set(pair_api, snap):
+    """symmetric mode == {a<b : r <= max(2h_a, 2h_b)}, each pair exactly once."""
+    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+
+    assert (i < j).all(), "symmetric pairs must be canonicalised to i < j"
+    keys = _pair_keys(i, j)
+    assert len(np.unique(keys)) == len(keys), "pairs must not be duplicated"
+
+    _assert_pair_set_matches_reference(snap, i, j, r, 'symmetric')
+
+
+def test_gather_mode_pair_set(pair_api, snap):
+    """gather mode == ordered pairs {(a,b) : r <= 2h_a}."""
+    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='gather'))
+
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+    assert (r <= 2.0 * h[i] * (1 + 1e-12)).all(), \
+        "gather mode must not exceed i's kernel"
+
+    _assert_pair_set_matches_reference(snap, i, j, r, 'gather')
+
+
+def test_the_two_modes_cover_the_same_unordered_pairs(pair_api, snap):
+    gi, gj, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
+    si, sj, _, _ = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+
+    gather_unordered = set(zip(np.minimum(gi, gj).tolist(),
+                               np.maximum(gi, gj).tolist()))
+    assert gather_unordered == set(zip(si.tolist(), sj.tolist()))
+
+
+def test_gather_mode_visits_some_pairs_from_only_one_side(pair_api, snap):
+    """Where h_a << h_b, (a,b) is a gather pair but (b,a) is not."""
+    gi, gj, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
+    ordered = set(zip(gi.tolist(), gj.tolist()))
+
+    one_sided = sum(1 for (a, b) in ordered if (b, a) not in ordered)
+    assert one_sided > 0, "expected at least one singly-counted gather pair"
+
+
+def test_symmetric_mode_includes_pairs_reachable_only_from_the_larger_h(
+        pair_api, snap):
+    """The point of symmetric mode: pairs with r > 2h_i but r < 2h_j."""
+    i, j, _, r = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+
+    one_sided = ((r > 2.0 * h[i]) & (r < 2.0 * h[j])) | \
+                ((r > 2.0 * h[j]) & (r < 2.0 * h[i]))
+    assert one_sided.sum() > 0, (
+        "no one-sided pairs in this snapshot, so the test cannot tell a "
+        "symmetric search from a gather search")
+
+
+# ---------------------------------------------------------------------------
+# pair_blocks: periodicity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_displacement_is_minimum_image(pair_api, periodic_snap,
+                                                   mode):
+    """``dx`` must be wrapped; computing ``pos[j]-pos[i]`` by hand is wrong."""
+    i, j, dx, r = _collect(pair_api.pair_blocks(periodic_snap, mode=mode))
+    boxsize = _boxsize_of(periodic_snap)
+    pos = np.asarray(periodic_snap['pos'], dtype=np.float64)
+
+    npt.assert_allclose(dx, _minimum_image(pos[j] - pos[i], boxsize),
+                        atol=1e-12)
+    assert (np.abs(dx) <= boxsize / 2 + 1e-12).all()
+
+
+def test_pair_blocks_finds_pairs_across_the_periodic_boundary(pair_api,
+                                                              periodic_snap):
+    """Some pairs must have an unwrapped separation of nearly a box length."""
+    i, j, _, r = _collect(pair_api.pair_blocks(periodic_snap))
+    pos = np.asarray(periodic_snap['pos'], dtype=np.float64)
+    d = pos[j] - pos[i]
+    unwrapped = np.sqrt(np.einsum('kl,kl->k', d, d))
+
+    assert (unwrapped > 2 * r).sum() > 0, (
+        "no boundary-straddling pairs, so periodicity is untested here")
+
+
+# ---------------------------------------------------------------------------
+# pair_reduce: accumulation semantics
+# ---------------------------------------------------------------------------
+
+def test_pair_reduce_counts_pairs_per_particle(pair_api, snap):
+    """A callback returning 1.0 counts pairs, i.e. repeated indices sum.
+
+    This is the ``np.bincount`` versus ``out[i] += c`` trap: the latter keeps
+    only one contribution per particle per block.
+    """
+    counts = pair_api.pair_reduce(
+        snap, lambda i, j, dx, r: (np.ones(len(i)), np.ones(len(j))),
+        mode='symmetric', blocksize=97)
+
+    i, j, _, _ = _collect(pair_api.pair_blocks(snap, mode='symmetric'))
+    expected = (np.bincount(i, minlength=len(snap))
+                + np.bincount(j, minlength=len(snap)))
+
+    npt.assert_array_equal(counts, expected)
+    assert counts.sum() == 2 * len(i)
+
+
+def test_pair_reduce_single_return_accumulates_at_i_only(pair_api, snap):
+    """Returning one array rather than a tuple means 'accumulate at i'."""
+    at_i = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i)),
+                                mode='gather')
+    i, _, _, _ = _collect(pair_api.pair_blocks(snap, mode='gather'))
+    npt.assert_array_equal(at_i, np.bincount(i, minlength=len(snap)))
+
+
+def test_pair_reduce_output_shape_scalar_and_vector(pair_api, snap):
+    m = np.asarray(snap['mass'], dtype=np.float64)
+
+    scalar = pair_api.pair_reduce(snap, lambda i, j, dx, r: m[j] / r)
+    assert scalar.shape == (len(snap),)
+
+    vector = pair_api.pair_reduce(
+        snap, lambda i, j, dx, r: (m[j] / r ** 3)[:, None] * dx)
+    assert vector.shape == (len(snap), 3)
+
+
+def test_pair_reduce_output_covers_every_particle(pair_api, snap):
+    """Output is always length N, whatever the pair distribution."""
+    out = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.zeros(len(i)))
+    assert out.shape == (len(snap),)
+    npt.assert_array_equal(out, 0.0)
+
+
+def test_pair_reduce_invariant_to_blocksize(pair_api, snap):
+    """A particle's pairs straddle block boundaries; that must not matter."""
+    m = np.asarray(snap['mass'], dtype=np.float64)
+    u = np.asarray(snap['u'], dtype=np.float64)
+
+    def func(i, j, dx, r):
+        c = m[j] * (u[j] - u[i]) / r
+        return c, -c
+
+    npt.assert_allclose(pair_api.pair_reduce(snap, func, blocksize=1 << 20),
+                        pair_api.pair_reduce(snap, func, blocksize=53),
+                        rtol=1e-12)
+
+
+def test_pair_reduce_dtype_is_respected(pair_api, snap):
+    out = pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i)),
+                               dtype=np.float32)
+    assert out.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# pair_reduce: the conservation property that motivates the design
+# ---------------------------------------------------------------------------
+
+def test_antisymmetric_reduction_conserves_exactly(pair_api, snap):
+    """An antisymmetric callback conserves energy to roundoff, by construction.
+
+    Because each unordered pair is visited once and both ends are accumulated
+    from that single visit, ``sum_i m_i du_i/dt == 0`` is an algebraic identity
+    rather than something a user has to verify numerically.
+    """
+    m = np.asarray(snap['mass'], dtype=np.float64)
+    u = np.asarray(snap['u'], dtype=np.float64)
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+    vel = np.asarray(snap['vel'], dtype=np.float64)
+
+    def conduction_like(i, j, dx, r):
+        v_d = np.abs(np.einsum('kl,kl->k', vel[j] - vel[i], dx) / r)
+        g = 1.0 / h[i] ** 4 + 1.0 / h[j] ** 4
+        c = v_d * (u[j] - u[i]) * g
+        return m[j] * c, -m[i] * c
+
+    du_dt = pair_api.pair_reduce(snap, conduction_like, mode='symmetric')
+
+    terms = m * du_dt
+    residual = np.abs(terms.sum()) / np.abs(terms).sum()
+    assert residual < 1e-13, f"energy residual {residual:.3e} is too large"
+
+
+def test_symmetric_reduction_of_positive_definite_term_stays_positive(pair_api,
+                                                                      snap):
+    """The viscous form is positive definite; that must survive the reduction."""
+    m = np.asarray(snap['mass'], dtype=np.float64)
+    vel = np.asarray(snap['vel'], dtype=np.float64)
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+
+    def viscosity_like(i, j, dx, r):
+        mu = np.minimum(np.einsum('kl,kl->k', vel[j] - vel[i], dx) / r, 0.0)
+        c = mu ** 2 * (1.0 / h[i] ** 4 + 1.0 / h[j] ** 4)
+        return m[j] * c, m[i] * c
+
+    assert (pair_api.pair_reduce(snap, viscosity_like) >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# pair_reduce cross-checked against pynbody's existing C++ SPH operations.
+# These use the reference kernel, so they test the pair set and the
+# accumulation rather than the proposed kernel API.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("snap_name", ['snap', 'periodic_snap'])
+def test_pair_reduce_reproduces_density(pair_api, request, snap_name):
+    """rho_i = sum_j m_j W(r, h_i), including the self-contribution."""
+    f = request.getfixturevalue(snap_name)
+    m = np.asarray(f['mass'], dtype=np.float64)
+    h = np.asarray(f['smooth'], dtype=np.float64)
+
+    rho = pair_api.pair_reduce(
+        f, lambda i, j, dx, r: m[j] * _reference_kernel_value(r, h[i]),
+        mode='gather')
+    rho += m * _reference_kernel_value(np.zeros(len(f)), h)
+
+    npt.assert_allclose(rho, np.asarray(f['rho'], dtype=np.float64), rtol=1e-9)
+
+
+def test_pair_reduce_reproduces_sph_divergence(pair_api, snap):
+    """Reproduce KDTree.sph_divergence, which uses the m_j/rho_j gather form.
+
+        div v_i = sum_j (m_j/rho_j) (v_j - v_i) . grad_i W(r, h_i)
+
+    with grad_i W = (dW/dr) * (-dx/r), since dx points from i towards j.
+    """
+    m = np.asarray(snap['mass'], dtype=np.float64)
+    rho = np.asarray(snap['rho'], dtype=np.float64)
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+    vel = np.asarray(snap['vel'], dtype=np.float64)
+
+    def divergence(i, j, dx, r):
+        dv_dot_dx = np.einsum('kl,kl->k', vel[j] - vel[i], dx)
+        return -(m[j] / rho[j]) * dv_dot_dx * _reference_kernel_gradient(r, h[i]) / r
+
+    div = pair_api.pair_reduce(snap, divergence, mode='gather')
+    expected = np.asarray(snap.kdtree.sph_divergence(
+        snap['vel'], pynbody.config['sph']['smooth-particles']))
+
+    npt.assert_allclose(div, expected, rtol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Head-to-head comparison of the two implementations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_matches_reference_pair_set(snap, mode):
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+
+    ri, rj, _, rr = _collect(ReferenceImplementation.pair_blocks(snap,
+                                                                 mode=mode))
+    ki, kj, _, kr = _collect(KDTreeImplementation.pair_blocks(snap, mode=mode))
+
+    ref_ok = _away_from_boundary(ri, rj, rr, h, mode)
+    kd_ok = _away_from_boundary(ki, kj, kr, h, mode)
+
+    npt.assert_array_equal(_pair_keys(ri[ref_ok], rj[ref_ok]),
+                           _pair_keys(ki[kd_ok], kj[kd_ok]))
+    npt.assert_allclose(np.sort(rr[ref_ok]), np.sort(kr[kd_ok]), rtol=1e-12)
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_boundary_disagreements_carry_no_kernel_weight(snap, mode):
+    """Where the two implementations disagree, the kernel is exactly zero.
+
+    This is what makes the r == 2h ambiguity harmless: such pairs enter every
+    SPH sum multiplied by W or dW/dr, both of which vanish at the edge of the
+    kernel, so no physical quantity can depend on which side they fall.
+    """
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+    kernel = snap.kdtree.kernel
+
+    ri, rj, _, rr = _collect(ReferenceImplementation.pair_blocks(snap,
+                                                                 mode=mode))
+    ki, kj, _, kr = _collect(KDTreeImplementation.pair_blocks(snap, mode=mode))
+
+    ref_keys = _pair_keys(ri, rj)
+    kd_keys = _pair_keys(ki, kj)
+    disputed = np.setxor1d(ref_keys, kd_keys)
+
+    if len(disputed) == 0:
+        pytest.skip("the two implementations agree exactly on this snapshot")
+
+    # locate the disputed pairs in whichever set contains them
+    for keys, i, j, r in ((ref_keys, ri, rj, rr), (kd_keys, ki, kj, kr)):
+        order = np.argsort(i.astype(np.int64) * (1 << 32) + j.astype(np.int64))
+        i, j, r = i[order], j[order], r[order]
+        sel = np.isin(keys, disputed)
+        if not sel.any():
+            continue
+
+        threshold = _boundary_threshold(i[sel], j[sel], h, mode)
+        npt.assert_allclose(r[sel], threshold, rtol=1e-12)
+
+        # both the kernel and its gradient vanish there, for either smoothing
+        for h_side in (h[i[sel]], h[j[sel]]):
+            weight = np.abs(kernel.value(r[sel], h_side))
+            grad = np.abs(kernel.gradient(r[sel], h_side))
+            assert (weight[r[sel] >= 2 * h_side] == 0).all()
+            assert (grad[r[sel] >= 2 * h_side] == 0).all()
+
+
+def test_matches_reference_reduction(snap):
+    """A realistic kernel-weighted sum agrees exactly, boundary notwithstanding."""
+    m = np.asarray(snap['mass'], dtype=np.float64)
+    u = np.asarray(snap['u'], dtype=np.float64)
+    h = np.asarray(snap['smooth'], dtype=np.float64)
+    kernel = snap.kdtree.kernel
+
+    def func(i, j, dx, r):
+        # as in any real SPH sum, the kernel gradient multiplies every term,
+        # so pairs sitting on r == 2h contribute exactly zero
+        g = kernel.gradient(r, h[i]) + kernel.gradient(r, h[j])
+        c = (u[j] - u[i]) * g
+        return m[j] * c, -m[i] * c
+
+    npt.assert_allclose(ReferenceImplementation.pair_reduce(snap, func),
+                        KDTreeImplementation.pair_reduce(snap, func),
+                        rtol=1e-11)
+
+
+def test_matches_reference_in_periodic_box(periodic_snap):
+    m = np.asarray(periodic_snap['mass'], dtype=np.float64)
+    h = np.asarray(periodic_snap['smooth'], dtype=np.float64)
+    kernel = periodic_snap.kdtree.kernel
+
+    def func(i, j, dx, r):
+        g = kernel.gradient(r, h[i]) + kernel.gradient(r, h[j])
+        c = (m[j] * g / r)[:, None] * dx
+        return c, -(m[i] / m[j])[:, None] * c
+
+    npt.assert_allclose(
+        ReferenceImplementation.pair_reduce(periodic_snap, func),
+        KDTreeImplementation.pair_reduce(periodic_snap, func), rtol=1e-11)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+def test_unknown_mode_raises(pair_api, snap):
+    with pytest.raises(ValueError):
+        list(pair_api.pair_blocks(snap, mode='not-a-mode'))
+
+
+def test_callback_returning_wrong_length_raises(pair_api, snap):
+    with pytest.raises(ValueError):
+        pair_api.pair_reduce(snap, lambda i, j, dx, r: np.ones(len(i) + 1))
+
+
+def test_callback_returning_inconsistent_shape_raises(pair_api, snap):
+    """The trailing shape is fixed by the first block and may not change."""
+    state = {'n': 0}
+
+    def wobbly(i, j, dx, r):
+        state['n'] += 1
+        return np.ones(len(i)) if state['n'] == 1 else np.ones((len(i), 3))
+
+    with pytest.raises(ValueError):
+        pair_api.pair_reduce(snap, wobbly, blocksize=53)
+
+
+# ---------------------------------------------------------------------------
+# Vectorised kernel access
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kernel_name", ['CubicSplineKernel',
+                                         'WendlandC2Kernel'])
+def test_kernel_value_is_vectorised(kernel_name):
+    """``kernel.value(r, h)`` takes arrays and matches the scalar ``get_value``."""
+    kernel = pynbody.sph.kernels.create_kernel(kernel_name)
+    r = np.linspace(0.0, 3.0, 41)
+    h = 1.3
+
+    npt.assert_allclose(kernel.value(r, h),
+                        [kernel.get_value(ri / h, h) for ri in r], rtol=1e-12)
+
+
+def test_kernel_value_accepts_per_pair_smoothing():
+    """Both arguments vary per pair, so both must broadcast."""
+    kernel = pynbody.sph.kernels.create_kernel('CubicSplineKernel')
+    r = np.linspace(0.1, 2.0, 20)
+    h = np.linspace(0.8, 1.5, 20)
+
+    npt.assert_allclose(kernel.value(r, h),
+                        [kernel.get_value(ri / hi, hi)
+                         for ri, hi in zip(r, h)], rtol=1e-12)
+
+
+@pytest.mark.parametrize("kernel_name", ['CubicSplineKernel',
+                                         'WendlandC2Kernel'])
+def test_kernel_gradient_matches_finite_difference(kernel_name):
+    kernel = pynbody.sph.kernels.create_kernel(kernel_name)
+    h = 1.1
+    r = np.linspace(0.15, 1.85, 30)  # avoid r=0 and the support boundary
+    eps = 1e-6
+
+    numerical = (kernel.value(r + eps, h) - kernel.value(r - eps, h)) / (2 * eps)
+    npt.assert_allclose(kernel.gradient(r, h), numerical, rtol=1e-5, atol=1e-9)
+
+
+@pytest.mark.parametrize("kernel_name", ['CubicSplineKernel',
+                                         'WendlandC2Kernel'])
+def test_kernel_is_normalised(kernel_name):
+    """4 pi int W(r,h) r^2 dr == 1, which pins down the h convention."""
+    kernel = pynbody.sph.kernels.create_kernel(kernel_name)
+    h = 1.7
+    r = np.linspace(0, 2 * h, 200001)
+    integral = 4 * np.pi * _trapezoid(kernel.value(r, h) * r ** 2, r)
+    npt.assert_allclose(integral, 1.0, rtol=1e-5)
+
+
+def test_kernel_vanishes_outside_support():
+    kernel = pynbody.sph.kernels.create_kernel('CubicSplineKernel')
+    h = 0.9
+    r = np.array([2 * h, 2.5 * h, 10 * h])
+    npt.assert_array_equal(kernel.value(r, h), np.zeros(3))
+    npt.assert_array_equal(kernel.gradient(r, h), np.zeros(3))
+
+
+def test_kernel_agrees_with_the_reference_cubic_spline():
+    """Ties the proposed kernel API to the normalisation assumed above."""
+    kernel = pynbody.sph.kernels.create_kernel('CubicSplineKernel')
+    r = np.linspace(0.0, 2.5, 60)
+    h = 1.15
+
+    npt.assert_allclose(kernel.value(r, h), _reference_kernel_value(r, h),
+                        rtol=1e-12)
+    npt.assert_allclose(kernel.gradient(r, h),
+                        _reference_kernel_gradient(r, h), rtol=1e-12)
+
+
+@pytest.mark.parametrize("kernel_name", ['CubicSplineKernel',
+                                         'WendlandC2Kernel'])
+def test_cxx_kernel_gradient_normalisation_matches_its_value(kernel_name):
+    """The C++ kernel's gradient must carry the same normalisation as its value.
+
+    smDivQty and smCurlQty multiply ``Kernel::gradient`` by the same
+    ``1/(pi h^n)`` factor that smDensity applies to ``Kernel::operator()``, so
+    if the two disagree by a constant, every divergence and curl computed with
+    that kernel is silently wrong by that factor.
+
+    This is a regression test: ``WendlandC2Kernel::gradient`` in kernels.hpp
+    once omitted the 21/16 prefactor that its ``operator()`` includes, which
+    made :meth:`~pynbody.kdtree.KDTree.sph_divergence` and
+    :meth:`~pynbody.kdtree.KDTree.sph_curl` wrong by 16/21 for that kernel
+    while the cubic spline was unaffected -- so no existing test caught it.
+
+    Comparing against the python kernel grounds out in code that does not
+    share the bug: :func:`test_kernel_gradient_matches_finite_difference` ties
+    ``gradient`` to ``value``, and :func:`test_kernel_value_is_vectorised` and
+    :func:`test_kernel_is_normalised` tie ``value`` to the long-standing
+    scalar ``get_value`` and to its own normalisation integral.
+    """
+    npart = 3000
+    f = pynbody.new(gas=npart)
+    np.random.seed(5)
+    f['pos'] = np.random.normal(scale=8.0, size=(npart, 3))
+    f['mass'] = np.random.uniform(0.5, 1.5, size=npart)
+    f['vel'] = np.random.normal(size=(npart, 3))
+    f['rho']
+
+    f.kdtree.set_kernel(kernel_name)
+    assert type(f.kdtree.kernel).__name__ == kernel_name
+
+    m = np.asarray(f['mass'], dtype=np.float64)
+    rho = np.asarray(f['rho'], dtype=np.float64)
+    h = np.asarray(f['smooth'], dtype=np.float64)
+    vel = np.asarray(f['vel'], dtype=np.float64)
+    kernel = f.kdtree.kernel
+
+    # grad_i W = (dW/dr) (x_i - x_j)/r = -(dW/dr) dx/r
+    def divergence(i, j, dx, r):
+        dv_dot_dx = np.einsum('kl,kl->k', vel[j] - vel[i], dx)
+        return -(m[j] / rho[j]) * dv_dot_dx * kernel.gradient(r, h[i]) / r
+
+    def curl(i, j, dx, r):
+        cross = np.cross(vel[j] - vel[i], dx)
+        return (m[j] / rho[j] * kernel.gradient(r, h[i]) / r)[:, None] * cross
+
+    nsmooth = pynbody.config['sph']['smooth-particles']
+
+    npt.assert_allclose(f.kdtree.pair_reduce(divergence, mode='gather'),
+                        np.asarray(f.kdtree.sph_divergence(f['vel'], nsmooth)),
+                        rtol=1e-8)
+
+    npt.assert_allclose(f.kdtree.pair_reduce(curl, mode='gather'),
+                        np.asarray(f.kdtree.sph_curl(f['vel'], nsmooth)),
+                        rtol=1e-8)
+
+
+def test_tree_exposes_the_kernel_it_uses(snap):
+    """The user must be able to reach the kernel the C++ code is using."""
+    snap.build_tree()
+
+    snap.kdtree.set_kernel('WendlandC2Kernel')
+    assert isinstance(snap.kdtree.kernel,
+                      pynbody.sph.kernels.WendlandC2Kernel)
+
+    snap.kdtree.set_kernel('CubicSplineKernel')
+    assert isinstance(snap.kdtree.kernel,
+                      pynbody.sph.kernels.CubicSplineKernel)

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -136,7 +136,7 @@ class ReferencePairs:
 
     def pair_reduce(self, func, mode='symmetric', blocksize=1 << 18,
                     dtype=np.float64):
-        out = np.zeros(self._npart, dtype=dtype)
+        out = np.zeros(self._npart, dtype=np.float64)
         trailing = None
 
         for i, j, dx, r in self.pair_blocks(mode, blocksize):
@@ -147,13 +147,14 @@ class ReferencePairs:
 
             if trailing is None:
                 trailing = contrib_i.shape[1:]
-                out = np.zeros((self._npart,) + trailing, dtype=dtype)
+                # accumulate in float64, convert on return; see KDTree.pair_reduce
+                out = np.zeros((self._npart,) + trailing, dtype=np.float64)
 
             _scatter_add(out, i, contrib_i)
             if contrib_j is not None:
                 _scatter_add(out, j, np.asarray(contrib_j))
 
-        return out
+        return out.astype(dtype, copy=False)
 
 
 # Reference cubic spline, matching pynbody's normalisation:
@@ -500,10 +501,46 @@ def test_pair_reduce_invariant_to_blocksize(pairs, snap):
                         rtol=1e-12)
 
 
-def test_pair_reduce_dtype_is_respected(pairs, snap):
+@pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int64])
+def test_pair_reduce_dtype_is_respected(pairs, snap, dtype):
+    """Any reasonable output dtype works, integers included.
+
+    Integer output is the case that constrains the implementation: bincount
+    returns float64, so converting each block as it arrives would truncate the
+    partial sums independently and make the answer depend on blocksize. The
+    accumulation therefore has to stay in double precision until the end.
+    """
     out = pairs(snap).pair_reduce(lambda i, j, dx, r: np.ones(len(i)),
-                                  dtype=np.float32)
-    assert out.dtype == np.float32
+                                  dtype=dtype)
+    assert out.dtype == dtype
+
+    i, _, _, _ = _collect(pairs(snap).pair_blocks())
+    npt.assert_array_equal(out, np.bincount(i, minlength=len(snap)))
+
+
+def test_pair_reduce_integer_output_truncates_once_not_per_block(pairs, snap):
+    """Integer output must truncate the total, not each block separately.
+
+    Converting each block to the output dtype as it arrived would discard a
+    fraction every time, so the shortfall would grow with the number of
+    blocks. Accumulating in double precision and converting once bounds the
+    total truncation by one unit however the pairs happen to be grouped.
+
+    Exact equality between blocksizes is not achievable here and is not
+    claimed: the float64 partial sums themselves differ in the last bit with
+    summation order, which can tip a value either side of an integer.
+    """
+    def fractional(i, j, dx, r):
+        return 0.6 * np.ones(len(i))
+
+    exact = pairs(snap).pair_reduce(fractional, blocksize=1 << 20)
+    assert exact.max() > 5.0, "test needs several units to truncate away"
+
+    # blocksize 3 gives roughly ten blocks per particle, so per-block
+    # truncation would lose several units rather than at most one
+    truncated = pairs(snap).pair_reduce(fractional, blocksize=3,
+                                        dtype=np.int64)
+    assert (np.abs(exact - truncated) < 1.0 + 1e-9).all()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Expressing a pairwise SPH operation — artificial viscosity, artificial conduction, or anything else summing over neighbour pairs — currently means looping over `KDTree.nn()` from python. Measured on 200k particles at 64 neighbours, that costs ~400 ns per neighbour against ~4 ns for the equivalent C++ pass, and it leaves the caller to rebuild the pair list, the periodic wrapping and the kernel normalisation by hand.

These operations can't be assembled from a fixed set of linear SPH sums: the pair function is genuinely nonlinear in the pair, containing terms like `sqrt(2|P_i-P_j|/(rho_i+rho_j))` and `min(mu_ij, 0)`. So the primitive has to accept user code, and the only real design question is granularity — per-pair would mean ~1e8 python calls, per-particle leaves numpy overhead dominating on length-32 arrays. This works on **blocks of pairs**, defaulting to 2^18 at a time.

## What's added

**`KDTree.pair_blocks(mode, blocksize)`** yields `(i, j, dx, r)` as flat read-only numpy arrays, with `dx` already periodic-wrapped. Note `i` and `j` are index *arrays*, one entry per pair, so per-particle quantities are reached by fancy indexing.

- `'gather'`: ordered pairs with `r <= 2 h_i` — the neighbour set behind the density estimate.
- `'symmetric'`: each unordered pair exactly once, `r <= max(2 h_i, 2 h_j)`, canonicalised to `i < j` — what operators involving *both* smoothing lengths require.

**`KDTree.pair_reduce(func, ...)`** accumulates a callback over those pairs. The callback returns `contrib_i` or `(contrib_i, contrib_j)`; pynbody does the `bincount` scatter-add.

**Vectorised `KernelBase.value(r, h)` / `.gradient(r, h)`, and `KDTree.kernel`**, so a callback can evaluate the same kernel the C++ is using rather than re-deriving its normalisation.

Artificial conduction then reads:

```python
m, rho, p, u, h = (f.g[k] for k in ('mass','rho','p','u','smooth'))
W = f.g.kdtree.kernel

def conduction(i, j, dx, r):
    mu  = np.einsum('kl,kl->k', vel[j] - vel[i], dx) / r
    v_d = 0.5 * (np.abs(mu) + np.sqrt(2*np.abs(p[i]-p[j]) / (rho[i]+rho[j])))
    g   = -(W.gradient(r, h[i])/rho[i] + W.gradient(r, h[j])/rho[j])
    c   = v_d * (u[j] - u[i]) * g
    return m[j] * c, -m[i] * c

du_dt = f.g.kdtree.pair_reduce(conduction)
```

Because each pair is visited once and both ends are accumulated from that single visit, an antisymmetric callback conserves energy **as an algebraic identity** rather than approximately — measured residual ~6e-19.

## Implementation notes

**No `hMax` needed on `KDNode`.** Symmetric mode falls out of a purely local test: while walking particle `a` and finding neighbour `b`, emit iff `a < b` or `r > 2 h_b`. In the second case `b`'s own walk cannot reach `a`, so nobody else emits it; in the first, the lower index breaks the tie. No global de-duplication, no communication between walks, and the node struct (mirrored in the python `KDNode` dtype and in `serialize`/`deserialize`) is untouched.

**Membership is tested on `r`, not `r^2`.** Since `h` is defined as half the distance to the nth neighbour, `r == 2h` is hit *exactly* for one neighbour of every particle — measured at exactly 400 boundary pairs on 400 particles. Deciding on `r^2` strands those pairs on the wrong side by an ulp. The boundary is inclusive, matching `smBallGather`, so a gather over `nSmooth` neighbours really does return `nSmooth` of them.

## Drive-by bug fix

`WendlandC2Kernel::gradient` in `kernels.hpp` omitted the `21/16` prefactor that its `operator()` includes. `smDivQty`/`smCurlQty` apply the same `1/(pi h^n)` factor to both, so **`sph_divergence` and `sph_curl` were wrong by 16/21 ≈ 0.762 whenever the Wendland kernel was selected**; the cubic spline was unaffected, which is why no existing test caught it. Measured ratio against an independently-verified python gradient was exactly 1.312500 before the fix, 1.000000 after.

This changes numerical output for anyone using `sph_divergence`/`sph_curl` with Wendland.

## Testing

`tests/user_sph_operations_test.py`, 86 tests. Every assertion runs against **both** the C++ path and a brute-force O(N²) reference implementation defined in the file, which serves as the specification. Coverage includes the callback contract, blocksize invariance and determinism, both pair sets, periodic minimum-image displacement, accumulation semantics (including the `bincount` vs `out[i] +=` trap), the conservation and positive-definiteness invariants, and cross-checks reproducing pynbody's own `rho`, `sph_divergence` and `sph_curl`.

Where the two implementations disagree on the `r == 2h` boundary — irreducibly, since two independent float evaluations of the same distance differ in the last bit — the tests assert the disputed pairs carry exactly zero kernel weight, so nothing physical can depend on them.

The new regression test was verified to fail against a deliberately re-broken build.

Version bumped to 2.6.0, with `.. versionadded:: 2.6.0` on each new public entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGC9utrm2V3Tbu6o6GwgK5