### PR TITLE
Fix profiles of 1D array slices when the ND array is not yet loaded

### DIFF
--- a/pynbody/analysis/profile.py
+++ b/pynbody/analysis/profile.py
@@ -39,7 +39,8 @@ class Profile:
     can be accessed as ``p['ar']`` where ``p`` is a ``Profile`` object. For example, ``p['vr']`` gives
     the radial velocity profile. Implicitly, this is averaged over all particles in each bin,
     weighted by mass (unless an alternate weighting scheme is passed to the ``weight_by`` keyword argument of the
-    constructor).
+    constructor). Individual components of an ND array may be profiled in the same way, e.g. ``p['vz']`` gives
+    the profile of the z-component of ``vel``.
 
     **Dispersions**: One may append ``_rms`` or ``_disp`` to the name of a
     defined array to get the root-mean-square or dispersion profile, respectively. For example,
@@ -64,6 +65,15 @@ class Profile:
     looking at the same set of particles, centered in the same way. It also means you *must* use the same centering
     method if you want to reuse a saved profile.
 
+    .. versionchanged:: 2.6.0
+
+      What can be profiled is now decided by what the snapshot is actually able to provide, rather than by whether
+      the name appears in ``keys`` or ``all_keys``. Nothing has to be loaded or derived in advance. In particular,
+      a derived array is profiled whenever the snapshot knows how to derive it, and a 1D slice of an ND array is
+      profiled whenever the parent array is available: ``p['vz']`` and ``p['vz_disp']`` now work on a freshly loaded
+      snapshot, where previously they raised ``KeyError`` unless something had already touched the velocities,
+      because a loader offers ``vel`` rather than ``vz``.
+
     .. versionchanged:: 2.0
 
       The method ``create_particle_array`` has been removed. Its behaviour was poorly defined in v1, and not believed
@@ -72,6 +82,10 @@ class Profile:
     """
 
     _profile_registry = {}
+
+    # the failure from the most recent attempt to get an underlying simulation array, used
+    # to explain why a profile could not be constructed
+    _last_array_error = None
 
     def _calculate_x(self, sim):
         if self._x_calculator is not None:
@@ -282,43 +296,61 @@ class Profile:
                 pass
             return self._profiles[name]
 
-        elif name in list(self.sim.keys()) or name in self.sim.all_keys():
-            self._profiles[name] = self._auto_profile(name)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
-
-        elif name[-5:] == "_disp" and (name[:-5] in list(self.sim.keys()) or name[:-5] in self.sim.all_keys()):
+        for source_name, kwargs in self._auto_profile_candidates(name):
+            if not self._source_obtainable(source_name, **kwargs):
+                continue
             logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(
-                name[:-5], dispersion=True)
+            self._profiles[name] = self._auto_profile(source_name, **kwargs)
             self._profiles[name].sim = self.sim
             return self._profiles[name]
 
-        elif name[-4:] == "_rms" and (name[:-4] in list(self.sim.keys()) or name[:-4] in self.sim.all_keys()):
-            logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(name[:-4], rms=True)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
+        raise KeyError(name + " is not a valid profile") from self._last_array_error
 
-        elif name[-4:] == "_med" and (name[:-4] in list(self.sim.keys()) or name[:-4] in self.sim.all_keys()):
-            logger.info("Auto-deriving %s" % name)
-            self._profiles[name] = self._auto_profile(name[:-4], median=True)
-            self._profiles[name].sim = self.sim
-            return self._profiles[name]
+    @staticmethod
+    def _auto_profile_candidates(name):
+        """Yield the (source name, :meth:`_auto_profile` options) pairs that *name* could be built from.
 
-        elif name[0:2] == "d_" and (name[2:] in list(self.keys()) or name[2:] in self.derivable_keys() or name[2:] in self.sim.all_keys()):
+        A source of exactly this name takes precedence over any interpretation of a trailing
+        ``_disp``, ``_rms`` or ``_med``, or of a leading ``d_``."""
+        yield name, {}
+        if name[-5:] == "_disp":
+            yield name[:-5], {'dispersion': True}
+        if name[-4:] == "_rms":
+            yield name[:-4], {'rms': True}
+        if name[-4:] == "_med":
+            yield name[:-4], {'median': True}
+        if name[0:2] == "d_":
+            yield name[2:], {'derivative': True}
+
+    def _source_obtainable(self, source_name, derivative=False, **kwargs):
+        """Returns True if the source a profile would be built from can actually be got.
+
+        This is established by asking for it, since nothing cheaper is reliable. Neither
+        ``keys()`` nor ``all_keys()`` is a good guide to what a snapshot can provide: the former
+        lists only what is already in memory, so a 1D slice such as ``vz`` appears only once
+        ``vel`` has been loaded, while the latter reports the names of blocks on disk (``vel``,
+        never ``vz``) alongside derivations which are registered but may still fail when run.
+
+        A derivative is taken of another profile, so for that case the source is looked up here
+        rather than in the snapshot. Anything obtained is left in place for :meth:`_auto_profile`
+        to use. Any failure is kept so that it can be attached to the eventual KeyError."""
+        try:
+            self[source_name] if derivative else self.sim[source_name]
+        except KeyError as e:
+            self._last_array_error = e
+            return False
+        return True
+
+    def _auto_profile(self, name, dispersion=False, rms=False, median=False, derivative=False):
+        if derivative:
+            # a derivative differentiates another profile with respect to radius, rather than
+            # averaging an underlying simulation array over the particles in each bin
             #            if np.diff(self['dr']).all() < 1e-13 :
-            logger.info("Auto-deriving %s/dR" % name)
-            self._profiles[name] = np.gradient(self[name[2:]], self['dr'][0])
-            self._profiles[name] = self._profiles[name] / self['dr'].units
-            return self._profiles[name]
+            underlying = self[name]
+            return np.gradient(underlying, self['dr'][0]) / self['dr'].units
             # else :
             #    raise RuntimeError, "Derivatives only possible for profiles of fixed bin width."
 
-        else:
-            raise KeyError(name + " is not a valid profile")
-
-    def _auto_profile(self, name, dispersion=False, rms=False, median=False):
         result = np.zeros(self.nbins)
 
         with self.sim.immediate_mode:
@@ -962,6 +994,12 @@ class VerticalProfile(Profile):
 
 class QuantileProfile(Profile):
     """A profile object that returns requested quantiles instead of means in each bin.
+
+    .. versionchanged:: 2.6.0
+
+      As for :class:`Profile`, what can be profiled is decided by what the snapshot is able to provide rather than
+      by the names it advertises, so derived arrays and 1D slices of ND arrays are quantiled without having to be
+      computed or loaded in advance.
     """
 
     def __init__(self, sim, q=(0.16, 0.50, 0.84), weights=None, load_from_file = False, ndim = 3, type = 'lin', **kwargs):
@@ -999,13 +1037,13 @@ class QuantileProfile(Profile):
         if name in self._profiles:
             return self._profiles[name]
 
-        elif name in list(self.sim.keys()) or name in self.sim.all_keys():
+        elif self._source_obtainable(name):
             self._profiles[name] = self._auto_profile(name)
             self._profiles[name].sim = self.sim
             return self._profiles[name]
 
         else:
-            raise KeyError(name + " is not a valid QuantileProfile")
+            raise KeyError(name + " is not a valid QuantileProfile") from self._last_array_error
 
     def _auto_profile(self, name, dispersion=False, rms=False, median=False):
         result = np.zeros((self.nbins, len(self.quantiles)))

--- a/tests/profile_test.py
+++ b/tests/profile_test.py
@@ -200,3 +200,135 @@ def test_quantile_profile(weight):
         # for where the cdf is 0.16 and 0.84
         expected_width *= 1.8724
     npt.assert_allclose(np.diff(pro['testquantity'], axis=1), expected_width, atol=2.5e-2)
+
+
+def _make_lazy_loading_snapshot(npart=1000):
+    np.random.seed(1337)
+    base = pynbody.new(star=npart)
+    base['pos'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'kpc')
+    base['vel'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'km s^-1')
+    base['mass'] = pynbody.array.SimArray(np.ones(npart), 'Msol')
+    return base.get_copy_on_access_simsnap()
+
+
+@pytest.fixture
+def lazy_loading_snapshot():
+    """A snapshot which lazily copies its arrays from another, as a file-backed one would.
+
+    Like a real loader, it advertises ``vel`` rather than ``vz`` in loadable_keys(), and nothing
+    is in memory until it is asked for."""
+    return _make_lazy_loading_snapshot()
+
+
+@pytest.fixture
+def preloaded_snapshot():
+    """The same snapshot, but with the velocities already pulled into memory."""
+    f = _make_lazy_loading_snapshot()
+    f['vel']
+    return f
+
+
+@pytest.mark.parametrize("name", ['vz', 'vz_disp', 'vz_rms', 'vz_med', 'd_vz'])
+def test_profile_of_1d_slice_without_preloading(name, lazy_loading_snapshot, preloaded_snapshot):
+    """Profiles of 1D slices must not depend on whether the ND array happens to be loaded already.
+
+    See issue #1018: 'vz' is only in keys() once 'vel' is in memory, and loaders advertise 'vel'
+    rather than 'vz' in loadable_keys(), so asking for e.g. 'vz_disp' first used to raise KeyError.
+    """
+    assert 'vel' not in lazy_loading_snapshot.keys()
+
+    p_lazy = pynbody.analysis.profile.Profile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    p_preloaded = pynbody.analysis.profile.Profile(preloaded_snapshot, rmin=0, rmax=3, nbins=5)
+
+    npt.assert_allclose(p_lazy[name], p_preloaded[name])
+
+
+def test_quantile_profile_of_1d_slice_without_preloading(lazy_loading_snapshot, preloaded_snapshot):
+    p_lazy = pynbody.analysis.profile.QuantileProfile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    p_preloaded = pynbody.analysis.profile.QuantileProfile(preloaded_snapshot, rmin=0, rmax=3, nbins=5)
+
+    npt.assert_allclose(p_lazy['vz'], p_preloaded['vz'])
+
+
+def test_profile_still_rejects_unknown_arrays(lazy_loading_snapshot):
+    p = pynbody.analysis.profile.Profile(lazy_loading_snapshot, rmin=0, rmax=3, nbins=5)
+    for name in ['nonsense', 'nonsense_disp', 'nonsense_rms', 'nonsense_med', 'nonsense_x',
+                 'd_nonsense']:
+        with pytest.raises(KeyError):
+            p[name]
+
+
+def _make_bin_centred_snapshot(nbins=10, rmax=10.0, per_bin=20):
+    """A snapshot whose particles sit exactly at the centre of each radial bin.
+
+    Placing them this way makes the average of a quantity within a bin an exact function of that
+    bin's centre, so a profile built from a linear quantity is itself exactly linear and its
+    radial derivative is known analytically."""
+    centres = (np.arange(nbins) + 0.5) * (rmax / nbins)
+    r = np.repeat(centres, per_bin)
+
+    pos = np.zeros((len(r), 3))
+    pos[:, 0] = r
+
+    f = pynbody.new(star=len(r))
+    f['pos'] = pynbody.array.SimArray(pos, 'kpc')
+    f['mass'] = pynbody.array.SimArray(np.ones(len(r)), 'Msol')
+    f['myquantity'] = pynbody.array.SimArray(3.0 * r + 7.0, 'km s^-1')
+    return f, centres
+
+
+def test_derivative_of_array_profile():
+    """``d_<name>`` differentiates the ``<name>`` profile with respect to radius."""
+    nbins, rmax = 10, 10.0
+    f, centres = _make_bin_centred_snapshot(nbins=nbins, rmax=rmax)
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=rmax, nbins=nbins, ndim=3)
+
+    # the profile of 3r + 7 is exactly 3r + 7 at the bin centres, so its gradient is exactly 3
+    npt.assert_allclose(p['myquantity'], 3.0 * centres + 7.0)
+    npt.assert_allclose(p['d_myquantity'], 3.0)
+    assert p['d_myquantity'].units == p['myquantity'].units / p['dr'].units
+
+
+def test_derivative_of_registered_profile():
+    """A derivative may also be taken of a profile that is not backed by a snapshot array."""
+    nbins, rmax, per_bin = 10, 10.0, 20
+    f, _ = _make_bin_centred_snapshot(nbins=nbins, rmax=rmax, per_bin=per_bin)
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=rmax, nbins=nbins, ndim=3)
+
+    # every bin holds the same mass, so the enclosed mass rises linearly and its gradient is that
+    # mass divided by the bin width
+    dr = rmax / nbins
+    npt.assert_allclose(p['mass_enc'], per_bin * (np.arange(nbins) + 1.0))
+    npt.assert_allclose(p['d_mass_enc'], per_bin / dr)
+    assert p['d_mass_enc'].units == p['mass_enc'].units / p['dr'].units
+
+
+class _BrokenDerivationSnap(pynbody.snapshot.simsnap.SimSnap):
+    pass
+
+
+@_BrokenDerivationSnap.derived_array
+def broken(sim):
+    return sim['no_such_array'] * 2
+
+
+def test_profile_reports_why_a_registered_derivation_failed():
+    """A name can be registered as derivable and still fail when the derivation is actually run.
+
+    Availability is therefore established by asking for the array; when that fails the underlying
+    reason must not be swallowed by the generic 'not a valid profile' message.
+    """
+    npart = 100
+    f = pynbody.new(star=npart, class_=_BrokenDerivationSnap)
+    f['pos'] = pynbody.array.SimArray(np.random.normal(size=(npart, 3)), 'kpc')
+    f['mass'] = pynbody.array.SimArray(np.ones(npart), 'Msol')
+
+    assert 'broken' in f.all_keys()  # registered, so a name-based check would think it available
+
+    p = pynbody.analysis.profile.Profile(f, rmin=0, rmax=3, nbins=5)
+    for name in ['broken', 'broken_disp']:
+        with pytest.raises(KeyError) as excinfo:
+            p[name]
+        assert 'no_such_array' in str(excinfo.value) + str(excinfo.value.__cause__)


### PR DESCRIPTION
Fixes #1018. **Stacked on #1019** — review that one first; this PR targets its branch, so the diff shown here is just the profile change.

## The bug

`Profile._get_profile` decided whether a name referred to a real array by testing it against `sim.keys()` and `sim.all_keys()`. Neither reports the 1D slice names of an ND array unless that array is already in memory:

- `keys()` returns `_arrays.keys()`. `_create_array('vel', ndim=3)` does register `vx`/`vy`/`vz` alongside `vel` — but only once `vel` has been created.
- `loadable_keys()` reports the blocks on disk: `['pos', 'vel', 'mass']`, never `vz`.

So on a freshly loaded snapshot `vz` matched nothing:

```
KeyError: 'vz_disp is not a valid profile'
```

Touch the velocities first and the same call works. Reproduced on a Gadget-2 file matching the reporter's setup:

```
loadable_keys: ['pos', 'vel', 'mass']
'vz' in all_keys: False | 'vz' in keys: False
  vz_disp: FAILED -> 'vz_disp is not a valid profile'
--- with vel preloaded ---
  vz_disp: OK [0.91654175 1.00766647]
```

Two details worth noting:

- **It is format-dependent.** Tipsy stores pos and vel in one record, so loading either loads both and the bug never appears there. The reporter's `.g2` is Gadget-2, which loads blocks independently.
- **It is not just `_disp`.** Plain `p['vz']`, `vz_rms`, `vz_med`, `d_vz` and `QuantileProfile` all failed the same way. The reporter's `p['x']` would have worked, but only incidentally — building the profile computes `rxy`, which loads `pos`.

## The fix

Availability is now established by asking the simulation for the array rather than guessing from its name. `keys()`/`all_keys()` are unreliable in a third way too: a name in `derivable_keys()` is merely *registered*, so the derivation may still fail when it is actually run.

`_get_profile` enumerates the array names a profile name could be built from — the exact name first, then the `_disp`/`_rms`/`_med` interpretations — and tries each. Nothing is wasted: the probed array stays in memory for `_auto_profile`, which was going to fetch it anyway. The `d_` branch likewise just tries `self[name[2:]]`, which recurses through `_get_profile` and so covers registered profiles, arrays and suffixes uniformly, replacing three separate name checks.

Because a failure can no longer be distinguished from "not a profile name" by inspection, the underlying error is attached to the result:

```python
raise KeyError(name + " is not a valid profile") from self._last_array_error
```

This also removes a false positive that a name-based check has: `_array_name_1D_to_ND` guesses `mass_x` is a slice of `mass`, so `p['mass_x']` used to leak `'No array mass_x for family star'` out of a profile lookup. It now correctly reports `'mass_x is not a valid profile'`.

## Trade-off worth flagging

If an array literally named `foo_disp` exists but its derivation raises `KeyError`, the loop now falls back to computing the dispersion of `foo` rather than propagating. That happens only for `KeyError` — the "not available" signal; a derivation failing for a substantive reason (units, bad data) raises something else and propagates as before, and when nothing succeeds the original error is preserved in the chain. Easy to reverse if you would rather the exact-name failure always win.

## Tests

The tests emulate lazy loading with `CopyOnAccessSimSnap`, so they need no downloaded test data — this is what #1019 enables. Each asserts that the lazy and preloaded paths give *identical results*, not merely that nothing raises.

All six `vz` tests fail against `master` with the exact error from the issue, and — importantly for the stack — still fail with #1019 alone:

```
FAIL test_profile_of_1d_slice_without_preloading[vz_disp] -> KeyError 'vz_disp is not a valid profile'
FAIL test_quantile_profile_of_1d_slice_without_preloading -> KeyError 'vz is not a valid QuantileProfile'
```

There is also a test for the registered-but-broken derivation case: a derived array whose dependency does not exist. It is in `all_keys()`, so a name check would call it available; the test asserts the real cause survives into the raised `KeyError`. Removing the `from` clause makes it fail, so the chaining is pinned.

## Verification

Every data-free test in `profile_test.py` (16), `copy_on_access_test.py` (11) and `snapshot_test.py` (18) passes. I could not run the data-backed tests — `api.osf.io` is blocked by this environment's network policy — so CI will be the first full run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GarVS1YfVbDnWMuDKrXcTC)_