### PR TITLE
Report the underlying class's derived arrays in derivable_keys

### DIFF
--- a/pynbody/snapshot/copy_on_access.py
+++ b/pynbody/snapshot/copy_on_access.py
@@ -23,6 +23,21 @@ class UnderlyingClassMixin:
         else:
             return super().find_deriving_function(name)
 
+    def derivable_keys(self):
+        """Returns a list of arrays which can be lazy-evaluated, including those of the underlying class.
+
+        .. versionchanged:: 2.6.0
+
+          Derived arrays belonging to the underlying class are now reported. Previously only the mixed-in
+          class's own MRO was searched, so ``derivable_keys`` disagreed with
+          :meth:`find_deriving_function` about what could be derived. See issue #1021.
+        """
+        res = super().derivable_keys()
+        underlying = self._derived_array_registry.get(self._underlying_class, {})
+        res += [name for name in underlying if name not in res]
+        return res
+
+
 class CopyOnAccessSimSnap(UnderlyingClassMixin, SimSnap):
     """SimSnap that copies data from another SimSnap when that data is needed.
 

--- a/tests/copy_on_access_test.py
+++ b/tests/copy_on_access_test.py
@@ -52,6 +52,30 @@ def test_copy_on_access_subsnap_emulating_class():
 
     assert 'foo' not in f.keys()
 
+
+def test_derivable_keys_includes_underlying_class():
+    """derivable_keys must agree with find_deriving_function about what can be derived.
+
+    See issue #1021: the mixin widens derivation to the emulated class, so a copy-on-access view could
+    derive an array whose name was missing from derivable_keys(), and hence from all_keys().
+    """
+    f = pynbody.new(10, class_=ExampleSnap)
+    f['blob'] = np.arange(10)
+
+    f_sub = f[[2, 3, 4]].get_copy_on_access_simsnap()
+
+    assert f_sub.find_deriving_function('foo') is not None
+    assert 'foo' in f_sub.derivable_keys()
+    assert 'foo' in f_sub.all_keys()
+
+    # the arrays derivable for any SimSnap are still reported
+    assert 'r' in f_sub.derivable_keys()
+
+    # and nothing is invented
+    assert 'not_a_derived_array' not in f_sub.derivable_keys()
+    assert f_sub.derivable_keys().count('foo') == 1
+
+
 def test_copy_on_access_subsnap_emulating_class_two_layers_down():
     f = pynbody.new(10, class_=ExampleSnap)
     f['blob'] = np.arange(10)


### PR DESCRIPTION
Fixes #1021.

`UnderlyingClassMixin` widens derivation to an emulated class — `find_deriving_function` consults `_underlying_class` before falling back to the MRO. `derivable_keys` was never widened to match, and still walked `type(self).__mro__` alone.

An array could therefore be derivable while its name was absent from `derivable_keys()`, and so from `all_keys()`:

```python
f_c.find_deriving_function('foo') is not None   # True
'foo' in f_c.derivable_keys()                   # False
f_c['foo']                                      # works
```

Callers that inspect `all_keys()` to work out what a snapshot can supply got the wrong answer for a copy-on-access view, and silently so, since asking for the array outright still worked. `Profile._get_profile` used to be one such caller — that is how this surfaced, during review of #1020.

## The change

Report the union of the MRO registrations and the underlying class's, mirroring `find_deriving_function`. Existing entries keep their order and the extra names are appended, so nothing that was reported before moves or disappears.

Before and after, for a derived array that has never been touched:

```
                     all_keys  derivable      all_keys (this PR)
plain                True      True           True
family subsnap .s    True      True           True
indexed subsnap      True      True           True
copy-on-access       False     True           True
coa family .s        False     True           True
```

## Tests

One regression test in `copy_on_access_test.py`, reusing the existing `ExampleSnap`/`foo` fixtures. It fails on `master` and passes here: `derivable_keys()` and `find_deriving_function` agree for a copy-on-access view, and `foo` reaches `all_keys()`. It also checks the generic `SimSnap` derivations are still listed, that nothing is invented, and that `foo` is not reported twice.

It needs no downloaded test data.

## Verification

`api.osf.io` is blocked in this environment, so I ran the affected modules under pytest from copies with the module-scoped `get_data` fixture stripped, using this repo's `filterwarnings` config so warnings are errors:

```
test_x_copy_on_access_test.py  test_x_snapshot_test.py
test_x_profile_test.py         test_x_derived_arrays_test.py
```

Every failure was `OSError: File 'testdata/gasoline_ahf/...' does not exist` — the missing download, not this change. CI has since run the full matrix green on `9277bef`, including those data-backed tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GarVS1YfVbDnWMuDKrXcTC)_