### PR TITLE
Hand neighbour pairs back in the tree's own precision

### DIFF
--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -63,7 +63,9 @@ def buffered_kernel(kernel, *args, ncols=None, both_ends=True):
         Takes the four pair arrays, then ``args``, then one or two output
         arrays. It must write **every** element of them: they are reused
         between blocks and are not cleared, so anything left unwritten is
-        whatever the previous block put there.
+        whatever the previous block put there. The output arrays are
+        ``float64``, whatever the precision of the tree, matching what
+        :meth:`~KDTree.pair_reduce` accumulates into.
     *args : arrays
         Passed through to ``kernel`` between the pair arrays and the output
         arrays. Typically the per-particle quantities the kernel needs.
@@ -519,13 +521,21 @@ class KDTree:
         =======  ======================  ==================================
         ``i``    ``(nblock,)`` intp      index of the first particle of each pair
         ``j``    ``(nblock,)`` intp      index of the second particle of each pair
-        ``dx``   ``(nblock, 3)`` f8      periodic-wrapped ``pos[j] - pos[i]``
-        ``r``    ``(nblock,)`` f8        ``|dx|``, always strictly positive
+        ``dx``   ``(nblock, 3)`` float   periodic-wrapped ``pos[j] - pos[i]``
+        ``r``    ``(nblock,)`` float     ``|dx|``, always strictly positive
         =======  ======================  ==================================
 
         Note that ``i`` and ``j`` are *arrays* of particle indices, one entry
         per pair, so per-particle quantities are used via fancy indexing, e.g.
         ``rho[i]`` is the density of the first particle of each pair.
+
+        The geometry, ``dx`` and ``r``, has the dtype of the positions the tree
+        was built from: ``float32`` for a single-precision snapshot and
+        ``float64`` for a double-precision one. The whole walk is carried out
+        in that precision, so a single-precision tree offers no less accuracy
+        here than it does anywhere else, but a callback that mixes these arrays
+        with per-particle quantities of its own should either work in the same
+        precision or promote them explicitly.
 
         The pair set is fixed by the smoothing lengths associated with the
         tree. Where pynbody derives those itself, accessing ``f['smooth']``
@@ -682,13 +692,17 @@ class KDTree:
             for c in all_contexts:
                 kdmain.pair_stop(self.kdtree, c)
 
-    @staticmethod
-    def _make_pair_buffers(capacity):
-        """Somewhere for the walks to write ``capacity`` pairs."""
+    def _make_pair_buffers(self, capacity):
+        """Somewhere for the walks to write ``capacity`` pairs.
+
+        The geometry is written in the precision of the positions the tree was
+        built from, which is the only precision the walk has to offer.
+        """
+        float_type = self._pos.dtype
         return (np.empty(capacity, dtype=np.intp),
                 np.empty(capacity, dtype=np.intp),
-                np.empty((capacity, 3), dtype=np.float64),
-                np.empty(capacity, dtype=np.float64))
+                np.empty((capacity, 3), dtype=float_type),
+                np.empty(capacity, dtype=float_type))
 
     def _fill_one_block(self, contexts, blocksize, buffers):
         """Run every walk once, and gather what they produced into one block.

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -134,6 +134,14 @@ template <> const char np_kind<KDNode>() { return 'V'; }
 
 template <> const char np_kind<npy_intp>() { return 'i'; }
 
+template <typename T> int np_typenum() { return NPY_NOTYPE; }
+
+template <> int np_typenum<double>() { return NPY_DOUBLE; }
+
+template <> int np_typenum<float>() { return NPY_FLOAT; }
+
+template <> int np_typenum<npy_intp>() { return NPY_INTP; }
+
 template <typename T> const char py_kind() { return '?'; }
 
 template <> const char py_kind<double>() { return 'd'; }
@@ -890,17 +898,18 @@ template <typename T> struct typed_pair_start {
   }
 };
 
-/* Validate one of the output buffers python has supplied, and return a
+/* Validate one of the output buffers python has supplied, and return a typed
    pointer to its data. The walk writes into these directly, so they have to
    be exactly the right type and laid out contiguously. */
-static void *pairOutputBuffer(PyObject *obj, const char *name, int typenum,
-                              int ndim, npy_intp expected) {
+template <typename Tbuf>
+static Tbuf *pairOutputBuffer(PyObject *obj, const char *name, int ndim,
+                              npy_intp expected) {
   if (!PyArray_Check(obj)) {
     PyErr_Format(PyExc_TypeError, "pair output %s must be a numpy array", name);
     return nullptr;
   }
   PyArrayObject *ar = (PyArrayObject *)obj;
-  if (PyArray_TYPE(ar) != typenum || PyArray_NDIM(ar) != ndim ||
+  if (PyArray_TYPE(ar) != np_typenum<Tbuf>() || PyArray_NDIM(ar) != ndim ||
       !PyArray_ISCARRAY(ar)) {
     PyErr_Format(PyExc_TypeError,
                  "pair output %s has the wrong type or layout", name);
@@ -912,7 +921,7 @@ static void *pairOutputBuffer(PyObject *obj, const char *name, int typenum,
                  "pair output %s has the wrong shape", name);
     return nullptr;
   }
-  return PyArray_DATA(ar);
+  return static_cast<Tbuf *>(PyArray_DATA(ar));
 }
 
 template <typename T> struct typed_pair_next {
@@ -928,21 +937,23 @@ template <typename T> struct typed_pair_next {
       return nullptr;
     }
 
-    // The caller owns the memory; this is just where to put the pairs.
+    // The caller owns the memory; this is just where to put the pairs. The
+    // displacements and separations come back in the tree's own precision, so
+    // for a single-precision tree these must be float32 arrays.
     npy_intp capacity = PyArray_Check(oI) ? PyArray_DIM((PyArrayObject *)oI, 0)
                                           : 0;
-    void *bufI = pairOutputBuffer(oI, "i", NPY_INTP, 1, capacity);
-    void *bufJ = pairOutputBuffer(oJ, "j", NPY_INTP, 1, capacity);
-    void *bufDx = pairOutputBuffer(oDx, "dx", NPY_DOUBLE, 2, capacity);
-    void *bufR = pairOutputBuffer(oR, "r", NPY_DOUBLE, 1, capacity);
+    npy_intp *bufI = pairOutputBuffer<npy_intp>(oI, "i", 1, capacity);
+    npy_intp *bufJ = pairOutputBuffer<npy_intp>(oJ, "j", 1, capacity);
+    T *bufDx = pairOutputBuffer<T>(oDx, "dx", 2, capacity);
+    T *bufR = pairOutputBuffer<T>(oR, "r", 1, capacity);
     if (bufI == nullptr || bufJ == nullptr || bufDx == nullptr ||
         bufR == nullptr)
       return nullptr;
 
-    pc->outI = static_cast<npy_intp *>(bufI);
-    pc->outJ = static_cast<npy_intp *>(bufJ);
-    pc->outDx = static_cast<double *>(bufDx);
-    pc->outR = static_cast<double *>(bufR);
+    pc->outI = bufI;
+    pc->outJ = bufJ;
+    pc->outDx = bufDx;
+    pc->outR = bufR;
     pc->capacity = capacity;
 
     Py_BEGIN_ALLOW_THREADS;

--- a/pynbody/kdtree/smooth.h
+++ b/pynbody/kdtree/smooth.h
@@ -404,10 +404,12 @@ public:
   /* Where the current block is written. The caller supplies the memory --
    * python allocates one buffer for the round and hands each walk its own
    * slice of it -- so the walk writes each pair straight to its final
-   * destination, and nothing here owns or allocates anything.
+   * destination, and nothing here owns or allocates anything. The geometry
+   * is handed back in the tree's own precision T, since that is all the
+   * positions it was built from can support.
    */
   npy_intp *outI, *outJ;
-  double *outDx, *outR;
+  T *outDx, *outR;
   npy_intp capacity;
   npy_intp outCount;
 
@@ -476,7 +478,7 @@ void smFillPairBlock(PairContext<T> *pc) {
     }
 
     npy_intp ia = kd->particleOffsets[pc->pendingParticle];
-    double hi = static_cast<double>(GET<T>(kd->pNumpySmooth, ia));
+    T hi = GET<T>(kd->pNumpySmooth, ia);
 
     while (pc->pendingIndex < pc->pendingCount &&
            pc->outCount < pc->capacity) {
@@ -492,25 +494,30 @@ void smFillPairBlock(PairContext<T> *pc) {
       // excluding the boundary, would strand those pairs on the wrong side by
       // an ulp. The inclusive test matches smBallGather, so a gather over
       // nSmooth neighbours really does yield nSmooth of them.
-      double r = sqrt(static_cast<double>(smx->fList[k]));
-      if (!(r <= 2.0 * hi))
+      //
+      // The whole comparison stays in T. Promoting r to double would break
+      // the exact hit: h is stored as T, so 2 h is the T-rounded distance to
+      // the nth neighbour, whereas a double sqrt of the T-rounded r^2 lands
+      // wherever the extra bits fall -- and half the time that is above it.
+      T r = std::sqrt(smx->fList[k]);
+      if (!(r <= 2 * hi))
         continue;
 
       npy_intp emitI = ia, emitJ = jb;
       bool flip = false;
 
       if (pc->mode == PAIR_MODE_SYMMETRIC && ia > jb) {
-        double hj = static_cast<double>(GET<T>(kd->pNumpySmooth, jb));
-        if (r <= 2.0 * hj)
+        T hj = GET<T>(kd->pNumpySmooth, jb);
+        if (r <= 2 * hj)
           continue; // jb's own walk finds ia, and will emit the pair
         emitI = jb;
         emitJ = ia;
         flip = true;
       }
 
-      double d0 = static_cast<double>(smx->dxList[3 * k + 0]);
-      double d1 = static_cast<double>(smx->dxList[3 * k + 1]);
-      double d2 = static_cast<double>(smx->dxList[3 * k + 2]);
+      T d0 = smx->dxList[3 * k + 0];
+      T d1 = smx->dxList[3 * k + 1];
+      T d2 = smx->dxList[3 * k + 2];
       if (flip) {
         // dx must always point from the emitted i towards the emitted j
         d0 = -d0;

--- a/tests/user_sph_operations_test.py
+++ b/tests/user_sph_operations_test.py
@@ -223,6 +223,24 @@ def periodic_snap():
     return f
 
 
+@pytest.fixture
+def single_precision_snap():
+    """A float32 snapshot, so that the tree -- and the pair walk -- is float32."""
+    npart = 300
+    f = pynbody.new(gas=npart)
+    for name, ndim in (('pos', 3), ('mass', 1), ('vel', 3)):
+        f._create_array(name, ndim, np.float32)
+
+    np.random.seed(1339)
+    f['pos'] = np.random.normal(scale=10.0, size=(npart, 3))
+    f['mass'] = np.random.uniform(0.5, 1.5, size=npart)
+    f['vel'] = np.random.normal(size=(npart, 3))
+    f['smooth']
+
+    assert f['pos'].dtype == np.float32 and f['smooth'].dtype == np.float32
+    return f
+
+
 def _collect(blocks):
     """Concatenate an iterator of pair blocks into single arrays."""
     parts = list(blocks)
@@ -495,18 +513,23 @@ def test_pair_blocks_is_deterministic(pairs, snap):
 # pair_blocks: which pairs are in the set
 # ---------------------------------------------------------------------------
 
-def _assert_pair_set_matches_reference(f, i, j, r, mode):
-    """Compare a pair set against the brute-force reference, off the boundary."""
+def _assert_pair_set_matches_reference(f, i, j, r, mode, rtol=BOUNDARY_RTOL):
+    """Compare a pair set against the brute-force reference, off the boundary.
+
+    ``rtol`` sets both the width of the ambiguous band around ``r == 2h`` and
+    the tolerance on ``r`` itself, so a single-precision tree can be compared
+    against the same double-precision reference.
+    """
     h = np.asarray(f['smooth'], dtype=np.float64)
     exp_i, exp_j, _, exp_r = _collect(ReferencePairs(f).pair_blocks(mode=mode))
 
-    got = _away_from_boundary(i, j, r, h, mode)
-    expected = _away_from_boundary(exp_i, exp_j, exp_r, h, mode)
+    got = _away_from_boundary(i, j, r, h, mode, rtol=rtol)
+    expected = _away_from_boundary(exp_i, exp_j, exp_r, h, mode, rtol=rtol)
 
     npt.assert_array_equal(np.sort(_pair_keys(i[got], j[got])),
                            np.sort(_pair_keys(exp_i[expected],
                                               exp_j[expected])))
-    npt.assert_allclose(np.sort(r[got]), np.sort(exp_r[expected]), rtol=1e-12)
+    npt.assert_allclose(np.sort(r[got]), np.sort(exp_r[expected]), rtol=rtol)
 
     # Each particle contributes at most one boundary pair, namely its own nth
     # neighbour, which is what defines its smoothing length. Anything much
@@ -596,6 +619,85 @@ def test_pair_blocks_finds_pairs_across_the_periodic_boundary(pairs,
 
     assert (unwrapped > 2 * r).sum() > 0, (
         "no boundary-straddling pairs, so periodicity is untested here")
+
+
+# ---------------------------------------------------------------------------
+# pair_blocks: single-precision trees
+#
+# The walk is carried out in the precision of the positions the tree was built
+# from, and hands ``dx`` and ``r`` back in it. These check the float32 case
+# against the same double-precision reference as everything above, so the
+# tolerance is set by float32 rather than by the walk.
+# ---------------------------------------------------------------------------
+
+#: Two evaluations of the same distance, one in float32 and one in float64,
+#: agree to about this much. Used both as the tolerance on ``r`` and as the
+#: width of the ambiguous band around the ``r == 2h`` boundary.
+SINGLE_PRECISION_RTOL = 1e-6
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_pair_blocks_geometry_follows_the_tree_precision(single_precision_snap,
+                                                         mode):
+    seen_any = False
+    for i, j, dx, r in single_precision_snap.kdtree.pair_blocks(mode=mode,
+                                                                blocksize=97):
+        seen_any = True
+        assert dx.dtype == np.float32 and r.dtype == np.float32
+        assert np.issubdtype(i.dtype, np.integer)
+        assert np.issubdtype(j.dtype, np.integer)
+        assert dx.shape == (len(i), 3) and r.shape == (len(i),)
+        npt.assert_allclose(r, np.sqrt(np.einsum('kl,kl->k', dx, dx)),
+                            rtol=SINGLE_PRECISION_RTOL)
+    assert seen_any, "no pairs were generated at all"
+
+
+@pytest.mark.parametrize("mode", ['symmetric', 'gather'])
+def test_single_precision_pair_set_matches_reference(single_precision_snap,
+                                                     mode):
+    """A float32 tree must find the same pairs, to within float32."""
+    i, j, _, r = _collect(single_precision_snap.kdtree.pair_blocks(mode=mode))
+
+    if mode == 'symmetric':
+        assert (i < j).all()
+    _assert_pair_set_matches_reference(single_precision_snap, i, j,
+                                       np.asarray(r, dtype=np.float64), mode,
+                                       rtol=SINGLE_PRECISION_RTOL)
+
+
+def test_single_precision_gather_includes_the_boundary_neighbour(
+        single_precision_snap):
+    """Each particle's nth neighbour, sitting exactly on r == 2h, is included.
+
+    That is what makes a gather over ``n`` neighbours yield ``n`` of them, and
+    it only holds while the comparison stays in the tree's own precision: ``h``
+    is stored as float32, so ``2h`` is the float32-rounded distance to the nth
+    neighbour, whereas the double-precision square root of the same float32
+    ``r^2`` lands above it about half the time.
+    """
+    f = single_precision_snap
+    i, j, _, r = _collect(f.kdtree.pair_blocks(mode='gather'))
+    h = np.asarray(f['smooth'])
+
+    on_boundary = r == 2 * h[i]
+    assert on_boundary.sum() >= len(f), (
+        "only %d of %d particles found a neighbour at exactly r == 2h"
+        % (on_boundary.sum(), len(f)))
+
+
+def test_single_precision_pair_reduce_reproduces_density(single_precision_snap):
+    """The float32 pairs still add up, end to end: rho_i = sum_j m_j W(r, h_i)."""
+    f = single_precision_snap
+    m = np.asarray(f['mass'], dtype=np.float64)
+    h = np.asarray(f['smooth'], dtype=np.float64)
+
+    rho = f.kdtree.pair_reduce(
+        lambda i, j, dx, r: m[j] * _reference_kernel_value(r, h[i]),
+        mode='gather')
+    rho += m * _reference_kernel_value(np.zeros(len(f)), h)
+
+    npt.assert_allclose(rho, np.asarray(f['rho'], dtype=np.float64),
+                        rtol=1e-4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #1016, which it targets.

`PairContext<T>` is templated on the tree's float type, and takes its positions, smoothing lengths and neighbour distances from it — but stored the pair geometry it hands back as `double*`. So a single-precision tree spent the whole walk in `float` and then widened `dx` and `r` on the way out. This makes them `T*`, and picks the buffer dtype in python from the positions the tree was built from.

### The boundary

Mostly this is consistency — there is nothing in a float32 tree for the extra bits to carry. But the widening was not free.

The walk deliberately includes the pair at exactly `r == 2h`, so that a gather over *n* neighbours really does yield *n* of them. That equality is not an edge case: `h` is *defined* as half the distance to the nth neighbour, so every particle has one neighbour sitting on it. It holds exactly because `h` is stored as `T`, making `2h` the `T`-rounded distance to that neighbour — and the walk's `r`, rounded the same way, hits it.

Taking the square root in double precision broke that. `sqrt((double) r2)` keeps bits that `2h` has already lost, and lands above it about half the time. On a 300-particle float32 snapshot, 161 of the 300 particles lost their nth neighbour; the gather returned 30 neighbours for those and 31 for the rest. The comparison now stays in `T` throughout.

Double-precision trees are unaffected in every respect: `T` is already `double`, so the arithmetic and the emitted pairs are unchanged, bit for bit.

### API

`pair_blocks` and `pair_reduce` now yield `dx` and `r` in the dtype of the tree's positions rather than always `float64`. That is the only user-visible change, and it is confined to the API #1016 introduces, which has not shipped. The docstring says so explicitly, and notes that a callback mixing the pair arrays with per-particle quantities of its own should either work in the same precision or promote them.

Contributions are unaffected: `pair_reduce` still accumulates in `float64` whatever the tree, and `buffered_kernel` still hands the kernel `float64` output arrays.

### Testing

The existing tests all run in double precision and are unchanged, bar one helper: `_assert_pair_set_matches_reference` grew an `rtol` argument, so that a float32 tree can be compared against the same double-precision brute-force reference. Four new tests, on a float32 fixture:

- `test_pair_blocks_geometry_follows_the_tree_precision` — `dx` and `r` come back as float32, with `r == |dx|`
- `test_single_precision_pair_set_matches_reference` — the same pairs as the brute-force reference, to within float32, in both modes
- `test_single_precision_gather_includes_the_boundary_neighbour` — every particle keeps its neighbour at exactly `r == 2h`; this is what fails on the previous code
- `test_single_precision_pair_reduce_reproduces_density` — the float32 pairs still add up end to end

Full file: 104 passed. Together with `kdtree_test.py`, `sph_image_test.py`, `gravity_test.py` and `filter_test.py`: 249 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGC9utrm2V3Tbu6o6GwgK5
