### PR TITLE
Report only ND parents, not their 1D slices, as loadable in CopyOnAccessSimSnap

### DIFF
--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -39,7 +39,8 @@ class Profile:
     can be accessed as ``p['ar']`` where ``p`` is a ``Profile`` object. For example, ``p['vr']`` gives
     the radial velocity profile. Implicitly, this is averaged over all particles in each bin,
     weighted by mass (unless an alternate weighting scheme is passed to the ``weight_by`` keyword argument of the
-    constructor).
+    constructor). Individual components of an ND array may be profiled in the same way, e.g. ``p['vz']`` gives
+    the profile of the z-component of ``vel``.
 
     **Dispersions**: One may append ``_rms`` or ``_disp`` to the name of a
     defined array to get the root-mean-square or dispersion profile, respectively. For example,
@@ -64,6 +65,15 @@ class Profile:
     looking at the same set of particles, centered in the same way. It also means you *must* use the same centering
     method if you want to reuse a saved profile.
 
+    .. versionchanged:: 2.6.0
+
+      What can be profiled is now decided by what the snapshot is actually able to provide, rather than by whether
+      the name appears in ``keys`` or ``all_keys``. Nothing has to be loaded or derived in advance. In particular,
+      a derived array is profiled whenever the snapshot knows how to derive it, and a 1D slice of an ND array is
+      profiled whenever the parent array is available: ``p['vz']`` and ``p['vz_disp']`` now work on a freshly loaded
+      snapshot, where previously they raised ``KeyError`` unless something had already touched the velocities,
+      because a loader offers ``vel`` rather than ``vz``.
+
     .. versionchanged:: 2.0
 
       The method ``create_particle_array`` has been removed. Its behaviour was poorly defined in v1, and not believed
@@ -72,6 +82,10 @@ class Profile:
     """
 
     _profile_registry = {}
+
+    # the failure from the most recent attempt to get an underlying simulation array, used
+    # to explain why a profile could not be constructed
+    _last_array_error = None
 
     def _calculate_x(self, sim):
         if self._x_calculator is not None:
@@ -282,43 +296,61 @@ class Profile:
                 pass
             return self._profiles[name]
 
-        elif name in list(self.sim.keys()) or name in self.sim.all_keys():
-            self._profiles[name] = self._auto_profile(name)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
-
-        elif name[-5:] == "_disp" and (name[:-5] in list(self.sim.keys()) or name[:-5] in self.sim.all_keys()):
+        for source_name, kwargs in self._auto_profile_candidates(name):
+            if not self._source_obtainable(source_name, **kwargs):
+                continue
             logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(
-                name[:-5], dispersion=True)
+            self._profiles[name] = self._auto_profile(source_name, **kwargs)
             self._profiles[name].sim = self.sim
             return self._profiles[name]
 
-        elif name[-4:] == "_rms" and (name[:-4] in list(self.sim.keys()) or name[:-4] in self.sim.all_keys()):
-            logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(name[:-4], rms=True)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
+        raise KeyError(name + " is not a valid profile") from self._last_array_error
 
-        elif name[-4:] == "_med" and (name[:-4] in list(self.sim.keys()) or name[:-4] in self.sim.all_keys()):
-            logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(name[:-4], median=True)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
+    @staticmethod
+    def _auto_profile_candidates(name):
+        """Yield the (source name, :meth:`_auto_profile` options) pairs that *name* could be built from.
 
-        elif name[0:2] == "d_" and (name[2:] in list(self.keys()) or name[2:] in self.derivable_keys() or name[2:] in self.sim.all_keys()):
+        A source of exactly this name takes precedence over any interpretation of a trailing
+        ``_disp``, ``_rms`` or ``_med``, or of a leading ``d_``."""
+        yield name, {}
+        if name[-5:] == "_disp":
+            yield name[:-5], {'dispersion': True}
+        if name[-4:] == "_rms":
+            yield name[:-4], {'rms': True}
+        if name[-4:] == "_med":
+            yield name[:-4], {'median': True}
+        if name[0:2] == "d_":
+            yield name[2:], {'derivative': True}
+
+    def _source_obtainable(self, source_name, derivative=False, **kwargs):
+        """Returns True if the source a profile would be built from can actually be got.
+
+        This is established by asking for it, since nothing cheaper is reliable. Neither
+        ``keys()`` nor ``all_keys()`` is a good guide to what a snapshot can provide: the former
+        lists only what is already in memory, so a 1D slice such as ``vz`` appears only once
+        ``vel`` has been loaded, while the latter reports the names of blocks on disk (``vel``,
+        never ``vz``) alongside derivations which are registered but may still fail when run.
+
+        A derivative is taken of another profile, so for that case the source is looked up here
+        rather than in the snapshot. Anything obtained is left in place for :meth:`_auto_profile`
+        to use. Any failure is kept so that it can be attached to the eventual KeyError."""
+        try:
+            self[source_name] if derivative else self.sim[source_name]
+        except KeyError as e:
+            self._last_array_error = e
+            return False
+        return True
+
+    def _auto_profile(self, name, dispersion=False, rms=False, median=False, derivative=False):
+        if derivative:
+            # a derivative differentiates another profile with respect to radius, rather than
+            # averaging an underlying simulation array over the particles in each bin
             #            if np.diff(self['dr']).all() < 1e-13 :
-            logger.info("Auto-deriving %s/dR" % name)
-            self._profiles[name] = np.gradient(self[name[2:]], self['dr'][0])
-            self._profiles[name] = self._profiles[name] / self['dr'].units
-            return self._profiles[name]
+            underlying = self[name]
+            return np.gradient(underlying, self['dr'][0]) / self['dr'].units
             # else :
             #    raise RuntimeError, "Derivatives only possible for profiles of fixed bin width."
 
-        else:
-            raise KeyError(name + " is not a valid profile")
-
-    def _auto_profile(self, name, dispersion=False, rms=False, median=False):
         result = np.zeros(self.nbins)
 
         with self.sim.immediate_mode:
@@ -962,6 +994,12 @@ class VerticalProfile(Profile):
 
 class QuantileProfile(Profile):
     """A profile object that returns requested quantiles instead of means in each bin.
+
+    .. versionchanged:: 2.6.0
+
+      As for :class:`Profile`, what can be profiled is decided by what the snapshot is able to provide rather than
+      by the names it advertises, so derived arrays and 1D slices of ND arrays are quantiled without having to be
+      computed or loaded in advance.
     """
 
     def __init__(self, sim, q=(0.16, 0.50, 0.84), weights=None, load_from_file = False, ndim = 3, type = 'lin', **kwargs):
@@ -999,13 +1037,13 @@ class QuantileProfile(Profile):
         if name in self._profiles:
             return self._profiles[name]
 
-        elif name in list(self.sim.keys()) or name in self.sim.all_keys():
+        elif self._source_obtainable(name):
             self._profiles[name] = self._auto_profile(name)
             self._profiles[name].sim = self.sim
             return self._profiles[name]
 
         else:
-            raise KeyError(name + " is not a valid QuantileProfile")
+            raise KeyError(name + " is not a valid QuantileProfile") from self._last_array_error
 
     def _auto_profile(self, name, dispersion=False, rms=False, median=False):
         result = np.zeros((self.nbins, len(self.quantiles)))

--- a/pynbody/snapshot/copy_on_access.py
+++ b/pynbody/snapshot/copy_on_access.py
@@ -27,7 +27,7 @@ class CopyOnAccessSimSnap(UnderlyingClassMixin, SimSnap):
     """SimSnap that copies data from another SimSnap when that data is needed.
 
     To the user, data which is already loaded in the underlying snapshot presents merely as 'loadable'
-    (i.e. in loadable_keys)."""
+    (i.e. in :meth:`loadable_keys`)."""
 
     def __init__(self, base: SimSnap, underlying_class=None):
         self._copy_from = base
@@ -63,8 +63,26 @@ class CopyOnAccessSimSnap(UnderlyingClassMixin, SimSnap):
             raise OSError("Not found in underlying snapshot") from e
 
     def loadable_keys(self, fam=None):
+        """Return the names of the arrays that can be copied from the underlying snapshot.
+
+        Only ND arrays are named, not the 1D slices that accompany them: ``vel`` is reported but
+        ``vz`` is not, matching what a snapshot loaded from disk offers. The slices remain
+        accessible, since a request for one is mapped onto its parent when it is loaded.
+
+        .. versionchanged:: 2.6.0
+
+          The 1D slices of ND arrays are no longer reported. Previously, an in-memory ``vel`` in
+          the underlying snapshot caused ``vx``, ``vy`` and ``vz`` to be listed as loadable as
+          well, which no file-backed snapshot does. Code inspecting ``loadable_keys`` to establish
+          what a snapshot can provide consequently got a different answer for a copy-on-access
+          view than for the snapshot it was copying from.
+        """
         if fam is None:
             loaded_keys_in_parent = self._copy_from.keys()
         else:
             loaded_keys_in_parent = self._copy_from.family_keys(fam)
-        return list(set(self._copy_from.loadable_keys(fam)).union(loaded_keys_in_parent))
+        keys = set(self._copy_from.loadable_keys(fam)).union(loaded_keys_in_parent)
+
+        # A 1D name is only dropped when its parent is genuinely present, so that a name which
+        # merely looks like a slice is left alone.
+        return [k for k in keys if self._array_name_1D_to_ND(k) not in keys]

--- a/tests/copy_on_access_test.py
+++ b/tests/copy_on_access_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 import pynbody
@@ -162,3 +163,62 @@ def test_only_try_loading_once():
 
     with pytest.raises(OSError, match="Previously tried"):
         f_c.dm._load_array('nonexistent')
+
+
+def test_loadable_keys_reports_nd_arrays_not_their_slices():
+    """The 1D slices that accompany an in-memory ND array must not be advertised as loadable.
+
+    A file-backed snapshot offers the blocks it stores, i.e. 'vel' but never 'vz', and code that
+    inspects loadable_keys() to decide what a snapshot can provide relies on that.
+    """
+    f = pynbody.new(10)
+    f['pos'] = np.random.normal(size=(10, 3))
+    f['vel'] = np.random.normal(size=(10, 3))
+    f['mass'] = np.ones(10)
+
+    f_c = f.get_copy_on_access_simsnap()
+
+    assert set(f_c.loadable_keys()) == {'pos', 'vel', 'mass'}
+
+
+def test_slices_of_nd_arrays_still_load():
+    """Hiding the slice names from loadable_keys must not stop them being accessible."""
+    f = pynbody.new(10)
+    f['vel'] = np.random.normal(size=(10, 3))
+
+    f_c = f.get_copy_on_access_simsnap()
+    assert 'vz' not in f_c.loadable_keys()
+    assert 'vz' not in f_c.keys()
+
+    npt.assert_allclose(f_c['vz'], f['vel'][:, 2])
+    # asking for the slice brings in the whole parent array
+    assert 'vel' in f_c.keys()
+
+
+def test_loaded_slices_are_views_onto_the_nd_array():
+    """A slice must be a view onto the copy's own ND array, not an independently stored copy.
+
+    Loading is triggered by the slice name here, which is the case most at risk of ending up with
+    'vx' and 'vel' as two unrelated arrays.
+    """
+    f = pynbody.new(10)
+    f['vel'] = np.random.normal(size=(10, 3))
+    original_vel = np.array(f['vel'])
+
+    f_c = f.get_copy_on_access_simsnap()
+    f_c['vx']  # noqa - triggers the load via the slice name rather than the parent
+
+    for i, name in enumerate(['vx', 'vy', 'vz']):
+        assert np.shares_memory(f_c[name], f_c['vel'][:, i])
+
+    # ...and the consequence that actually matters: writes are seen from both directions
+    f_c['vel'][:, 0] = np.arange(10)
+    npt.assert_allclose(f_c['vx'], np.arange(10))
+
+    f_c['vy'] = np.arange(10, 20)
+    npt.assert_allclose(f_c['vel'][:, 1], np.arange(10, 20))
+
+    # the copy remains isolated from the snapshot it copied from, which is the whole point of
+    # copy-on-access: none of those writes may reach the original
+    assert not np.shares_memory(f_c['vel'], f['vel'])
+    npt.assert_allclose(f['vel'], original_vel)

--- a/tests/profile_test.py
+++ b/tests/profile_test.py
@@ -200,3 +200,135 @@ def test_quantile_profile(weight):
         # for where the cdf is 0.16 and 0.84
         expected_width *= 1.8724
     npt.assert_allclose(np.diff(pro['testquantity'], axis=1), expected_width, atol=2.5e-2)
+
+
+def _make_lazy_loading_snapshot(npart=1000):
+    np.random.seed(1337)
+    base = pynbody.new(star=npart)
+    base['pos'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'kpc')
+    base['vel'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'km s^-1')
+    base['mass'] = pynbody.array.SimArray(np.ones(npart), 'Msol')
+    return base.get_copy_on_access_simsnap()
+
+
+@pytest.fixture
+def lazy_loading_snapshot():
+    """A snapshot which lazily copies its arrays from another, as a file-backed one would.
+
+    Like a real loader, it advertises ``vel`` rather than ``vz`` in loadable_keys(), and nothing
+    is in memory until it is asked for."""
+    return _make_lazy_loading_snapshot()
+
+
+@pytest.fixture
+def preloaded_snapshot():
+    """The same snapshot, but with the velocities already pulled into memory."""
+    f = _make_lazy_loading_snapshot()
+    f['vel']
+    return f
+
+
+@pytest.mark.parametrize("name", ['vz', 'vz_disp', 'vz_rms', 'vz_med', 'd_vz'])
+def test_profile_of_1d_slice_without_preloading(name, lazy_loading_snapshot, preloaded_snapshot):
+    """Profiles of 1D slices must not depend on whether the ND array happens to be loaded already.
+
+    See issue #1018: 'vz' is only in keys() once 'vel' is in memory, and loaders advertise 'vel'
+    rather than 'vz' in loadable_keys(), so asking for e.g. 'vz_disp' first used to raise KeyError.
+    """
+    assert 'vel' not in lazy_loading_snapshot.keys()
+
+    p_lazy = pynbody.analysis.profile.Profile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    p_preloaded = pynbody.analysis.profile.Profile(preloaded_snapshot, rmin=0, rmax=3, nbins=5)
+
+    npt.assert_allclose(p_lazy[name], p_preloaded[name])
+
+
+def test_quantile_profile_of_1d_slice_without_preloading(lazy_loading_snapshot, preloaded_snapshot):
+    p_lazy = pynbody.analysis.profile.QuantileProfile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    p_preloaded = pynbody.analysis.profile.QuantileProfile(preloaded_snapshot, rmin=0, rmax=3, nbins=5)
+
+    npt.assert_allclose(p_lazy['vz'], p_preloaded['vz'])
+
+
+def test_profile_still_rejects_unknown_arrays(lazy_loading_snapshot):
+    p = pynbody.analysis.profile.Profile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    for name in ['nonsense', 'nonsense_disp', 'nonsense_rms', 'nonsense_med', 'nonsense_x',
+                 'd_nonsense']:
+        with pytest.raises(KeyError):
+            p[name]
+
+
+def _make_bin_centred_snapshot(nbins=10, rmax=10.0, per_bin=20):
+    """A snapshot whose particles sit exactly at the centre of each radial bin.
+
+    Placing them this way makes the average of a quantity within a bin an exact function of that
+    bin's centre, so a profile built from a linear quantity is itself exactly linear and its
+    radial derivative is known analytically."""
+    centres = (np.arange(nbins) + 0.5) * (rmax / nbins)
+    r = np.repeat(centres, per_bin)
+
+    pos = np.zeros((len(r), 3))
+    pos[:, 0] = r
+
+    f = pynbody.new(star=len(r))
+    f['pos'] = pynbody.array.SimArray(pos, 'kpc')
+    f['mass'] = pynbody.array.SimArray(np.ones(len(r)), 'Msol')
+    f['myquantity'] = pynbody.array.SimArray(3.0 * r + 7.0, 'km s^-1')
+    return f, centres
+
+
+def test_derivative_of_array_profile():
+    """``d_<name>`` differentiates the ``<name>`` profile with respect to radius."""
+    nbins, rmax = 10, 10.0
+    f, centres = _make_bin_centred_snapshot(nbins=nbins, rmax=rmax)
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=rmax, nbins=nbins, ndim=3)
+
+    # the profile of 3r + 7 is exactly 3r + 7 at the bin centres, so its gradient is exactly 3
+    npt.assert_allclose(p['myquantity'], 3.0 * centres + 7.0)
+    npt.assert_allclose(p['d_myquantity'], 3.0)
+    assert p['d_myquantity'].units == p['myquantity'].units / p['dr'].units
+
+
+def test_derivative_of_registered_profile():
+    """A derivative may also be taken of a profile that is not backed by a snapshot array."""
+    nbins, rmax, per_bin = 10, 10.0, 20
+    f, _ = _make_bin_centred_snapshot(nbins=nbins, rmax=rmax, per_bin=per_bin)
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=rmax, nbins=nbins, ndim=3)
+
+    # every bin holds the same mass, so the enclosed mass rises linearly and its gradient is that
+    # mass divided by the bin width
+    dr = rmax / nbins
+    npt.assert_allclose(p['mass_enc'], per_bin * (np.arange(nbins) + 1.0))
+    npt.assert_allclose(p['d_mass_enc'], per_bin / dr)
+    assert p['d_mass_enc'].units == p['mass_enc'].units / p['dr'].units
+
+
+class _BrokenDerivationSnap(pynbody.snapshot.simsnap.SimSnap):
+    pass
+
+
+@_BrokenDerivationSnap.derived_array
+def broken(sim):
+    return sim['no_such_array'] * 2
+
+
+def test_profile_reports_why_a_registered_derivation_failed():
+    """A name can be registered as derivable and still fail when the derivation is actually run.
+
+    Availability is therefore established by asking for the array; when that fails the underlying
+    reason must not be swallowed by the generic 'not a valid profile' message.
+    """
+    npart = 100
+    f = pynbody.new(star=npart, class_=_BrokenDerivationSnap)
+    f['pos'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'kpc')
+    f['mass'] = pynbody.array.SimArray(np.ones(npart), 'Msol')
+
+    assert 'broken' in f.all_keys()  # registered, so a name-based check would think it available
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=3, nbins=5)
+    for name in ['broken', 'broken_disp']:
+        with pytest.raises(KeyError) as excinfo:
+            p[name]
+        assert 'no_such_array' in str(excinfo.value) + str(excinfo.value.__cause__)


### PR DESCRIPTION
Fixes #1018 (via #1020, now merged into this branch — see the note at the end).

`CopyOnAccessSimSnap` presents the arrays held by another snapshot as loadable. It built that list by unioning the parent's `loadable_keys()` with its `keys()` — and the latter contains the 1D slices that accompany every ND array, since `_create_array('vel', ndim=3)` also registers `vx`, `vy` and `vz` in `_arrays`.

The copy therefore advertised `vz` as loadable, which no file-backed snapshot ever does — those report the blocks they actually store, i.e. `vel` alone:

```python
f = pynbody.new(10)
f['pos'] = ...; f['vel'] = ...; f['mass'] = ...

f.get_copy_on_access_simsnap().loadable_keys()
# before: ['mass', 'pos', 'vel', 'vx', 'vy', 'vz', 'x', 'y', 'z']
# after:  ['mass', 'pos', 'vel']
```

That divergence matters because code which inspects `loadable_keys()` to work out what a snapshot can provide gets a different answer depending on whether it is looking at a real loader or a copy-on-access view — so a bug that shows up with one is invisible with the other.

## The change

Report just the ND parents. The slices remain fully accessible: a request for one is mapped onto its parent by `_load_array_and_perform_postprocessing`, so `f_c['vz']` still works and pulls in `vel`.

A 1D name is only dropped when its parent is genuinely present in the key set, so a name that merely looks like a slice is left alone. This mirrors the guard already documented in `SimSnap._array_name_implies_ND_slice`.

## Tests

Three regression tests in `copy_on_access_test.py`, all failing on `master` and passing here:

- `loadable_keys()` reports exactly `{pos, vel, mass}` rather than the nine names including slices
- slices still load, and asking for one brings its parent into memory
- a loaded slice is a *view* onto the copy's own ND array rather than a separately stored copy — `np.shares_memory(f_c['vx'], f_c['vel'][:, 0])`, with write-through checked in both directions, and the copy still isolated from the snapshot it copied from

None of them need downloaded test data.

## What this branch now contains

#1020 has been merged into this branch, so the diff here is both changes:

1. this one — `CopyOnAccessSimSnap.loadable_keys` reporting only ND parents
2. **the fix for #1018** — `Profile`/`QuantileProfile` deciding what can be profiled by asking the snapshot rather than looking the name up in `keys`/`all_keys`, so `p['vz_disp']` no longer depends on whether `vel` happens to have been loaded

Because #1020 merged into this branch rather than into `master`, its `Fixes #1018` will not close the issue on its own; the reference at the top of this description covers that when this PR lands.

Both were green across the full 24-check matrix before the merge, and a separate follow-up is filed as #1021.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GarVS1YfVbDnWMuDKrXcTC)_