### PR TITLE
Fix SPH smoothing on large and periodic snapshots, and add a volume/mass weighting option

### DIFF
--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -699,7 +699,7 @@ class KDTree:
 
         .. math::
 
-          r_i = \sum_{j=0}^{N_{smooth}}\left( \frac{m_j}{\rho_j} q_i W(|x_i - x_j|, s_i) \right)
+          r_i = \sum_{j=0}^{N_{smooth}}\left( \frac{m_j}{\rho_j} q_j W(|x_i - x_j|, s_i) \right)
 
         where r is the result of the smoothing, m is the mass array, rho is the density array, q is the input array,
         s_i is the smoothing length, and W is the kernel function.
@@ -715,20 +715,27 @@ class KDTree:
             Number of neighbours to use when smoothing.
 
         weighting : str
-            Which average over the kernel to compute. The two agree where the
-            density is nearly constant across a kernel, and differ where it is
-            not.
+            Which average over the kernel to compute.
 
-            * ``'volume'`` (default): the volume-weighted average,
-              :math:`\int f W \, dV`, taking each neighbour's own volume
-              :math:`m_j/\rho_j`. This is the direct discretisation of the
-              smoothing integral.
-            * ``'mass'``: the mass-weighted average,
-              :math:`\int f \rho W \, dV / \int \rho W \, dV`, taking
-              :math:`m_j/\rho_i`. Since :math:`\rho_i` is itself
-              :math:`\sum_j m_j W_{ij}`, the weights sum to one exactly, so
-              this reproduces a constant field exactly and can never fall
-              outside the range of its input.
+            Writing :math:`i` for the particle whose value is being computed
+            and :math:`j` for each of its neighbours, both options evaluate
+            :math:`\sum_j V_j q_j W(|x_i - x_j|, s_i)`, differing only in the
+            volume :math:`V_j` given to each neighbour:
+
+            * ``'volume'`` (default): :math:`V_j = m_j/\rho_j`, each
+              neighbour's own volume. The sum is then the direct
+              discretisation of the smoothing integral, giving the
+              volume-weighted average :math:`\int q W \, dV`.
+            * ``'mass'``: :math:`V_j = m_j/\rho_i`, using the density at the
+              particle being evaluated, which gives the mass-weighted average
+              :math:`\int q \rho W \, dV / \int \rho W \, dV`. Since
+              :math:`\rho_i` is itself :math:`\sum_j m_j W(|x_i - x_j|, s_i)`,
+              the weights here sum to one exactly, so this reproduces a
+              constant field exactly and can never return a value outside the
+              range of its input.
+
+            The two agree where the density is nearly constant across a
+            kernel, and differ where it is not.
 
             For a divergence, ``'mass'`` is the form that satisfies the
             continuity equation exactly, and so is the one appearing in the
@@ -767,13 +774,13 @@ class KDTree:
 
         .. math::
 
-          r_i = \sum_{j=0}^{N_{smooth}}\left( \frac{m_j}{\rho_j} q_i W(|x_i - x_j|, s_i) \right)
+          r_i = \sum_{j=0}^{N_{smooth}}\left( \frac{m_j}{\rho_j} q_j W(|x_i - x_j|, s_i) \right)
 
         Then the squared root of the SPH smoothed variance:
 
         .. math::
 
-          d_i = \left\{ \sum_{j=0}^{N_{smooth}} \frac{m_j}{\rho_j} (q_i - r_i)^2 W(|x_i - x_j|, s_i) \right\}^{1/2}
+          d_i = \left\{ \sum_{j=0}^{N_{smooth}} \frac{m_j}{\rho_j} (q_j - r_i)^2 W(|x_i - x_j|, s_i) \right\}^{1/2}
 
         where d_i is the calculated dispersion, m is the mass array, rho is the density array, q is the input array,
         s_i is the smoothing length, and W is the kernel function.

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -1,6 +1,13 @@
 """
 Efficient 3D KDTree implementation for fast geometrical calculations such as neighbour lists and smoothing lengths.
 
+As well as the smoothing operations built on it -- :meth:`~KDTree.sph_mean`,
+:meth:`~KDTree.sph_dispersion`, :meth:`~KDTree.sph_divergence` and
+:meth:`~KDTree.sph_curl` -- the tree can hand neighbour pairs back to python,
+so that pairwise SPH operations pynbody does not itself provide can be written
+without a python-level loop over particles. See :meth:`~KDTree.pair_reduce`
+and :meth:`~KDTree.pair_blocks`.
+
 """
 import logging
 import time
@@ -36,12 +43,12 @@ def _scatter_add(out, index, contrib):
     contribution per repeated index.
 
     Which of the two viable methods is faster depends strongly on how the
-    length of the output compares with the length of the block.
-    ``np.bincount`` allocates and fills a whole length-N temporary on every
-    call, so it wins only while N is comparable to the block size; once the
-    output is much the longer of the two -- which for pair sums means any
-    large snapshot -- that temporary dominates everything else, and the
-    in-place scatter of ``np.add.at`` is faster by two orders of magnitude.
+    length of ``out`` compares with the length of the block. ``np.bincount``
+    allocates and fills a temporary as long as ``out`` on every call, so it
+    wins only while the two lengths are comparable; once ``out`` is much the
+    longer -- which for pair sums means any large snapshot -- that temporary
+    dominates everything else, and the in-place scatter of ``np.add.at`` is
+    faster by two orders of magnitude.
     """
     npart = out.shape[0]
 
@@ -71,7 +78,7 @@ class KDTree:
     KDTree can also be used to accelerate geometrical queries on a snapshot, e.g.:
 
     >>> f = pynbody.load('my_snapshot')
-    >>> f.build_kdtree()
+    >>> f.build_tree()
     >>> f[pynbody.filt.Sphere('10 kpc')]
 
     See :ref:`performance of filters <filters_tutorial_performance_implications>` for more information.
@@ -408,10 +415,15 @@ class KDTree:
 
         Parameters
         --------
-        mode : str (see `kdtree.smooth_operation_to_id`)
-            Specify operation to perform (compute smoothing lengths, density, SPH mean, or SPH dispersion).
+        mode : str
+            Operation to perform; see :meth:`smooth_operation_to_id` for the
+            accepted names, which cover smoothing lengths, density, SPH mean,
+            dispersion, divergence and curl.
         nn : int
-            Number of neighbours to be considered when smoothing.
+            Number of neighbours the smoothing lengths correspond to. Note
+            this does not itself select the neighbours: except when computing
+            smoothing lengths, those are whichever particles lie within the
+            kernel. See :meth:`sph_mean`.
         weighting : str
             Whether to take the volume-weighted or the mass-weighted average
             over the kernel; see :meth:`sph_mean` for what the two mean and
@@ -477,9 +489,15 @@ class KDTree:
         per pair, so per-particle quantities are used via fancy indexing, e.g.
         ``rho[i]`` is the density of the first particle of each pair.
 
-        Smoothing lengths are taken from the ``smooth`` array currently
-        associated with the tree, so accessing ``f['smooth']`` (or ``f['rho']``)
-        before calling this is what fixes the pair set.
+        The pair set is fixed by the smoothing lengths associated with the
+        tree. Where pynbody derives those itself, accessing ``f['smooth']``
+        associates them automatically. Where they instead come from the
+        snapshot file, they must be associated explicitly, since reading them
+        does not involve the tree at all::
+
+            f.build_tree()
+            f.kdtree.set_array_ref('smooth',
+                                   f['smooth'].in_units(f['pos'].units))
 
         Parameters
         ----------
@@ -491,14 +509,15 @@ class KDTree:
               so that ``i < j``. This is what SPH operators involving both
               smoothing lengths require, such as artificial viscosity or
               conduction.
-            * ``'gather'``: every ordered pair with :math:`r \leq 2 h_i`. Both
-              ``(a, b)`` and ``(b, a)`` appear when each lies inside the
-              other's kernel. This is the neighbour set used by the density
-              estimate and by :meth:`sph_mean`.
+            * ``'gather'``: every ordered pair with :math:`r \leq 2 h_i`,
+              where :math:`h` is the smoothing length. A pair appears in both
+              orderings when each particle lies inside the other's kernel.
+              This is the neighbour set used by the density estimate and by
+              :meth:`sph_mean`.
 
             The boundary is inclusive, matching the neighbour search used by
-            the density estimate, so that a gather over ``nSmooth`` neighbours
-            really does yield ``nSmooth`` of them. This is worth noting because
+            the density estimate, so that a gather over ``n`` neighbours really
+            does yield ``n`` of them. This is worth noting because
             :math:`r = 2h` is not a rare edge case: smoothing lengths are half
             the distance to the nth neighbour, so exactly one neighbour of
             every particle sits on the boundary. Nothing physical depends on
@@ -537,9 +556,12 @@ class KDTree:
             raise ValueError("blocksize must be at least 1")
 
         if self.get_array_ref('smooth') is None:
-            raise ValueError("No smoothing lengths are associated with this "
-                             "KDTree; access the 'smooth' array of your "
-                             "snapshot before generating pairs")
+            raise ValueError(
+                "No smoothing lengths are associated with this KDTree. If "
+                "pynbody derives them, access the 'smooth' array of your "
+                "snapshot first; if they come from the snapshot file, "
+                "associate them with set_array_ref('smooth', ...), converted "
+                "to the units of the 'pos' array.")
 
         # validation above happens eagerly, rather than on first iteration
         return self._pair_blocks_generator(self._pair_modes[mode], blocksize)
@@ -572,14 +594,15 @@ class KDTree:
         while ``func`` is called once per block of pairs and works on flat
         numpy arrays.
 
-        The result is an array ``out`` with
+        For every pair, ``func`` returns a contribution :math:`c_i` for the
+        first particle and :math:`c_j` for the second. Each particle's result
+        is the sum of the contributions from every pair it takes part in, at
+        whichever end it appears:
 
         .. math::
 
-            \mathrm{out}[a] = \sum_{\mathrm{pairs}\ (a, j)} c_i
-                            + \sum_{\mathrm{pairs}\ (i, a)} c_j
-
-        where :math:`(c_i, c_j)` is what ``func`` returned for each pair.
+            \mathrm{out}[k] = \sum_{\mathrm{pairs}\ (k,\, j)} c_i
+                             \;+ \sum_{\mathrm{pairs}\ (i,\, k)} c_j
 
         Parameters
         ----------
@@ -624,6 +647,10 @@ class KDTree:
 
         Notes
         -----
+        The neighbour search releases the GIL, but a python callback cannot,
+        so ``func`` runs on a single thread. Writing it against flat arrays,
+        rather than one particle at a time, is what keeps that from mattering.
+
         In ``'symmetric'`` mode each pair is visited exactly once and both ends
         are accumulated from that single visit. Returning an antisymmetric
         contribution ``(m[j] * c, -m[i] * c)`` therefore conserves
@@ -712,7 +739,12 @@ class KDTree:
             Quantity to smooth (compute SPH interpolation at particles position).
 
         nsmooth:
-            Number of neighbours to use when smoothing.
+            Number of neighbours the smoothing lengths correspond to. Note
+            that this does not itself select the neighbours: those are
+            whichever particles lie within the kernel, as set by the smoothing
+            lengths. It sizes the internal neighbour buffer, and sets the
+            neighbour count that kernels needing one (such as Wendland C2) are
+            normalised for.
 
         weighting : str
             Which average over the kernel to compute.
@@ -793,7 +825,12 @@ class KDTree:
             Quantity to compute dispersion of.
 
         nsmooth: int
-            Number of neighbours to use when smoothing.
+            Number of neighbours the smoothing lengths correspond to. Note
+            that this does not itself select the neighbours: those are
+            whichever particles lie within the kernel, as set by the smoothing
+            lengths. It sizes the internal neighbour buffer, and sets the
+            neighbour count that kernels needing one (such as Wendland C2) are
+            normalised for.
 
         weighting : str
             Whether to take the volume-weighted or the mass-weighted average
@@ -861,7 +898,12 @@ class KDTree:
             Quantity to compute curl of.
 
         nsmooth : int
-            Number of neighbours to use when smoothing.
+            Number of neighbours the smoothing lengths correspond to. Note
+            that this does not itself select the neighbours: those are
+            whichever particles lie within the kernel, as set by the smoothing
+            lengths. It sizes the internal neighbour buffer, and sets the
+            neighbour count that kernels needing one (such as Wendland C2) are
+            normalised for.
 
         weighting : str
             Whether to take the volume-weighted or the mass-weighted average
@@ -888,7 +930,12 @@ class KDTree:
             Quantity to compute the divergence of.
 
         nsmooth : int
-            Number of neighbours to use when smoothing.
+            Number of neighbours the smoothing lengths correspond to. Note
+            that this does not itself select the neighbours: those are
+            whichever particles lie within the kernel, as set by the smoothing
+            lengths. It sizes the internal neighbour buffer, and sets the
+            neighbour count that kernels needing one (such as Wendland C2) are
+            normalised for.
 
         weighting : str
             Whether to take the volume-weighted or the mass-weighted average

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -32,16 +32,28 @@ KDNode = np.dtype([
 def _scatter_add(out, index, contrib):
     """Perform ``out[index] += contrib``, summing over repeated indices.
 
-    ``np.add.at`` would do this, but is very slow; ``out[index] += contrib``
-    is wrong, since it keeps only one contribution per repeated index.
+    Note ``out[index] += contrib`` will not do, since it keeps only one
+    contribution per repeated index.
+
+    Which of the two viable methods is faster depends strongly on how the
+    length of the output compares with the length of the block.
+    ``np.bincount`` allocates and fills a whole length-N temporary on every
+    call, so it wins only while N is comparable to the block size; once the
+    output is much the longer of the two -- which for pair sums means any
+    large snapshot -- that temporary dominates everything else, and the
+    in-place scatter of ``np.add.at`` is faster by two orders of magnitude.
     """
     npart = out.shape[0]
-    if out.ndim == 1:
-        out += np.bincount(index, weights=contrib, minlength=npart)
+
+    if npart <= 4 * len(index):
+        if out.ndim == 1:
+            out += np.bincount(index, weights=contrib, minlength=npart)
+        else:
+            for k in range(out.shape[1]):
+                out[:, k] += np.bincount(index, weights=contrib[..., k],
+                                         minlength=npart)
     else:
-        for k in range(out.shape[1]):
-            out[:, k] += np.bincount(index, weights=contrib[..., k],
-                                     minlength=npart)
+        np.add.at(out, index, contrib)
 
 
 class KDTree:

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -109,16 +109,16 @@ class KDTree:
     _pair_modes = {'gather': PAIR_MODE_GATHER,
                    'symmetric': PAIR_MODE_SYMMETRIC}
 
-    _density_weightings = {'neighbour': 0, 'self': 1}
+    _weightings = {'volume': 0, 'mass': 1}
 
     @classmethod
-    def _density_weighting_to_flag(cls, density_weighting):
+    def _weighting_to_flag(cls, weighting):
         try:
-            return cls._density_weightings[density_weighting]
+            return cls._weightings[weighting]
         except KeyError:
             raise ValueError(
-                "Unknown density_weighting %r; should be one of %s"
-                % (density_weighting, sorted(cls._density_weightings))) from None
+                "Unknown weighting %r; should be one of %s"
+                % (weighting, sorted(cls._weightings))) from None
 
     def __init__(self, pos, mass, leafsize=32, boxsize=None, num_threads=None, shared_mem=False):
         """Create a KDTree
@@ -403,8 +403,8 @@ class KDTree:
 
 
 
-    def populate(self, mode, nn, density_weighting='neighbour'):
-        """Create the KDTree and perform the operation specified by `mode`.
+    def populate(self, mode, nn, weighting='volume'):
+        r"""Create the KDTree and perform the operation specified by `mode`.
 
         Parameters
         --------
@@ -412,10 +412,10 @@ class KDTree:
             Specify operation to perform (compute smoothing lengths, density, SPH mean, or SPH dispersion).
         nn : int
             Number of neighbours to be considered when smoothing.
-        density_weighting : str
-            Which density to divide each neighbour's contribution by; see
-            :meth:`sph_mean`. Ignored when computing smoothing lengths or
-            densities, which do not use one.
+        weighting : str
+            Whether to take the volume-weighted or the mass-weighted average
+            over the kernel; see :meth:`sph_mean` for what the two mean and
+            when they differ.
 
             .. versionadded:: 2.6.0
         """
@@ -424,7 +424,7 @@ class KDTree:
         if nn is None:
             nn = 64
 
-        self_weighting = self._density_weighting_to_flag(density_weighting)
+        self_weighting = self._weighting_to_flag(weighting)
 
         smx = kdmain.nn_start(self.kdtree, int(nn), self.boxsize)
 
@@ -692,7 +692,7 @@ class KDTree:
 
         return out.astype(dtype, copy=False)
 
-    def sph_mean(self, array, nsmooth=64, density_weighting='neighbour'):
+    def sph_mean(self, array, nsmooth=64, weighting='volume'):
         r"""Calculate the SPH mean of a simulation array.
 
         Given a kernel W, this calculates
@@ -714,20 +714,26 @@ class KDTree:
         nsmooth:
             Number of neighbours to use when smoothing.
 
-        density_weighting : str
-            Which density divides each neighbour's contribution.
+        weighting : str
+            Which average over the kernel to compute. The two agree where the
+            density is nearly constant across a kernel, and differ where it is
+            not.
 
-            * ``'neighbour'`` (default): weight by the neighbour's own volume,
-              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
-              consistent with the other smoothing operations here.
-            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
-              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
-              reproduces a constant field exactly, and it is what SPH
-              simulation codes use internally. Choose it to reproduce a
-              quantity as the code that wrote the snapshot computed it.
+            * ``'volume'`` (default): the volume-weighted average,
+              :math:`\int f W \, dV`, taking each neighbour's own volume
+              :math:`m_j/\rho_j`. This is the direct discretisation of the
+              smoothing integral.
+            * ``'mass'``: the mass-weighted average,
+              :math:`\int f \rho W \, dV / \int \rho W \, dV`, taking
+              :math:`m_j/\rho_i`. Since :math:`\rho_i` is itself
+              :math:`\sum_j m_j W_{ij}`, the weights sum to one exactly, so
+              this reproduces a constant field exactly and can never fall
+              outside the range of its input.
 
-            The two agree wherever the density varies little across a kernel,
-            and differ substantially where it does not.
+            For a divergence, ``'mass'`` is the form that satisfies the
+            continuity equation exactly, and so is the one appearing in the
+            SPH equations of motion. Use it to reproduce a quantity as the
+            simulation code itself computed it.
 
             .. versionadded:: 2.6.0
 
@@ -747,14 +753,14 @@ class KDTree:
 
         logger.info("Smoothing array with %d nearest neighbours" % nsmooth)
         start = time.time()
-        self.populate("qty_mean", nsmooth, density_weighting)
+        self.populate("qty_mean", nsmooth, weighting)
         end = time.time()
 
         logger.info("SPH smooth done in %5.3g s" % (end - start))
 
         return output
 
-    def sph_dispersion(self, array, nsmooth=64, density_weighting='neighbour'):
+    def sph_dispersion(self, array, nsmooth=64, weighting='volume'):
         r"""Calculate the SPH dispersion of a simulation array.
 
         Given a kernel W, this routine computes the smoothed quantity:
@@ -782,20 +788,10 @@ class KDTree:
         nsmooth: int
             Number of neighbours to use when smoothing.
 
-        density_weighting : str
-            Which density divides each neighbour's contribution.
-
-            * ``'neighbour'`` (default): weight by the neighbour's own volume,
-              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
-              consistent with the other smoothing operations here.
-            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
-              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
-              reproduces a constant field exactly, and it is what SPH
-              simulation codes use internally. Choose it to reproduce a
-              quantity as the code that wrote the snapshot computed it.
-
-            The two agree wherever the density varies little across a kernel,
-            and differ substantially where it does not.
+        weighting : str
+            Whether to take the volume-weighted or the mass-weighted average
+            over the kernel; see :meth:`sph_mean` for what the two mean and
+            when they differ.
 
             .. versionadded:: 2.6.0
 
@@ -814,7 +810,7 @@ class KDTree:
 
         logger.info("Getting dispersion of array with %d nearest neighbours" % nsmooth)
         start = time.time()
-        self.populate("qty_disp", nsmooth, density_weighting)
+        self.populate("qty_disp", nsmooth, weighting)
         end = time.time()
 
         logger.info("SPH dispersion done in %5.3g s" % (end - start))
@@ -822,7 +818,7 @@ class KDTree:
         return output
 
     def _sph_differential_operator(self, array, op, nsmooth=64,
-                                   density_weighting='neighbour'):
+                                   weighting='volume'):
         if op == "div":
             op_label = "divergence"
             output = np.empty(len(array), dtype=array.dtype)
@@ -841,15 +837,15 @@ class KDTree:
 
         logger.info("Getting %s of array with %d nearest neighbours" % (op_label, nsmooth))
         start = time.time()
-        self.populate("qty_%s" % op, nsmooth, density_weighting)
+        self.populate("qty_%s" % op, nsmooth, weighting)
         end = time.time()
 
         logger.info(f"SPH {op_label} done in {end - start:5.3g} s")
 
         return output
 
-    def sph_curl(self, array, nsmooth=64, density_weighting='neighbour'):
-        """Calculate the curl of a given array using SPH smoothing.
+    def sph_curl(self, array, nsmooth=64, weighting='volume'):
+        r"""Calculate the curl of a given array using SPH smoothing.
 
         Parameters
         ----------
@@ -860,20 +856,10 @@ class KDTree:
         nsmooth : int
             Number of neighbours to use when smoothing.
 
-        density_weighting : str
-            Which density divides each neighbour's contribution.
-
-            * ``'neighbour'`` (default): weight by the neighbour's own volume,
-              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
-              consistent with the other smoothing operations here.
-            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
-              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
-              reproduces a constant field exactly, and it is what SPH
-              simulation codes use internally. Choose it to reproduce a
-              quantity as the code that wrote the snapshot computed it.
-
-            The two agree wherever the density varies little across a kernel,
-            and differ substantially where it does not.
+        weighting : str
+            Whether to take the volume-weighted or the mass-weighted average
+            over the kernel; see :meth:`sph_mean` for what the two mean and
+            when they differ.
 
             .. versionadded:: 2.6.0
 
@@ -883,10 +869,10 @@ class KDTree:
             The curl of the input array.
         """
         return self._sph_differential_operator(array, "curl", nsmooth,
-                                              density_weighting)
+                                              weighting)
 
-    def sph_divergence(self, array, nsmooth=64, density_weighting='neighbour'):
-        """Calculate the divergence of a given array using SPH smoothing.
+    def sph_divergence(self, array, nsmooth=64, weighting='volume'):
+        r"""Calculate the divergence of a given array using SPH smoothing.
 
         Parameters
         ----------
@@ -897,20 +883,10 @@ class KDTree:
         nsmooth : int
             Number of neighbours to use when smoothing.
 
-        density_weighting : str
-            Which density divides each neighbour's contribution.
-
-            * ``'neighbour'`` (default): weight by the neighbour's own volume,
-              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
-              consistent with the other smoothing operations here.
-            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
-              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
-              reproduces a constant field exactly, and it is what SPH
-              simulation codes use internally. Choose it to reproduce a
-              quantity as the code that wrote the snapshot computed it.
-
-            The two agree wherever the density varies little across a kernel,
-            and differ substantially where it does not.
+        weighting : str
+            Whether to take the volume-weighted or the mass-weighted average
+            over the kernel; see :meth:`sph_mean` for what the two mean and
+            when they differ.
 
             .. versionadded:: 2.6.0
 
@@ -920,7 +896,7 @@ class KDTree:
             The divergence of the input array.
         """
         return self._sph_differential_operator(array, "div", nsmooth,
-                                              density_weighting)
+                                              weighting)
 
     def __del__(self):
         if hasattr(self, "kdtree"):

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -109,6 +109,17 @@ class KDTree:
     _pair_modes = {'gather': PAIR_MODE_GATHER,
                    'symmetric': PAIR_MODE_SYMMETRIC}
 
+    _density_weightings = {'neighbour': 0, 'self': 1}
+
+    @classmethod
+    def _density_weighting_to_flag(cls, density_weighting):
+        try:
+            return cls._density_weightings[density_weighting]
+        except KeyError:
+            raise ValueError(
+                "Unknown density_weighting %r; should be one of %s"
+                % (density_weighting, sorted(cls._density_weightings))) from None
+
     def __init__(self, pos, mass, leafsize=32, boxsize=None, num_threads=None, shared_mem=False):
         """Create a KDTree
 
@@ -392,7 +403,7 @@ class KDTree:
 
 
 
-    def populate(self, mode, nn):
+    def populate(self, mode, nn, density_weighting='neighbour'):
         """Create the KDTree and perform the operation specified by `mode`.
 
         Parameters
@@ -401,11 +412,19 @@ class KDTree:
             Specify operation to perform (compute smoothing lengths, density, SPH mean, or SPH dispersion).
         nn : int
             Number of neighbours to be considered when smoothing.
+        density_weighting : str
+            Which density to divide each neighbour's contribution by; see
+            :meth:`sph_mean`. Ignored when computing smoothing lengths or
+            densities, which do not use one.
+
+            .. versionadded:: 2.6.0
         """
 
 
         if nn is None:
             nn = 64
+
+        self_weighting = self._density_weighting_to_flag(density_weighting)
 
         smx = kdmain.nn_start(self.kdtree, int(nn), self.boxsize)
 
@@ -417,7 +436,8 @@ class KDTree:
 
 
             if self.num_threads == 1:
-                kdmain.populate(self.kdtree, smx, propid, 0, self._kernel_id)
+                kdmain.populate(self.kdtree, smx, propid, 0, self._kernel_id,
+                                self_weighting)
             else:
                 util.thread_map(
                     kdmain.populate,
@@ -425,7 +445,8 @@ class KDTree:
                     [smx] * self.num_threads,
                     [propid] * self.num_threads,
                     list(range(0, self.num_threads)),
-                    [self._kernel_id] * self.num_threads
+                    [self._kernel_id] * self.num_threads,
+                    [self_weighting] * self.num_threads
                 )
         finally:
             # Free C-structures memory
@@ -671,7 +692,7 @@ class KDTree:
 
         return out.astype(dtype, copy=False)
 
-    def sph_mean(self, array, nsmooth=64):
+    def sph_mean(self, array, nsmooth=64, density_weighting='neighbour'):
         r"""Calculate the SPH mean of a simulation array.
 
         Given a kernel W, this calculates
@@ -693,6 +714,23 @@ class KDTree:
         nsmooth:
             Number of neighbours to use when smoothing.
 
+        density_weighting : str
+            Which density divides each neighbour's contribution.
+
+            * ``'neighbour'`` (default): weight by the neighbour's own volume,
+              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
+              consistent with the other smoothing operations here.
+            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
+              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
+              reproduces a constant field exactly, and it is what SPH
+              simulation codes use internally. Choose it to reproduce a
+              quantity as the code that wrote the snapshot computed it.
+
+            The two agree wherever the density varies little across a kernel,
+            and differ substantially where it does not.
+
+            .. versionadded:: 2.6.0
+
         Returns
         -------
         output : pynbody.array.SimArray
@@ -709,14 +747,14 @@ class KDTree:
 
         logger.info("Smoothing array with %d nearest neighbours" % nsmooth)
         start = time.time()
-        self.populate("qty_mean", nsmooth)
+        self.populate("qty_mean", nsmooth, density_weighting)
         end = time.time()
 
         logger.info("SPH smooth done in %5.3g s" % (end - start))
 
         return output
 
-    def sph_dispersion(self, array, nsmooth=64):
+    def sph_dispersion(self, array, nsmooth=64, density_weighting='neighbour'):
         r"""Calculate the SPH dispersion of a simulation array.
 
         Given a kernel W, this routine computes the smoothed quantity:
@@ -744,6 +782,23 @@ class KDTree:
         nsmooth: int
             Number of neighbours to use when smoothing.
 
+        density_weighting : str
+            Which density divides each neighbour's contribution.
+
+            * ``'neighbour'`` (default): weight by the neighbour's own volume,
+              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
+              consistent with the other smoothing operations here.
+            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
+              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
+              reproduces a constant field exactly, and it is what SPH
+              simulation codes use internally. Choose it to reproduce a
+              quantity as the code that wrote the snapshot computed it.
+
+            The two agree wherever the density varies little across a kernel,
+            and differ substantially where it does not.
+
+            .. versionadded:: 2.6.0
+
         Returns
         -------
         output : pynbody.array.SimArray
@@ -759,14 +814,15 @@ class KDTree:
 
         logger.info("Getting dispersion of array with %d nearest neighbours" % nsmooth)
         start = time.time()
-        self.populate("qty_disp", nsmooth)
+        self.populate("qty_disp", nsmooth, density_weighting)
         end = time.time()
 
         logger.info("SPH dispersion done in %5.3g s" % (end - start))
 
         return output
 
-    def _sph_differential_operator(self, array, op, nsmooth=64):
+    def _sph_differential_operator(self, array, op, nsmooth=64,
+                                   density_weighting='neighbour'):
         if op == "div":
             op_label = "divergence"
             output = np.empty(len(array), dtype=array.dtype)
@@ -785,14 +841,14 @@ class KDTree:
 
         logger.info("Getting %s of array with %d nearest neighbours" % (op_label, nsmooth))
         start = time.time()
-        self.populate("qty_%s" % op, nsmooth)
+        self.populate("qty_%s" % op, nsmooth, density_weighting)
         end = time.time()
 
         logger.info(f"SPH {op_label} done in {end - start:5.3g} s")
 
         return output
 
-    def sph_curl(self, array, nsmooth=64):
+    def sph_curl(self, array, nsmooth=64, density_weighting='neighbour'):
         """Calculate the curl of a given array using SPH smoothing.
 
         Parameters
@@ -804,14 +860,32 @@ class KDTree:
         nsmooth : int
             Number of neighbours to use when smoothing.
 
+        density_weighting : str
+            Which density divides each neighbour's contribution.
+
+            * ``'neighbour'`` (default): weight by the neighbour's own volume,
+              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
+              consistent with the other smoothing operations here.
+            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
+              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
+              reproduces a constant field exactly, and it is what SPH
+              simulation codes use internally. Choose it to reproduce a
+              quantity as the code that wrote the snapshot computed it.
+
+            The two agree wherever the density varies little across a kernel,
+            and differ substantially where it does not.
+
+            .. versionadded:: 2.6.0
+
         Returns
         -------
         pynbody.array.SimArray:
             The curl of the input array.
         """
-        return self._sph_differential_operator(array, "curl", nsmooth)
+        return self._sph_differential_operator(array, "curl", nsmooth,
+                                              density_weighting)
 
-    def sph_divergence(self, array, nsmooth=64):
+    def sph_divergence(self, array, nsmooth=64, density_weighting='neighbour'):
         """Calculate the divergence of a given array using SPH smoothing.
 
         Parameters
@@ -823,12 +897,30 @@ class KDTree:
         nsmooth : int
             Number of neighbours to use when smoothing.
 
+        density_weighting : str
+            Which density divides each neighbour's contribution.
+
+            * ``'neighbour'`` (default): weight by the neighbour's own volume,
+              :math:`m_j/\\rho_j`. This is the usual SPH interpolant, and is
+              consistent with the other smoothing operations here.
+            * ``'self'``: weight by :math:`m_j/\\rho_i`. Because
+              :math:`\\rho_i` is itself :math:`\\sum_j m_j W_{ij}`, this form
+              reproduces a constant field exactly, and it is what SPH
+              simulation codes use internally. Choose it to reproduce a
+              quantity as the code that wrote the snapshot computed it.
+
+            The two agree wherever the density varies little across a kernel,
+            and differ substantially where it does not.
+
+            .. versionadded:: 2.6.0
+
         Returns
         -------
         pynbody.array.SimArray:
             The curl of the input array.
         """
-        return self._sph_differential_operator(array, "div", nsmooth)
+        return self._sph_differential_operator(array, "div", nsmooth,
+                                              density_weighting)
 
     def __del__(self):
         if hasattr(self, "kdtree"):

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -892,7 +892,7 @@ class KDTree:
         ----------
 
         array : pynbody.array.SimArray
-            Quantity to compute curl of.
+            Quantity to compute the divergence of.
 
         nsmooth : int
             Number of neighbours to use when smoothing.
@@ -917,7 +917,7 @@ class KDTree:
         Returns
         -------
         pynbody.array.SimArray:
-            The curl of the input array.
+            The divergence of the input array.
         """
         return self._sph_differential_operator(array, "div", nsmooth,
                                               density_weighting)

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -729,6 +729,8 @@ template <typename Tf, typename Tq> struct typed_populate {
 
     smx_local = smInitThreadLocalCopy(smx_global);
     smx_local->warnings = false;
+    // overflow is handled by growing the buffer and retrying, below
+    smx_local->suppressOverflowWarning = true;
     smx_local->pi = 0;
 
     smx_global->warnings = false;
@@ -783,8 +785,19 @@ template <typename Tf, typename Tq> struct typed_populate {
         // retrieve the existing smoothing length
         hsm = GETSMOOTH(Tf, i);
 
-        // use it to get nearest neighbours
+        // use it to get nearest neighbours, growing the buffer if this
+        // particle turns out to enclose more than it currently holds. The
+        // initial size assumes the smoothing lengths came from our own
+        // nearest-neighbour search; one taken from a snapshot may enclose any
+        // number of particles. Each thread owns its own buffer, so this needs
+        // no synchronisation.
+        smx_local->warnings = false;
         nCnt = smBallGather<Tf, smBallGatherStoreResultInSmx>(smx_local, 4 * hsm * hsm, ri);
+        while (smx_local->warnings) {
+          smx_local->warnings = false;
+          smx_local->growNeighbourBuffer();
+          nCnt = smBallGather<Tf, smBallGatherStoreResultInSmx>(smx_local, 4 * hsm * hsm, ri);
+        }
 
         // calculate the density
         (*pSmFn)(smx_local, i, nCnt);

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -856,6 +856,9 @@ template <typename T> struct typed_pair_start {
     if (smx == nullptr)
       return nullptr; // smInit sets the error message
     smx->warnings = false;
+    // smFillPairBlock grows the neighbour buffer and retries rather than
+    // treating an overflow as an error, so the usual warning would be noise
+    smx->suppressOverflowWarning = true;
 
     auto pc = new PairContext<T>(smx, blocksize, mode);
 

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -618,13 +618,15 @@ PyObject *get_arrayref(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  Py_INCREF(*existing);
-
+  // the NULL check must come first: Py_INCREF dereferences its argument, so
+  // asking for an array that has never been set would otherwise segfault
   if (*existing == NULL) {
     Py_INCREF(Py_None);
     return Py_None;
-  } else
-    return ((PyObject *) *existing);
+  }
+
+  Py_INCREF(*existing);
+  return ((PyObject *) *existing);
 }
 
 PyObject *domain_decomposition(PyObject *self, PyObject *args) {

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -702,8 +702,11 @@ template <typename Tf, typename Tq> struct typed_populate {
 
     PyObject *kdobj, *smxobj;
 
-    PyArg_ParseTuple(args, "OOiii", &kdobj, &smxobj, &propid, &procid,
-                     &kernel_id);
+    int self_density_weighting = 0;
+
+    if (!PyArg_ParseTuple(args, "OOiii|i", &kdobj, &smxobj, &propid, &procid,
+                          &kernel_id, &self_density_weighting))
+      return nullptr;
     kd = static_cast<KDContext*>(PyCapsule_GetPointer(kdobj, NULL));
     smx_global = (SmoothingContext<Tf> *)PyCapsule_GetPointer(smxobj, NULL);
 
@@ -731,6 +734,7 @@ template <typename Tf, typename Tq> struct typed_populate {
     smx_local->warnings = false;
     // overflow is handled by growing the buffer and retrying, below
     smx_local->suppressOverflowWarning = true;
+    smx_local->selfDensityWeighting = (self_density_weighting != 0);
     smx_local->pi = 0;
 
     smx_global->warnings = false;

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -63,8 +63,14 @@ public:
       dxList(3 * nListSize), pMutex(copy.pMutex),
       smx_global(const_cast<SmoothingContext<T>*>(&copy)),
       priorityQueue(std::make_unique<PriorityQueue<T>>(nSmooth, kd->nActive)),
-      pKernel(copy.pKernel) { }
+      pKernel(copy.pKernel),
+      selfDensityWeighting(copy.selfDensityWeighting) { }
       // copy constructor takes a pointer to the global context
+
+  bool selfDensityWeighting = false;
+  // false: weight each neighbour by its own volume m_j/rho_j, the usual SPH
+  // interpolant. true: weight by m_j/rho_i, the form hydro codes use, whose
+  // partition of unity is exact because rho_i is itself sum_j m_j W_ij.
 
   bool suppressOverflowWarning = false;
   // Set when the caller is prepared to grow the neighbour buffer and retry,
@@ -855,7 +861,7 @@ void smMeanQty1D(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs = kernel(r2);
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     ACCUM<Tq>(kd->pNumpyQtySmoothed, pi_iord,
               rs * mass * GET<Tq>(kd->pNumpyQty, kd->particleOffsets[pj]) / rho);
   }
@@ -883,7 +889,7 @@ void smMeanQtyND(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs = kernel(r2);
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     for (k = 0; k < 3; ++k) {
       ACCUM2<Tq>(kd->pNumpyQtySmoothed, pi_iord, k,
                  rs * mass * GET2<Tq>(kd->pNumpyQty, kd->particleOffsets[pj], k) /
@@ -933,7 +939,7 @@ void smCurlQty(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs *= fNorm;
 
     mass = GET<Tf>(kd->pNumpyMass, pj_iord);
-    rho = GET<Tf>(kd->pNumpyDen, pj_iord);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : pj_iord);
 
     for (k = 0; k < 3; ++k)
       dqty[k] = GET2<Tq>(kd->pNumpyQty, pj_iord, k) - qty_i[k];
@@ -986,7 +992,7 @@ void smDivQty(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs *= fNorm;
 
     mass = GET<Tf>(kd->pNumpyMass, pj_iord);
-    rho = GET<Tf>(kd->pNumpyDen, pj_iord);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : pj_iord);
 
     for (k = 0; k < 3; ++k)
       dqty[k] = GET2<Tq>(kd->pNumpyQty, pj_iord, k) - qty_i[k];
@@ -1026,7 +1032,7 @@ void smDispQtyND(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs = kernel(r2);
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     for (k = 0; k < 3; ++k)
       mean[k] += rs * mass * GET2<Tq>(kd->pNumpyQty, kd->particleOffsets[pj], k) / rho;
   }
@@ -1039,7 +1045,7 @@ void smDispQtyND(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs = kernel(r2);
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     for (k = 0; k < 3; ++k) {
       tdiff = mean[k] - GET2<Tq>(kd->pNumpyQty, kd->particleOffsets[pj], k);
       ACCUM<Tq>(kd->pNumpyQtySmoothed, pi_iord,
@@ -1080,7 +1086,7 @@ void smDispQty1D(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
 
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     mean += rs * mass * GET<Tq>(kd->pNumpyQty, kd->particleOffsets[pj]) / rho;
   }
 
@@ -1092,7 +1098,7 @@ void smDispQty1D(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
     rs = kernel(r2);
     rs *= fNorm;
     mass = GET<Tf>(kd->pNumpyMass, kd->particleOffsets[pj]);
-    rho = GET<Tf>(kd->pNumpyDen, kd->particleOffsets[pj]);
+    rho = GET<Tf>(kd->pNumpyDen, smx->selfDensityWeighting ? pi_iord : kd->particleOffsets[pj]);
     tdiff = mean - GET<Tq>(kd->pNumpyQty, kd->particleOffsets[pj]);
     ACCUM<Tq>(kd->pNumpyQtySmoothed, pi_iord, rs * mass * tdiff * tdiff / rho);
   }

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -66,8 +66,28 @@ public:
       pKernel(copy.pKernel) { }
       // copy constructor takes a pointer to the global context
 
+  bool suppressOverflowWarning = false;
+  // Set when the caller is prepared to grow the neighbour buffer and retry,
+  // so that a too-small buffer is a routine event rather than a hard error.
+
   void setupKernel(int kernel_id) {
     pKernel = kernels::Kernel<T>::create(kernel_id, nSmooth);
+  }
+
+  void growNeighbourBuffer() {
+    /* Double the space available to a single ball-gather.
+     *
+     * The initial size is derived from the configured number of smoothing
+     * neighbours, which is only meaningful when the smoothing lengths came
+     * from pynbody's own nearest-neighbour search. Where they instead come
+     * from a snapshot, an h can enclose arbitrarily many particles -- a
+     * particle whose h was set in a sparse region and which now sits beside a
+     * dense one, for instance -- so the buffer has to be able to grow.
+     */
+    nListSize *= 2;
+    fList.resize(nListSize);
+    pList.resize(nListSize);
+    dxList.resize(3 * nListSize);
   }
 };
 
@@ -265,7 +285,7 @@ inline npy_intp smBallGatherStoreResultInSmx(SmoothingContext<T>* smx, T fDist2,
                                              npy_intp particleIndex,
                                              npy_intp foundIndex) {
   if (foundIndex >= smx->nListSize) {
-    if (!smx->warnings)
+    if (!smx->warnings && !smx->suppressOverflowWarning)
       fprintf(stderr, "Smooth - particle cache too small for local density - "
                       "results will be incorrect\n");
     smx->warnings = true;
@@ -420,13 +440,21 @@ void smFillPairBlock(PairContext<T> *pc) {
       T fBall2Search = 4 * hi * hi;
       fBall2Search *= (1 + 16 * std::numeric_limits<T>::epsilon());
 
+      // Retry with a larger buffer for as long as this particle's neighbours
+      // do not fit. Doubling keeps the total cost amortised, and the buffer
+      // then stays large enough for subsequent particles.
+      smx->warnings = false;
       pc->pendingCount =
           smBallGather<T, smBallGatherStoreResultInSmx>(smx, fBall2Search, ri);
+      while (smx->warnings) {
+        smx->warnings = false;
+        smx->growNeighbourBuffer();
+        pc->pendingCount =
+            smBallGather<T, smBallGatherStoreResultInSmx>(smx, fBall2Search, ri);
+      }
+
       pc->pendingIndex = 0;
       pc->havePending = true;
-
-      if (smx->warnings)
-        return; // neighbour buffer overflowed; caller raises
     }
 
     npy_intp ia = kd->particleOffsets[pc->pendingParticle];

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -925,9 +925,13 @@ void smCurlQty(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
   for (j = 0; j < nSmooth; ++j) {
     pj = smx->pList[j];
     pj_iord = kd->particleOffsets[pj];
-    dx = x - GET2<Tf>(kd->pNumpyPos, pj_iord, 0);
-    dy = y - GET2<Tf>(kd->pNumpyPos, pj_iord, 1);
-    dz = z - GET2<Tf>(kd->pNumpyPos, pj_iord, 2);
+    // Take the displacement recorded by the ball-gather rather than
+    // differencing the stored positions: the gather works in the periodic
+    // minimum image, so for a pair straddling a box face the raw difference
+    // is a whole box length while r2 below is small.
+    dx = -smx->dxList[3 * j + 0];
+    dy = -smx->dxList[3 * j + 1];
+    dz = -smx->dxList[3 * j + 2];
 
     r2 = smx->fList[j];
     q2 = r2 * ih2;
@@ -980,9 +984,13 @@ void smDivQty(SmoothingContext<Tf> * smx, npy_intp pi, int nSmooth) {
   for (j = 0; j < nSmooth; ++j) {
     pj = smx->pList[j];
     pj_iord = kd->particleOffsets[pj];
-    dx = x - GET2<Tf>(kd->pNumpyPos, pj_iord, 0);
-    dy = y - GET2<Tf>(kd->pNumpyPos, pj_iord, 1);
-    dz = z - GET2<Tf>(kd->pNumpyPos, pj_iord, 2);
+    // Take the displacement recorded by the ball-gather rather than
+    // differencing the stored positions: the gather works in the periodic
+    // minimum image, so for a pair straddling a box face the raw difference
+    // is a whole box length while r2 below is small.
+    dx = -smx->dxList[3 * j + 0];
+    dy = -smx->dxList[3 * j + 1];
+    dz = -smx->dxList[3 * j + 2];
 
     r2 = smx->fList[j];
     q2 = r2 * ih2;

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -343,3 +343,64 @@ def test_kdtree_float64_rounding(npart=1000):
     f.build_tree()
 
     _ = f['smooth']
+
+
+def _weighting_test_snapshot(npart=8000):
+    f = pynbody.new(gas=npart)
+    np.random.seed(2024)
+    # a strong density gradient, so that rho_i and rho_j differ across a kernel
+    r = 10.0 * np.random.uniform(size=npart)
+    d = np.random.normal(size=(npart, 3))
+    d /= np.linalg.norm(d, axis=1)[:, None]
+    f['pos'] = d * r[:, None]
+    f['mass'] = np.random.uniform(0.5, 1.5, size=npart)
+    f['vel'] = np.random.normal(size=(npart, 3))
+    f['rho']
+    return f
+
+
+def test_density_weighting_self_reproduces_a_constant_field():
+    """The 'self' weighting has an exact partition of unity, 'neighbour' does not.
+
+    rho_i is by definition sum_j m_j W_ij, so weighting each neighbour by
+    m_j/rho_i makes the interpolant reproduce a constant exactly. Weighting by
+    m_j/rho_j -- the usual SPH volume element -- only does so approximately.
+    """
+    f = _weighting_test_snapshot()
+    constant = pynbody.array.SimArray(np.full(len(f), 3.25))
+    inner = np.linalg.norm(np.asarray(f['pos'], dtype=np.float64), axis=1) < 8.0
+
+    exact = np.asarray(f.kdtree.sph_mean(constant, 32, density_weighting='self'))
+    usual = np.asarray(f.kdtree.sph_mean(constant, 32,
+                                         density_weighting='neighbour'))
+
+    npt.assert_allclose(exact[inner], 3.25, rtol=1e-12)
+    assert np.abs(usual[inner] - 3.25).max() > 1e-6, \
+        "the two weightings should differ where the density varies"
+
+
+@pytest.mark.parametrize("operation", ['sph_mean', 'sph_dispersion',
+                                       'sph_divergence', 'sph_curl'])
+def test_density_weighting_is_accepted_and_changes_the_result(operation):
+    """Every operation that divides by a density takes the option."""
+    f = _weighting_test_snapshot()
+    qty = f['vel'] if operation in ('sph_divergence', 'sph_curl') else f['vx']
+    call = getattr(f.kdtree, operation)
+
+    default = np.asarray(call(qty, 32))
+    neighbour = np.asarray(call(qty, 32, density_weighting='neighbour'))
+    self_ = np.asarray(call(qty, 32, density_weighting='self'))
+
+    # the default must not have changed
+    npt.assert_array_equal(default, neighbour)
+
+    inner = np.linalg.norm(np.asarray(f['pos'], dtype=np.float64), axis=1) < 8.0
+    assert not np.allclose(neighbour[inner], self_[inner]), \
+        "%s should depend on the weighting where the density varies" % operation
+    assert np.isfinite(self_).all()
+
+
+def test_unknown_density_weighting_raises():
+    f = _weighting_test_snapshot(1000)
+    with pytest.raises(ValueError):
+        f.kdtree.sph_mean(f['vx'], 32, density_weighting='not-a-weighting')

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -359,7 +359,7 @@ def _weighting_test_snapshot(npart=8000):
     return f
 
 
-def test_density_weighting_self_reproduces_a_constant_field():
+def test_mass_weighting_reproduces_a_constant_field():
     """The 'self' weighting has an exact partition of unity, 'neighbour' does not.
 
     rho_i is by definition sum_j m_j W_ij, so weighting each neighbour by
@@ -370,9 +370,9 @@ def test_density_weighting_self_reproduces_a_constant_field():
     constant = pynbody.array.SimArray(np.full(len(f), 3.25))
     inner = np.linalg.norm(np.asarray(f['pos'], dtype=np.float64), axis=1) < 8.0
 
-    exact = np.asarray(f.kdtree.sph_mean(constant, 32, density_weighting='self'))
+    exact = np.asarray(f.kdtree.sph_mean(constant, 32, weighting='mass'))
     usual = np.asarray(f.kdtree.sph_mean(constant, 32,
-                                         density_weighting='neighbour'))
+                                         weighting='volume'))
 
     npt.assert_allclose(exact[inner], 3.25, rtol=1e-12)
     assert np.abs(usual[inner] - 3.25).max() > 1e-6, \
@@ -381,15 +381,15 @@ def test_density_weighting_self_reproduces_a_constant_field():
 
 @pytest.mark.parametrize("operation", ['sph_mean', 'sph_dispersion',
                                        'sph_divergence', 'sph_curl'])
-def test_density_weighting_is_accepted_and_changes_the_result(operation):
+def test_weighting_is_accepted_and_changes_the_result(operation):
     """Every operation that divides by a density takes the option."""
     f = _weighting_test_snapshot()
     qty = f['vel'] if operation in ('sph_divergence', 'sph_curl') else f['vx']
     call = getattr(f.kdtree, operation)
 
     default = np.asarray(call(qty, 32))
-    neighbour = np.asarray(call(qty, 32, density_weighting='neighbour'))
-    self_ = np.asarray(call(qty, 32, density_weighting='self'))
+    neighbour = np.asarray(call(qty, 32, weighting='volume'))
+    self_ = np.asarray(call(qty, 32, weighting='mass'))
 
     # the default must not have changed
     npt.assert_array_equal(default, neighbour)
@@ -400,7 +400,55 @@ def test_density_weighting_is_accepted_and_changes_the_result(operation):
     assert np.isfinite(self_).all()
 
 
-def test_unknown_density_weighting_raises():
+def test_unknown_weighting_raises():
     f = _weighting_test_snapshot(1000)
     with pytest.raises(ValueError):
-        f.kdtree.sph_mean(f['vx'], 32, density_weighting='not-a-weighting')
+        f.kdtree.sph_mean(f['vx'], 32, weighting='not-a-weighting')
+
+
+@pytest.mark.parametrize("operation", ['sph_divergence', 'sph_curl'])
+def test_divergence_and_curl_use_the_periodic_minimum_image(operation):
+    """Displacements must be wrapped, as the neighbour search itself is.
+
+    Regression test: smDivQty and smCurlQty differenced the stored positions
+    directly, while the ball-gather that found the neighbour works in the
+    minimum image. For a pair straddling a box face the two disagree by a box
+    length, so every particle within 2h of a face came out wrong -- which on
+    a cosmological volume is a substantial fraction of them.
+    """
+    npart = 6000
+    f = pynbody.new(gas=npart)
+    rng = np.random.default_rng(12)
+    f['pos'] = rng.uniform(0, 10.0, size=(npart, 3))
+    f['pos'].units = 'kpc'
+    f['mass'] = rng.uniform(0.5, 1.5, size=npart)
+    f['vel'] = rng.normal(size=(npart, 3))
+    f.properties['boxsize'] = pynbody.units.Unit('10 kpc')
+    f['rho']
+
+    m = np.asarray(f['mass'], dtype=np.float64)
+    rho = np.asarray(f['rho'], dtype=np.float64)
+    h = np.asarray(f['smooth'], dtype=np.float64)
+    vel = np.asarray(f['vel'], dtype=np.float64)
+    kernel = f.kdtree.kernel
+
+    # pair_blocks supplies minimum-imaged displacements, so this is the
+    # independent statement of what the C++ ought to produce
+    def divergence(i, j, dx, r):
+        w = (m[j] / rho[i]) * kernel.gradient(r, h[i]) / r
+        if operation == 'sph_divergence':
+            # smDivQty forms (x_i - x_j) . (v_j - v_i), i.e. -(dx . dv)
+            return -w * np.einsum('kl,kl->k', vel[j] - vel[i], dx)
+        # smCurlQty forms (x_i - x_j) x (v_j - v_i), i.e. +(dv x dx)
+        return w[:, None] * np.cross(vel[j] - vel[i], dx)
+
+    expected = f.kdtree.pair_reduce(divergence, mode='gather')
+    got = np.asarray(getattr(f.kdtree, operation)(f['vel'], 32,
+                                                  weighting='mass'))
+
+    # the particles that would have been wrong are the ones near a face
+    pos = np.asarray(f['pos'], dtype=np.float64)
+    near_face = ((pos < 2 * h[:, None]) | (pos > 10.0 - 2 * h[:, None])).any(axis=1)
+    assert near_face.mean() > 0.2, "test needs plenty of particles near a face"
+
+    npt.assert_allclose(got, expected, rtol=1e-8, atol=1e-12)

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -709,8 +709,8 @@ def test_pair_reduce_reproduces_density(pairs, request, snap_name):
     npt.assert_allclose(rho, np.asarray(f['rho'], dtype=np.float64), rtol=1e-9)
 
 
-@pytest.mark.parametrize("density_weighting", ['neighbour', 'self'])
-def test_pair_reduce_reproduces_sph_divergence(pairs, snap, density_weighting):
+@pytest.mark.parametrize("weighting", ['volume', 'mass'])
+def test_pair_reduce_reproduces_sph_divergence(pairs, snap, weighting):
     """Reproduce KDTree.sph_divergence, in both of its weighting conventions.
 
         div v_i = sum_j V_j (v_j - v_i) . grad_i W(r, h_i)
@@ -725,14 +725,14 @@ def test_pair_reduce_reproduces_sph_divergence(pairs, snap, density_weighting):
     vel = np.asarray(snap['vel'], dtype=np.float64)
 
     def divergence(i, j, dx, r):
-        volume = m[j] / (rho[i] if density_weighting == 'self' else rho[j])
+        volume = m[j] / (rho[i] if weighting == 'mass' else rho[j])
         dv_dot_dx = np.einsum('kl,kl->k', vel[j] - vel[i], dx)
         return -volume * dv_dot_dx * _reference_kernel_gradient(r, h[i]) / r
 
     div = pairs(snap).pair_reduce(divergence, mode='gather')
     expected = np.asarray(snap.kdtree.sph_divergence(
         snap['vel'], pynbody.config['sph']['smooth-particles'],
-        density_weighting=density_weighting))
+        weighting=weighting))
 
     npt.assert_allclose(div, expected, rtol=1e-8)
 

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -357,6 +357,42 @@ def test_pair_blocks_handles_far_more_neighbours_than_the_default_buffer():
     assert len(i) == npart * (npart - 1) // 2
 
 
+def test_smoothing_operations_handle_more_neighbours_than_the_default_buffer():
+    """The same buffer limits sph_divergence, sph_curl, sph_mean and rho.
+
+    These share the gather used by pair_blocks, so they fail the same way once
+    the smoothing lengths come from a snapshot rather than from pynbody's own
+    search. Regression test: on a FLAMINGO snapshot both sph_divergence and
+    sph_curl raised "Buffer overflow in smoothing operation".
+
+    Ordinary pynbody usage does not reach this, because the smoothing lengths
+    are recomputed to hold exactly the configured neighbour count; it takes an
+    externally supplied h, which pair_blocks now makes routine.
+    """
+    npart = 1200
+    f = pynbody.new(gas=npart)
+    np.random.seed(101)
+    f['pos'] = np.random.normal(size=(npart, 3))
+    f['mass'] = np.ones(npart)
+    f['vel'] = np.random.normal(size=(npart, 3))
+    f['rho'] = np.ones(npart)
+    f['smooth'] = np.full(npart, 100.0)         # encloses the whole snapshot
+
+    assert npart - 1 > int(pynbody.config['sph']['smooth-particles']) + 500
+
+    f.build_tree()
+    for name in ('smooth', 'mass', 'rho'):
+        f.kdtree.set_array_ref(name, np.asarray(f[name],
+                                                dtype=f['pos'].dtype))
+
+    nsmooth = int(pynbody.config['sph']['smooth-particles'])
+    div = f.kdtree.sph_divergence(f['vel'], nsmooth)
+    curl = f.kdtree.sph_curl(f['vel'], nsmooth)
+
+    assert np.isfinite(div).all() and np.isfinite(curl).all()
+    assert div.shape == (npart,) and curl.shape == (npart, 3)
+
+
 @pytest.mark.parametrize("npart", [200, 200000])
 @pytest.mark.parametrize("trailing", [(), (3,)])
 def test_scatter_add_agrees_across_both_strategies(npart, trailing):

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -321,6 +321,73 @@ def test_pair_blocks_invariant_to_blocksize(pairs, snap, mode):
     npt.assert_allclose(np.sort(r1), np.sort(r2), rtol=1e-14)
 
 
+def test_pair_blocks_handles_far_more_neighbours_than_the_default_buffer():
+    """A smoothing length from a snapshot may enclose any number of particles.
+
+    The gather buffer starts out sized from the configured neighbour count,
+    which says nothing about how many particles an arbitrary h encloses. This
+    is a regression test: a FLAMINGO snapshot, whose h comes from SWIFT rather
+    than from pynbody's own neighbour search, raised "Buffer overflow while
+    gathering neighbour pairs" here. The estimate that the density implies is
+    not an upper bound either -- a particle whose h was fixed in a sparse
+    region and which now sits beside a dense one encloses far more than
+    rho * h^3 suggests.
+    """
+    npart = 1200
+    f = pynbody.new(gas=npart)
+    np.random.seed(99)
+    f['pos'] = np.random.normal(size=(npart, 3))
+    f['mass'] = np.ones(npart)
+
+    # every kernel spans the whole distribution, so each particle has
+    # npart - 1 neighbours
+    f['smooth'] = np.full(npart, 100.0)
+    f.build_tree()
+    f.kdtree.set_array_ref('smooth',
+                           np.asarray(f['smooth'], dtype=f['pos'].dtype))
+
+    default_buffer = int(pynbody.config['sph']['smooth-particles']) + 500
+    assert npart - 1 > default_buffer, "test must exceed the initial buffer"
+
+    i, _, _, _ = _collect(f.kdtree.pair_blocks(mode='gather'))
+    npt.assert_array_equal(np.bincount(i, minlength=npart),
+                           np.full(npart, npart - 1))
+
+    i, _, _, _ = _collect(f.kdtree.pair_blocks(mode='symmetric'))
+    assert len(i) == npart * (npart - 1) // 2
+
+
+@pytest.mark.parametrize("npart", [200, 200000])
+@pytest.mark.parametrize("trailing", [(), (3,)])
+def test_scatter_add_agrees_across_both_strategies(npart, trailing):
+    """The accumulation must not depend on which strategy is chosen.
+
+    ``_scatter_add`` switches on the ratio of output length to block length:
+    ``np.bincount`` allocates a length-N temporary on every call, so it pays
+    only while N is comparable to the block, whereas for a large snapshot the
+    in-place ``np.add.at`` is faster by two orders of magnitude. Both branches
+    are exercised here, against an independent reference.
+    """
+    from pynbody.kdtree import _scatter_add
+
+    rng = np.random.default_rng(4)
+    nblock = 5000
+    index = rng.integers(0, npart, nblock)
+    contrib = rng.normal(size=(nblock,) + trailing)
+
+    got = np.zeros((npart,) + trailing)
+    _scatter_add(got, index, contrib)
+
+    if trailing:
+        expected = np.stack(
+            [np.bincount(index, weights=contrib[:, k], minlength=npart)
+             for k in range(trailing[0])], axis=1)
+    else:
+        expected = np.bincount(index, weights=contrib, minlength=npart)
+
+    npt.assert_allclose(got, expected, rtol=1e-12)
+
+
 def test_pair_blocks_is_deterministic(pairs, snap):
     """Same tree and blocksize => identical blocks, so results are reproducible."""
     first = list(pairs(snap).pair_blocks(blocksize=311))

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -709,12 +709,15 @@ def test_pair_reduce_reproduces_density(pairs, request, snap_name):
     npt.assert_allclose(rho, np.asarray(f['rho'], dtype=np.float64), rtol=1e-9)
 
 
-def test_pair_reduce_reproduces_sph_divergence(pairs, snap):
-    """Reproduce KDTree.sph_divergence, which uses the m_j/rho_j gather form.
+@pytest.mark.parametrize("density_weighting", ['neighbour', 'self'])
+def test_pair_reduce_reproduces_sph_divergence(pairs, snap, density_weighting):
+    """Reproduce KDTree.sph_divergence, in both of its weighting conventions.
 
-        div v_i = sum_j (m_j/rho_j) (v_j - v_i) . grad_i W(r, h_i)
+        div v_i = sum_j V_j (v_j - v_i) . grad_i W(r, h_i)
 
-    with grad_i W = (dW/dr) * (-dx/r), since dx points from i towards j.
+    with grad_i W = (dW/dr) * (-dx/r), since dx points from i towards j, and
+    the volume element V_j being either m_j/rho_j ('neighbour') or m_j/rho_i
+    ('self', the form SPH simulation codes use).
     """
     m = np.asarray(snap['mass'], dtype=np.float64)
     rho = np.asarray(snap['rho'], dtype=np.float64)
@@ -722,12 +725,14 @@ def test_pair_reduce_reproduces_sph_divergence(pairs, snap):
     vel = np.asarray(snap['vel'], dtype=np.float64)
 
     def divergence(i, j, dx, r):
+        volume = m[j] / (rho[i] if density_weighting == 'self' else rho[j])
         dv_dot_dx = np.einsum('kl,kl->k', vel[j] - vel[i], dx)
-        return -(m[j] / rho[j]) * dv_dot_dx * _reference_kernel_gradient(r, h[i]) / r
+        return -volume * dv_dot_dx * _reference_kernel_gradient(r, h[i]) / r
 
     div = pairs(snap).pair_reduce(divergence, mode='gather')
     expected = np.asarray(snap.kdtree.sph_divergence(
-        snap['vel'], pynbody.config['sph']['smooth-particles']))
+        snap['vel'], pynbody.config['sph']['smooth-particles'],
+        density_weighting=density_weighting))
 
     npt.assert_allclose(div, expected, rtol=1e-8)
 


### PR DESCRIPTION
Correctness and performance fixes to the KDTree SPH operations, plus a new `weighting` option for them.

Most of these surfaced while exercising the pairwise API added in #1014 on large cosmological snapshots. Several are pre-existing and affect `sph_mean`, `sph_dispersion`, `sph_divergence`, `sph_curl` and `rho`, not only the new code.

**Behaviour change to flag:** `sph_divergence` and `sph_curl` return different values for particles near a periodic boundary, because they were previously wrong there. Everything else leaves existing results untouched.

---

## Correctness

### The neighbour buffer could overflow when smoothing lengths come from a snapshot

The buffer used to collect a particle's neighbours is sized as `config['sph']['smooth-particles'] + RESMOOTH_SAFE`, 532 by default. That is meaningful only when the smoothing lengths came from pynbody's own nearest-neighbour search, which by construction puts a known number of particles inside each kernel. When `h` is instead read from the snapshot, as for any SWIFT or GADGET file carrying its own smoothing lengths, a kernel can enclose arbitrarily many particles and the gather overflows:

```
RuntimeError: Buffer overflow in smoothing operation
RuntimeError: Buffer overflow while gathering neighbour pairs
```

This affects `populate` and therefore `sph_mean`, `sph_dispersion`, `sph_divergence`, `sph_curl` and `rho`, as well as the new `pair_blocks`. On a cosmological hydrodynamics snapshot it triggers within half a second.

The local density does not bound the problem. Estimating the worst case as `(4/3)π(2h)³ρ/m` gives a maximum of 142 neighbours across 42M particles, where the true figure exceeds 532: `ρ_i` is a kernel-weighted average dominated by nearby particles, while the count scales with volume, so a particle whose `h` was set in a sparse region and which now sits beside a dense one exceeds it. The measured mean was 78 neighbours within `2h`, with a sampled maximum of 327.

The buffer now doubles and the gather is retried, which is amortised O(1) and leaves it large enough for subsequent particles. Each thread owns its own buffer, so this needs no synchronisation.

### `sph_divergence` and `sph_curl` ignored periodicity

`smDivQty` and `smCurlQty` obtained the pair displacement by differencing the stored positions, while the ball-gather that found the neighbour works in the periodic minimum image. For a pair straddling a box face the two disagree by a box length, so the displacement used bore no relation to the separation the neighbour was selected on.

Every particle within `2h` of a box face was affected. On a uniform periodic test that is 3158 of 8000 particles, with 100% of the disagreements adjacent to a face; on a non-periodic distribution there is no discrepancy at all. The existing `test_div_curl_smoothing` uses a zoom simulation whose particles lie far from the box faces, which is why it neither caught this nor changes now.

The gather already records the wrapped displacement, so both routines now read it from there.

### `get_arrayref` segfaulted when the array was unset

`Py_INCREF` was called before the `NULL` check, so requesting an array that had never been set dereferenced `NULL` instead of returning `None`.

## Performance

`pair_reduce`'s accumulation used `np.bincount(..., minlength=N)`, which allocates and fills a temporary as long as the output on every call. For a large snapshot that dominates everything else — at 42M particles it moves 340 MB per block per end:

```
bincount:    122 ms and 100 ms per block
np.add.at:   0.8 ms and 0.7 ms per block
```

`np.add.at` is the slower of the two only while the output is comparable in length to the block, which is the regime the previous code assumed. The choice is now made on that ratio, with `bincount` retained where it wins. This is worth 2.7x on a large snapshot and nothing is given up on a small one.

## New: `weighting='volume'` or `'mass'`

`sph_mean`, `sph_dispersion`, `sph_divergence` and `sph_curl` divide each neighbour's contribution by that neighbour's own density, `m_j/ρ_j`. Dividing by `m_j/ρ_i` instead is equally standard and is the form SPH codes use internally. Both are now available; the default is unchanged.

The two are not competing estimates of one quantity. They converge to different quantities:

| | limit | consistent with |
|---|---|---|
| `'volume'` (default, `m_j/ρ_j`) | `∫ q W dV` | the continuum smoothing integral, of which it is the direct quadrature |
| `'mass'` (`m_j/ρ_i`) | `∫ q ρ W dV / ∫ ρ W dV` | the discrete mass distribution: the weights `m_j W_ij` sum to `ρ_i` by definition |

Interpolating a field correlated with density shows the difference directly: the ratio between them is 1.088 for `q = ρ`, 0.938 for `q = 1/ρ`, and 1.015 for an uncorrelated field.

Naming them for what they average over makes the properties follow from the name. A mass-weighted average is a true weighted mean, so it reproduces a constant field exactly and can never return a value outside the range of its input:

```
interpolating a constant 3.25:
  'mass'     3.250000   max error 3e-15
  'volume'   3.229914   max error 1.2
```

A volume-weighted average makes no assumption about density being constant across a kernel, and is the faithful discretisation of the smoothing integral.

For a divergence the mass form is the one that satisfies the continuity equation exactly (verified to `6.4e-16`), and hence the one appearing in the SPH equations of motion. It is therefore what is needed to reproduce a velocity divergence as the simulation itself computed it: against the `VelocityDivergences` stored in a SWIFT snapshot, correlation is 0.94 with `'mass'` and 0.41 with `'volume'`.

`rho` and `smooth` take no such weighting and are unaffected — `smDensity` is what defines ρ.

## Documentation

Several docstrings were inaccurate rather than merely unclear:

- `pair_blocks` stated that accessing `f['smooth']` fixes the pair set. That holds only where pynbody derives the smoothing lengths; where they come from the file, reading them never involves the tree and they must be associated with it explicitly. The error message now distinguishes the two cases.
- The `nsmooth` argument to `sph_mean`, `sph_dispersion`, `sph_divergence` and `sph_curl` was described as the number of neighbours to use. It does not select the neighbours, which follow from the smoothing lengths — `sph_mean(q, 16)` and `sph_mean(q, 256)` return bit-identical answers. It sizes the buffer and sets the neighbour count that kernels such as Wendland C2 are normalised for.
- `populate` documented four of the six operations it accepts.
- The `KDTree` class docstring gave `f.build_kdtree()` as a worked example; the method is `build_tree()`.
- `sph_divergence`'s parameter and return descriptions were copy-pasted from `sph_curl` and named the wrong operation.
- `sph_mean` and `sph_dispersion` wrote `q_i` inside a sum over `j`, and the dispersion gave `(q_i - r_i)²` where the code forms the difference against each neighbour's value.

Remaining changes are consistency: indices are defined before use, `pair_reduce` no longer overloads `i` and `j` for both the ends of a pair and the particle being accumulated into, and it now states that the callback runs on a single thread.

## Testing

217 tests pass. Each new test was checked against the unfixed code to confirm it fails there:

- `test_pair_blocks_handles_far_more_neighbours_than_the_default_buffer`
- `test_smoothing_operations_handle_more_neighbours_than_the_default_buffer`
- `test_divergence_and_curl_use_the_periodic_minimum_image` — both operations, against the wrapped displacements from `pair_blocks`
- `test_scatter_add_agrees_across_both_strategies` — both branches, 1-D and 2-D output, against an independent reference
- `test_mass_weighting_reproduces_a_constant_field`
- `test_weighting_is_accepted_and_changes_the_result` — all four operations, and asserts the default is unchanged

The existing C++-versus-python cross-check for `sph_divergence` now runs over both weightings, so the two implementations cannot drift apart.

For scale, with the buffer fix in place `sph_divergence` and `sph_curl` complete over a 42M particle gas snapshot in 14.1 s and 14.6 s.

No version bump: v2.5.0 is the most recent tag, so 2.6.0 is unreleased and this folds into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGC9utrm2V3Tbu6o6GwgK5