### PR TITLE
Parallelise the whole kdtree build, not just its lower levels

### DIFF
--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -182,7 +182,7 @@ class KDTree:
         num_threads : int, optional
             Number of threads to use when building tree (if None, use configured/detected number of processors).
 
-            .. versionchanged:: 2.7.0
+            .. versionchanged:: 2.6.0
                 Any number of threads is now used in full. Previously the build
                 rounded this down to a power of two, and spent the early part of
                 the build on fewer threads than requested. Building with more
@@ -229,6 +229,10 @@ class KDTree:
     def _set_num_threads(self, num_threads):
         if num_threads is None:
             num_threads = int(config["number_of_threads"])
+        num_threads = int(num_threads)
+        if num_threads < 1:
+            raise ValueError(
+                f"Number of threads must be at least one, not {num_threads}")
         self.num_threads = num_threads
         return num_threads
 

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -181,17 +181,29 @@ class KDTree:
             Boxsize (default None)
         num_threads : int, optional
             Number of threads to use when building tree (if None, use configured/detected number of processors).
+
+            .. versionchanged:: 2.7.0
+                Any number of threads is now used in full. Previously the build
+                rounded this down to a power of two, and spent the early part of
+                the build on fewer threads than requested. Building with more
+                than one thread temporarily needs one extra ``intp`` per
+                particle while the top of the tree is laid out.
+
+            .. note::
+                The tree does not depend on ``num_threads`` unless particles
+                share a coordinate value exactly. Where they do, which of them
+                ends up on each side of a split is not defined, so the tree --
+                while still correct -- may differ from one thread count to
+                another. Exact ties are common in single precision positions
+                once there are more than a few hundred thousand particles, and
+                essentially absent in double precision. Build with
+                ``num_threads=1`` if you need a bit-for-bit reproducible tree
+                from single precision positions.
         shared_mem : bool, optional
             Whether to keep kdtree in shared memory so that it can be shared between processes (default False).
         """
 
         num_threads = self._set_num_threads(num_threads)
-
-        # get a power of 2 for num_threads to pass to the constructor, because
-        # otherwise the workload will not be balanced across threads and they
-        # will be wasted
-        num_threads_init = 2 ** int(np.log2(num_threads))
-
 
         self.leafsize = int(leafsize)
         self.kdtree = kdmain.init(pos, mass, self.leafsize)
@@ -208,7 +220,7 @@ class KDTree:
             self.kdnodes = np.zeros(nodes, dtype=KDNode)
             self.particle_offsets = np.empty(len(pos), dtype=np.intp)
 
-        kdmain.build(self.kdtree, self.kdnodes, self.particle_offsets, num_threads_init)
+        kdmain.build(self.kdtree, self.kdnodes, self.particle_offsets, num_threads)
 
         self.boxsize = boxsize
         self._pos = pos

--- a/pynbody/kdtree/__init__.py
+++ b/pynbody/kdtree/__init__.py
@@ -186,8 +186,12 @@ class KDTree:
                 Any number of threads is now used in full. Previously the build
                 rounded this down to a power of two, and spent the early part of
                 the build on fewer threads than requested. Building with more
-                than one thread temporarily needs one extra ``intp`` per
-                particle while the top of the tree is laid out.
+                than one thread temporarily allocates one extra ``intp`` per
+                particle while the top of the tree is laid out. That is freed
+                before the node array fills up, so the effect on peak memory
+                is smaller than the allocation and is often nothing at all;
+                past a million or so particles it adds at most 3 bytes per
+                particle.
 
             .. note::
                 The tree does not depend on ``num_threads`` unless particles

--- a/pynbody/kdtree/kd.cpp
+++ b/pynbody/kdtree/kd.cpp
@@ -1,14 +1,16 @@
+#include <algorithm>
 #include <assert.h>
+#include <atomic>
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <memory>
 #include <stdlib.h>
-#include <thread>
+#include <vector>
 
 #define NO_IMPORT_ARRAY
 #include "kd.h"
-
-#define MAX_ROOT_ITTR 32
-
+#include "threadpool.h"
 
 void kdCombine(KDNode *p1, KDNode *p2, KDNode *pOut) {
   int j;
@@ -28,6 +30,11 @@ void kdCombine(KDNode *p1, KDNode *p2, KDNode *pOut) {
   }
 }
 
+/*
+ ** Partition p[l..r] about the k'th smallest particle in dimension d, so that
+ ** everything at or below k lies on the low side of it and everything above k
+ ** on the high side.
+ */
 template <typename T>
 void kdSelect(KDContext* kd, npy_intp d, npy_intp k, npy_intp l, npy_intp r) {
   npy_intp *p, t;
@@ -79,6 +86,12 @@ template <typename T> void kdUpPass(KDContext* kd, npy_intp iCell) {
   } else {
     l = c[iCell].pLower;
     u = c[iCell].pUpper;
+    // Which particles land in this leaf does not depend on how the build was
+    // shared out between threads, but the order the partitioning leaves them
+    // in does. Sorting settles it, so that particleOffsets comes out the same
+    // whatever num_threads was, and has the loop below walk the position
+    // array in ascending order.
+    std::sort(kd->particleOffsets + l, kd->particleOffsets + u + 1);
     for (j = 0; j < 3; ++j) {
       c[iCell].bnd.fMin[j] = GET2<T>(kd->pNumpyPos, kd->particleOffsets[u], j);
       c[iCell].bnd.fMax[j] = c[iCell].bnd.fMin[j];
@@ -110,33 +123,275 @@ void kdCountNodes(KDContext *kd) {
   kd->nNodes = l << 1;
 }
 
-template <typename T> void kdBuildTree(KDContext* kd, int num_threads) {
-  npy_intp i, j;
-  T rj;
+/*
+ ** Work out how node iCell should be split, or return false if it is a leaf.
+ ** On success d is the splitting dimension and m the index of the median
+ ** particle within the node's range.
+ */
+static bool kdPrepareSplit(KDContext *kd, npy_intp iCell, npy_intp &d, npy_intp &m) {
+  KDNode *nodes = kd->kdNodes;
+  assert(nodes[iCell].pUpper - nodes[iCell].pLower + 1 > 0);
+  if (!(iCell < kd->nSplit && (nodes[iCell].pUpper - nodes[iCell].pLower) > 0)) {
+    nodes[iCell].iDim = -1;
+    return false;
+  }
+
+  // Select splitting dimension on the basis of keeping things as square as
+  // possible
+  d = 0;
+  for (npy_intp j = 1; j < 3; ++j) {
+    if (nodes[iCell].bnd.fMax[j] - nodes[iCell].bnd.fMin[j] >
+        nodes[iCell].bnd.fMax[d] - nodes[iCell].bnd.fMin[d])
+      d = j;
+  }
+  nodes[iCell].iDim = d;
+
+  // Find mid-point of particle list at which splitting will ultimately take
+  // place
+  m = (nodes[iCell].pLower + nodes[iCell].pUpper) / 2;
+  return true;
+}
+
+/*
+ ** Record the split of node iCell and set up its two children. The particle
+ ** list must already have been partitioned about m (see kdSelect).
+ */
+template <typename T>
+static void kdRecordSplit(KDContext *kd, npy_intp iCell, npy_intp d, npy_intp m) {
+  KDNode *nodes = kd->kdNodes;
+
+  // Note split point based on median particle
+  nodes[iCell].fSplit = GET2<T>(kd->pNumpyPos, kd->particleOffsets[m], d);
+
+  // Set up lower cell
+  nodes[LOWER(iCell)].bnd = nodes[iCell].bnd;
+  nodes[LOWER(iCell)].bnd.fMax[d] = nodes[iCell].fSplit;
+  nodes[LOWER(iCell)].pLower = nodes[iCell].pLower;
+  nodes[LOWER(iCell)].pUpper = m;
+
+  // Set up upper cell
+  nodes[UPPER(iCell)].bnd = nodes[iCell].bnd;
+  nodes[UPPER(iCell)].bnd.fMin[d] = nodes[iCell].fSplit;
+  nodes[UPPER(iCell)].pLower = m + 1;
+  nodes[UPPER(iCell)].pUpper = nodes[iCell].pUpper;
+
+  npy_intp diff = (m - nodes[iCell].pLower + 1) - (nodes[iCell].pUpper - m);
+  assert(diff == 0 || diff == 1);
+  (void)diff;
+}
+
+/* Bounding box of particles at offsets [begin, end). */
+template <typename T>
+static Boundary kdBounds(KDContext *kd, npy_intp begin, npy_intp end) {
   Boundary bnd;
+  for (npy_intp j = 0; j < 3; ++j) {
+    bnd.fMin[j] = HUGE_VAL;
+    bnd.fMax[j] = -HUGE_VAL;
+  }
+  for (npy_intp i = begin; i < end; ++i) {
+    for (npy_intp j = 0; j < 3; ++j) {
+      T rj = GET2<T>(kd->pNumpyPos, kd->particleOffsets[i], j);
+      if (rj < bnd.fMin[j])
+        bnd.fMin[j] = rj;
+      if (rj > bnd.fMax[j])
+        bnd.fMax[j] = rj;
+    }
+  }
+  return bnd;
+}
 
+static void kdExpandBounds(Boundary &bnd, const Boundary &other) {
+  for (npy_intp j = 0; j < 3; ++j) {
+    if (other.fMin[j] < bnd.fMin[j])
+      bnd.fMin[j] = other.fMin[j];
+    if (other.fMax[j] > bnd.fMax[j])
+      bnd.fMax[j] = other.fMax[j];
+  }
+}
+
+/*
+ ** Scratch space for a selection that all threads work on together. The buffer
+ ** holds the partitioned copy of the range being worked on, and is therefore
+ ** as long as the particle list; it is only allocated while the top of the
+ ** tree is being built (see kdBuildTree).
+ */
+namespace {
+struct SelectWorkspace {
+  std::unique_ptr<npy_intp[]> buffer; // deliberately left uninitialised
+  std::vector<npy_intp> nBelow, nEqual, nAbove; // per-rank counts
+};
+} // namespace
+
+static inline uint64_t kdRandom(uint64_t &state) {
+  // splitmix64; we only need something cheap that doesn't resonate with
+  // regular particle grids
+  state += 0x9e3779b97f4a7c15ull;
+  uint64_t z = state;
+  z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+  z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+  return z ^ (z >> 31);
+}
+
+/*
+ ** As kdSelect, but with every thread in the pool working on the same range.
+ **
+ ** The range is repeatedly partitioned three ways about a sampled pivot ---
+ ** below it, equal to it, above it --- with each thread responsible for a
+ ** contiguous block: every thread counts its own block, the counts are
+ ** combined to tell each thread where to write, and each thread then copies
+ ** its block into the shared buffer. Only the part of the range that still
+ ** contains the median is carried into the next iteration, so this converges
+ ** in a handful of passes, and the range is down to the serial kdSelect long
+ ** before the synchronisation cost becomes comparable to the work done
+ ** between barriers.
+ **
+ ** The pivot is one of the particles in the range, so the equal block is never
+ ** empty and the range therefore strictly shrinks each time round. If the
+ ** median falls inside the equal block there is nothing left to decide: every
+ ** particle there shares the split coordinate.
+ */
+template <typename T>
+static void kdSelectCooperative(KDContext *kd, ThreadPool &pool,
+                                SelectWorkspace &ws, npy_intp d, npy_intp k,
+                                npy_intp l, npy_intp r) {
+  const npy_intp MIN_COOPERATIVE_RANGE = 1 << 14;
+  const int nThreads = pool.size();
+  npy_intp *p = kd->particleOffsets;
+  npy_intp *buffer = ws.buffer.get();
+  uint64_t rng = 0x5eed5eed5eed5eedull ^ (uint64_t)l ^ ((uint64_t)r << 20) ^
+                 ((uint64_t)d << 40);
+
+  while (r - l > MIN_COOPERATIVE_RANGE) {
+    // Pivot from a small random sample, aimed at the rank we actually want.
+    // Sampling at random rather than at a fixed stride matters for particles
+    // laid out on a grid, where a stride can hit the same coordinate every time.
+    const int nSample = 63;
+    T sample[nSample];
+    for (int i = 0; i < nSample; ++i)
+      sample[i] = GET2<T>(kd->pNumpyPos,
+                          p[l + (npy_intp)(kdRandom(rng) % (uint64_t)(r - l + 1))], d);
+    std::sort(sample, sample + nSample);
+    npy_intp iSample = (npy_intp)((double(k - l) / double(r - l)) * nSample);
+    if (iSample < 0)
+      iSample = 0;
+    if (iSample >= nSample)
+      iSample = nSample - 1;
+    const T v = sample[iSample];
+
+    pool.run([&](int rank) {
+      npy_intp begin, end;
+      kdRankRange(r - l + 1, rank, nThreads, begin, end);
+      begin += l;
+      end += l;
+
+      npy_intp nBelow = 0, nEqual = 0, nAbove = 0;
+      for (npy_intp i = begin; i < end; ++i) {
+        T x = GET2<T>(kd->pNumpyPos, p[i], d);
+        if (x < v)
+          ++nBelow;
+        else if (x > v)
+          ++nAbove;
+        else
+          ++nEqual;
+      }
+      ws.nBelow[rank] = nBelow;
+      ws.nEqual[rank] = nEqual;
+      ws.nAbove[rank] = nAbove;
+
+      pool.barrier();
+
+      npy_intp totalBelow = 0, totalEqual = 0;
+      for (int i = 0; i < nThreads; ++i) {
+        totalBelow += ws.nBelow[i];
+        totalEqual += ws.nEqual[i];
+      }
+      npy_intp offsetBelow = 0, offsetEqual = 0, offsetAbove = 0;
+      for (int i = 0; i < rank; ++i) {
+        offsetBelow += ws.nBelow[i];
+        offsetEqual += ws.nEqual[i];
+        offsetAbove += ws.nAbove[i];
+      }
+      npy_intp writeBelow = l + offsetBelow;
+      npy_intp writeEqual = l + totalBelow + offsetEqual;
+      npy_intp writeAbove = l + totalBelow + totalEqual + offsetAbove;
+      for (npy_intp i = begin; i < end; ++i) {
+        T x = GET2<T>(kd->pNumpyPos, p[i], d);
+        if (x < v)
+          buffer[writeBelow++] = p[i];
+        else if (x > v)
+          buffer[writeAbove++] = p[i];
+        else
+          buffer[writeEqual++] = p[i];
+      }
+
+      pool.barrier();
+
+      for (npy_intp i = begin; i < end; ++i)
+        p[i] = buffer[i];
+    });
+
+    npy_intp totalBelow = 0, totalEqual = 0;
+    for (int i = 0; i < nThreads; ++i) {
+      totalBelow += ws.nBelow[i];
+      totalEqual += ws.nEqual[i];
+    }
+    if (k < l + totalBelow) {
+      r = l + totalBelow - 1;
+    } else if (k < l + totalBelow + totalEqual) {
+      // k lies among the particles sharing the pivot's coordinate, so the
+      // range is already partitioned about the median
+      return;
+    } else {
+      l = l + totalBelow + totalEqual;
+    }
+  }
+
+  kdSelect<T>(kd, d, k, l, r);
+}
+
+/*
+ ** Build the tree, using num_threads threads.
+ **
+ ** The top of the tree has too few nodes to give every thread one each, so
+ ** there the threads cooperate on each node's median selection in turn
+ ** (kdSelectCooperative). Once there are enough nodes to go round, each node
+ ** is handled by a single thread, and below that the independent subtrees are
+ ** handed out through an atomic counter so that any number of threads --- not
+ ** just a power of two --- is kept busy to the end of the build.
+ */
+template <typename T> void kdBuildTree(KDContext* kd, int num_threads) {
   // start by assuming kdCountNodes(kd) has been called and kd->kdNodes!=NULL
-
   assert(kd->nNodes > 0);
   assert(kd->kdNodes != NULL);
 
-  // Calculate bounds
-  // Initialize with any particle:
-  for (j = 0; j < 3; ++j) {
-    rj = GET2<T>(kd->pNumpyPos, kd->particleOffsets[0], j);
-    bnd.fMin[j] = rj;
-    bnd.fMax[j] = rj;
+  ThreadPool pool(num_threads);
+  const int nThreads = pool.size();
+
+  // Set up the initial ordering, and the bounding box of all particles
+  Boundary bnd;
+  if (nThreads == 1) {
+    for (npy_intp i = 0; i < kd->nActive; ++i)
+      kd->particleOffsets[i] = i;
+    bnd = kdBounds<T>(kd, 0, kd->nActive);
+  } else {
+    std::vector<Boundary> partial(nThreads);
+    pool.run([&](int rank) {
+      npy_intp begin, end;
+      kdRankRange(kd->nActive, rank, nThreads, begin, end);
+      for (npy_intp i = begin; i < end; ++i)
+        kd->particleOffsets[i] = i;
+      partial[rank] = kdBounds<T>(kd, begin, end);
+    });
+    bnd = partial[0];
+    for (int rank = 1; rank < nThreads; ++rank)
+      kdExpandBounds(bnd, partial[rank]);
   }
 
-  // Expand to enclose all particles:
-  for (i = 1; i < kd->nActive; ++i) {
-    for (j = 0; j < 3; ++j) {
-      rj = GET2<T>(kd->pNumpyPos, kd->particleOffsets[i], j);
-      if (bnd.fMin[j] > rj)
-        bnd.fMin[j] = rj;
-      else if (bnd.fMax[j] < rj)
-        bnd.fMax[j] = rj;
-    }
+  if (kd->nActive == 0) {
+    kd->kdNodes[ROOT].pLower = 0;
+    kd->kdNodes[ROOT].pUpper = -1;
+    kd->kdNodes[ROOT].iDim = -1;
+    return;
   }
 
   // Set up root node
@@ -144,92 +399,127 @@ template <typename T> void kdBuildTree(KDContext* kd, int num_threads) {
   kd->kdNodes[ROOT].pUpper = kd->nActive - 1;
   kd->kdNodes[ROOT].bnd = bnd;
 
-  // Recursively build tree
-  kdBuildNode<T>(kd, ROOT, num_threads);
+  if (nThreads == 1) {
+    kdBuildNode<T>(kd, ROOT);
+    kdUpPass<T>(kd, ROOT);
+    return;
+  }
 
-  // Calculate and store bounds information by passing it up the tree
-  kdUpPass<T>(kd, ROOT);
+  // Depth at which nodes become independent tasks. Several times more tasks
+  // than threads keeps every thread busy whatever the thread count, at
+  // negligible cost since the levels above are parallel anyway.
+  int nTreeLevels = 0;
+  for (npy_intp n = kd->nSplit; n > 1; n >>= 1)
+    ++nTreeLevels;
+  int taskLevel = 0;
+  while ((npy_intp(1) << taskLevel) < 8 * (npy_intp)nThreads && taskLevel < nTreeLevels)
+    ++taskLevel;
+
+  // A node is only built if all of its ancestors were split; the rest of the
+  // node array is left untouched, exactly as in a serial build.
+  std::vector<char> reached((size_t)2 << taskLevel, 0);
+  reached[ROOT] = 1;
+
+  {
+    // The cooperative selection needs somewhere to build the partitioned copy
+    // of a range, which for the root node means the whole particle list: one
+    // extra npy_intp per particle, held only for as long as the top of the
+    // tree is being built. If it cannot be had, fall back to splitting the top
+    // nodes one thread at a time, which is slower but still correct.
+    SelectWorkspace ws;
+    ws.buffer.reset(new (std::nothrow) npy_intp[kd->nActive]);
+    ws.nBelow.resize(nThreads);
+    ws.nEqual.resize(nThreads);
+    ws.nAbove.resize(nThreads);
+
+    for (int level = 0; level < taskLevel; ++level) {
+      const npy_intp first = npy_intp(1) << level;
+
+      if (first < nThreads && ws.buffer) {
+        // Too few nodes to go round: all threads work on each in turn
+        for (npy_intp i = first; i < 2 * first; ++i) {
+          npy_intp d, m;
+          if (!reached[i] || !kdPrepareSplit(kd, i, d, m))
+            continue;
+          kdSelectCooperative<T>(kd, pool, ws, d, m, kd->kdNodes[i].pLower,
+                                 kd->kdNodes[i].pUpper);
+          kdRecordSplit<T>(kd, i, d, m);
+          reached[LOWER(i)] = reached[UPPER(i)] = 1;
+        }
+      } else {
+        // One node per thread; contiguous blocks so that a thread stays on its
+        // own part of the particle list from one level to the next
+        pool.run([&](int rank) {
+          npy_intp begin, end;
+          kdRankRange(first, rank, nThreads, begin, end);
+          for (npy_intp i = first + begin; i < first + end; ++i) {
+            npy_intp d, m;
+            if (!reached[i] || !kdPrepareSplit(kd, i, d, m))
+              continue;
+            kdSelect<T>(kd, d, m, kd->kdNodes[i].pLower, kd->kdNodes[i].pUpper);
+            kdRecordSplit<T>(kd, i, d, m);
+            reached[LOWER(i)] = reached[UPPER(i)] = 1;
+          }
+        });
+      }
+    }
+  } // the selection buffer is no longer needed
+
+  // Each remaining subtree is independent, so hand them out one at a time
+  std::vector<npy_intp> tasks;
+  for (npy_intp i = npy_intp(1) << taskLevel; i < npy_intp(2) << taskLevel; ++i)
+    if (reached[i])
+      tasks.push_back(i);
+
+  std::atomic<size_t> nextTask(0);
+  pool.run([&](int rank) {
+    while (true) {
+      size_t task = nextTask.fetch_add(1);
+      if (task >= tasks.size())
+        break;
+      kdBuildNode<T>(kd, tasks[task]);
+      kdUpPass<T>(kd, tasks[task]);
+    }
+  });
+
+  // The subtrees have passed their bounds up as far as taskLevel; fold the
+  // remaining few levels together here.
+  for (int level = taskLevel - 1; level >= 0; --level) {
+    for (npy_intp i = npy_intp(1) << level; i < npy_intp(2) << level; ++i) {
+      if (!reached[i])
+        continue;
+      if (kd->kdNodes[i].iDim != -1)
+        kdCombine(&kd->kdNodes[LOWER(i)], &kd->kdNodes[UPPER(i)], &kd->kdNodes[i]);
+      else
+        kdUpPass<T>(kd, i); // a leaf this high up: work its bounds out directly
+    }
+  }
 }
 
 template <typename T>
-void kdBuildNode(KDContext* kd, npy_intp local_root, int num_threads) {
+void kdBuildNode(KDContext* kd, npy_intp local_root) {
 
   npy_intp i = local_root;
-  npy_intp d, j, m, diff;
+  npy_intp d, m;
   KDNode *nodes;
   nodes = kd->kdNodes;
 
   while (1) {
-    assert(nodes[i].pUpper - nodes[i].pLower + 1 > 0);
-    if (i < kd->nSplit && (nodes[i].pUpper - nodes[i].pLower) > 0) {
-
-      // Select splitting dimensions on the basis of keeping things
-      // as square as possible
-      d = 0;
-      for (j = 1; j < 3; ++j) {
-        if (nodes[i].bnd.fMax[j] - nodes[i].bnd.fMin[j] >
-            nodes[i].bnd.fMax[d] - nodes[i].bnd.fMin[d])
-          d = j;
-      }
-      nodes[i].iDim = d;
-
-      // Find mid-point of particle list at which splitting will
-      // ultimately take place
-      m = (nodes[i].pLower + nodes[i].pUpper) / 2;
+    if (kdPrepareSplit(kd, i, d, m)) {
 
       // Sort list to ensure particles between lower and m are to
       // the 'left' of particles between m and upper
       kdSelect<T>(kd, d, m, nodes[i].pLower, nodes[i].pUpper);
 
-      // Note split point based on median particle
-      nodes[i].fSplit = GET2<T>(kd->pNumpyPos, kd->particleOffsets[m], d);
+      kdRecordSplit<T>(kd, i, d, m);
 
-      // Set up lower cell
-      nodes[LOWER(i)].bnd = nodes[i].bnd;
-      nodes[LOWER(i)].bnd.fMax[d] = nodes[i].fSplit;
-      nodes[LOWER(i)].pLower = nodes[i].pLower;
-      nodes[LOWER(i)].pUpper = m;
-
-      // Set up upper cell
-      nodes[UPPER(i)].bnd = nodes[i].bnd;
-      nodes[UPPER(i)].bnd.fMin[d] = nodes[i].fSplit;
-      nodes[UPPER(i)].pLower = m + 1;
-      nodes[UPPER(i)].pUpper = nodes[i].pUpper;
-      diff = (m - nodes[i].pLower + 1) - (nodes[i].pUpper - m);
-      assert(diff == 0 || diff == 1);
-
-      if (i < num_threads) {
-        // Launch a thread to handle the lower part of the tree,
-        // handle the upper part on the current thread.
-        std::thread t1(kdBuildNode<T>, kd, LOWER(i), num_threads);
-
-        // do upper part locally
-        kdBuildNode<T>(kd, UPPER(i), num_threads);
-
-        t1.join();
-        // NB if we have a non-power-of-two num_threads, we are basically
-        // wasting threads because we will end up waiting at this join point.
-        // This could be optimised by using a different threading model, but
-        // this symmetric branching model is simple and works well for
-        // power-of-two num_threads.
-
-        // at this point, we've finished processing this node and all subnodes,
-        // so continue back up the tree
-        SETNEXT(i, local_root);
-
-      } else {
-        // Continue processing on these threads
-        // Next cell is the lower one. Upper one will be processed
-        // on the way up.
-        i = LOWER(i);
-      }
+      // Next cell is the lower one. Upper one will be processed
+      // on the way up.
+      i = LOWER(i);
 
     } else {
-      // Cell does not need to be split. Mark as leaf
-      nodes[i].iDim = -1;
-
-      // Go back up the tree and process the UPPER cells where
-      // necessary
+      // Cell does not need to be split; kdPrepareSplit has marked it as a
+      // leaf. Go back up the tree and process the UPPER cells where necessary
       SETNEXT(i, local_root);
     }
     if (i == local_root)
@@ -246,7 +536,7 @@ template void kdUpPass<double>(KDContext* kd, npy_intp iCell);
 
 template void kdBuildTree<double>(KDContext* kd, int num_threads);
 
-template void kdBuildNode<double>(KDContext* kd, npy_intp local_root, int num_threads);
+template void kdBuildNode<double>(KDContext* kd, npy_intp local_root);
 
 template void kdSelect<float>(KDContext* kd, npy_intp d, npy_intp k, npy_intp l,
                               npy_intp r);
@@ -255,4 +545,4 @@ template void kdUpPass<float>(KDContext* kd, npy_intp iCell);
 
 template void kdBuildTree<float>(KDContext* kd, int num_threads);
 
-template void kdBuildNode<float>(KDContext* kd, npy_intp local_root, int num_threads);
+template void kdBuildNode<float>(KDContext* kd, npy_intp local_root);

--- a/pynbody/kdtree/kd.cpp
+++ b/pynbody/kdtree/kd.cpp
@@ -364,6 +364,12 @@ template <typename T> void kdBuildTree(KDContext* kd, int num_threads) {
   assert(kd->nNodes > 0);
   assert(kd->kdNodes != NULL);
 
+  // A thread is only ever any use if there is a subtree to give it, so there
+  // is nothing to be gained from a pool bigger than the number of leaves. In
+  // particular a tree that is a single leaf spawns no threads at all.
+  if (num_threads > kd->nSplit)
+    num_threads = (int)kd->nSplit;
+
   ThreadPool pool(num_threads);
   const int nThreads = pool.size();
 

--- a/pynbody/kdtree/kd.h
+++ b/pynbody/kdtree/kd.h
@@ -156,7 +156,7 @@ struct KDContext {
 void kdCountNodes(KDContext *kd);
 
 template <typename T> void kdBuildTree(KDContext*, int num_threads);
-template <typename T> void kdBuildNode(KDContext*, npy_intp, int);
+template <typename T> void kdBuildNode(KDContext*, npy_intp);
 
 void kdCombine(KDNode *p1, KDNode *p2, KDNode *pOut);
 

--- a/pynbody/kdtree/kdmain.cpp
+++ b/pynbody/kdtree/kdmain.cpp
@@ -300,10 +300,6 @@ PyObject * build_or_import(PyObject *self, PyObject *args, bool import_mode) {
 
   if(!import_mode) {
     Py_BEGIN_ALLOW_THREADS;
-    for (npy_intp i = 0; i < kd->nParticles; i++) {
-      kd->particleOffsets[i] = i;
-    }
-
     if (kd->nBitDepth == 64)
       kdBuildTree<double>(kd, num_threads);
     else

--- a/pynbody/kdtree/threadpool.h
+++ b/pynbody/kdtree/threadpool.h
@@ -1,0 +1,120 @@
+#ifndef KD_THREADPOOL_HINCLUDED
+#define KD_THREADPOOL_HINCLUDED
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+/*
+ ** A minimal fixed-size thread pool, sufficient for the kdtree build.
+ **
+ ** The thread that constructs the pool takes part in the work as rank 0, so a
+ ** pool of n threads spawns only n-1 workers. run() hands the same callable to
+ ** every rank and returns once all of them have finished; barrier() lets the
+ ** ranks synchronise part-way through a run().
+ **
+ ** The pool is deliberately simple: there is no task queue and no work
+ ** stealing. Everything the build needs is expressed as "all ranks run this
+ ** function", with any load balancing done by the callable itself (see
+ ** kdBuildTree, which hands out subtrees via an atomic counter).
+ */
+class ThreadPool {
+public:
+  explicit ThreadPool(int nThreads) : nThreads(nThreads < 1 ? 1 : nThreads) {
+    for (int rank = 1; rank < this->nThreads; ++rank)
+      workers.emplace_back(&ThreadPool::workerLoop, this, rank);
+  }
+
+  ~ThreadPool() {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stopping = true;
+    }
+    startCv.notify_all();
+    for (auto &worker : workers)
+      worker.join();
+  }
+
+  ThreadPool(const ThreadPool &) = delete;
+  ThreadPool &operator=(const ThreadPool &) = delete;
+
+  int size() const { return nThreads; }
+
+  /* Run fn(rank) on every rank, returning once they have all finished. */
+  void run(std::function<void(int)> fn) {
+    if (nThreads == 1) {
+      fn(0);
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      job = std::move(fn);
+      nFinished = 0;
+      ++generation;
+    }
+    startCv.notify_all();
+    job(0);
+    std::unique_lock<std::mutex> lock(mutex);
+    doneCv.wait(lock, [this] { return nFinished == nThreads - 1; });
+  }
+
+  /* Wait for all ranks to reach this point. Only valid inside run(). */
+  void barrier() {
+    if (nThreads == 1)
+      return;
+    std::unique_lock<std::mutex> lock(barrierMutex);
+    unsigned long long seen = barrierGeneration;
+    if (++nWaiting == nThreads) {
+      nWaiting = 0;
+      ++barrierGeneration;
+      barrierCv.notify_all();
+    } else {
+      barrierCv.wait(lock, [this, seen] { return barrierGeneration != seen; });
+    }
+  }
+
+private:
+  void workerLoop(int rank) {
+    unsigned long long seen = 0;
+    while (true) {
+      std::unique_lock<std::mutex> lock(mutex);
+      startCv.wait(lock, [this, seen] { return stopping || generation != seen; });
+      if (stopping)
+        return;
+      seen = generation;
+      lock.unlock();
+
+      job(rank);
+
+      lock.lock();
+      if (++nFinished == nThreads - 1)
+        doneCv.notify_one();
+    }
+  }
+
+  const int nThreads;
+  std::vector<std::thread> workers;
+  std::function<void(int)> job;
+
+  std::mutex mutex;
+  std::condition_variable startCv, doneCv;
+  unsigned long long generation = 0;
+  int nFinished = 0;
+  bool stopping = false;
+
+  std::mutex barrierMutex;
+  std::condition_variable barrierCv;
+  unsigned long long barrierGeneration = 0;
+  int nWaiting = 0;
+};
+
+/* Split [0, n) into nThreads contiguous blocks and return the rank'th. */
+inline void kdRankRange(npy_intp n, int rank, int nThreads, npy_intp &begin,
+                        npy_intp &end) {
+  begin = (n * rank) / nThreads;
+  end = (n * (rank + 1)) / nThreads;
+}
+
+#endif

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -259,6 +259,33 @@ def test_kdtree_parallel_build():
         assert (poff1 == poff).all()
 
 
+@pytest.mark.parametrize("num_threads", [0, -1])
+def test_kdtree_rejects_non_positive_num_threads(num_threads):
+    """A thread count below one must be rejected rather than silently doing nothing."""
+    f = pynbody.new(dm=100)
+    f['pos'] = np.random.uniform(size=(100, 3))
+    f['mass'] = np.ones(100)
+
+    with pytest.raises(ValueError):
+        f.build_tree(num_threads)
+
+
+@pytest.mark.parametrize("npart", [1, 2, 33, 200])
+def test_kdtree_build_more_threads_than_work(npart):
+    """Asking for more threads than the tree can use must still build it correctly."""
+    f = pynbody.new(dm=npart)
+    f['pos'] = np.random.uniform(size=(npart, 3))
+    f['mass'] = np.ones(npart)
+
+    f.build_tree(64)
+    offsets = f.kdtree.particle_offsets
+    assert sorted(offsets.tolist()) == list(range(npart))
+
+    del f.kdtree
+    f.build_tree(1)
+    npt.assert_array_equal(offsets, f.kdtree.particle_offsets)
+
+
 def test_kdtree_parallel_build_with_tied_coordinates():
     """A tree built from particles sharing coordinates must still be a valid tree.
 

--- a/tests/kdtree_test.py
+++ b/tests/kdtree_test.py
@@ -177,9 +177,14 @@ def test_neighbour_list():
     t = f.g.kdtree
     n_neigh = 32
 
-    generator_nn = t.nn(n_neigh)
-    n = next(generator_nn)
-    # print(n)
+    # The tree returns particles in its own internal order, which is an
+    # implementation detail; pick out a specific particle so that the expected
+    # values below do not depend on it.
+    for position, n in enumerate(t.nn(n_neigh)):
+        if n[0] == 9:
+            break
+    else:
+        raise AssertionError("particle 9 was not returned by the neighbour list generator")
 
     p_idx = n[0]       # particle index in snapshot arrays
     hsml = n[1]        # smoothing length
@@ -205,7 +210,7 @@ def test_neighbour_list():
                         rtol=1e-6)
 
     neighbour_list_all = t.all_nn(n_neigh)
-    assert n == neighbour_list_all[0]
+    assert n == neighbour_list_all[position]
     for nl in neighbour_list_all:
         assert len(nl[2]) == n_neigh   # always find n_neigh neighbours
         idx_self = nl[2].index(nl[0])  # index of self in the neighbour list (not necessarily the first element)
@@ -226,33 +231,69 @@ def test_div_curl_smoothing(div_curl):
     assert f.g['vorticity'].units == f.g['vel'].units/f.g['pos'].units
 
 def test_kdtree_parallel_build():
-    """Check that parallel tree build results in identical tree to serial build."""
+    """Check that the parallel tree build results in an identical tree to the serial build.
+
+    Positions here are float64 and drawn from a continuous distribution, so no two
+    particles share a coordinate and the tree is fully determined. Thread counts
+    that are not a power of two are included, since the build no longer rounds
+    down to one.
+    """
     f = pynbody.new(dm=5000)
     f['pos'] = np.random.uniform(size=(5000,3))
     f['mass'] = np.random.uniform(size=5000)
 
     f.build_tree(1)
-    result_one_thread = f.kdtree.serialize()
+    leafsize, boxsize, kdn1, poff1, kernel = f.kdtree.serialize()
 
-    _, _, kdn1, poff1, _ = result_one_thread
+    for num_threads in (2, 3, 4, 5, 8, 16):
+        del f.kdtree
+        f.build_tree(num_threads)
+        _, _, kdn, poff, _ = f.kdtree.serialize()
 
-    del f.kdtree
-
-    f.build_tree(4)
-    result_four_threads = f.kdtree.serialize()
-    _, _, kdn4, poff4, _ = result_four_threads
-
-    assert (kdn1['pLower'] == kdn4['pLower']).all()
-    assert (kdn1['pUpper'] == kdn4['pUpper']).all()
-    assert (kdn1['iDim'] == kdn4['iDim']).all()
-    npt.assert_allclose(kdn1['bnd']['fMin'], kdn4['bnd']['fMin'])
-    npt.assert_allclose(kdn1['bnd']['fMax'], kdn4['bnd']['fMax'])
-    npt.assert_allclose(kdn1['fSplit'], kdn4['fSplit'])
-    assert (poff1 == poff4).all()
+        assert (kdn1['pLower'] == kdn['pLower']).all()
+        assert (kdn1['pUpper'] == kdn['pUpper']).all()
+        assert (kdn1['iDim'] == kdn['iDim']).all()
+        npt.assert_allclose(kdn1['bnd']['fMin'], kdn['bnd']['fMin'])
+        npt.assert_allclose(kdn1['bnd']['fMax'], kdn['bnd']['fMax'])
+        npt.assert_allclose(kdn1['fSplit'], kdn['fSplit'])
+        assert (poff1 == poff).all()
 
 
+def test_kdtree_parallel_build_with_tied_coordinates():
+    """A tree built from particles sharing coordinates must still be a valid tree.
 
+    Which of a set of tied particles ends up on each side of a split is not
+    defined, so the tree may differ between thread counts here; it must
+    nevertheless partition every node correctly and use each particle once.
+    """
+    n = 20000
+    pos = np.random.randint(0, 4, size=(n, 3)).astype(np.float64)  # heavily tied
+    f = pynbody.new(dm=n)
+    f['pos'] = pos
+    f['mass'] = np.ones(n)
 
+    for num_threads in (1, 2, 3, 4, 8):
+        if hasattr(f, 'kdtree'):
+            del f.kdtree
+        f.build_tree(num_threads)
+        kdn = f.kdtree.kdnodes
+        offsets = f.kdtree.particle_offsets
+
+        assert sorted(offsets.tolist()) == list(range(n))
+
+        nsplit = len(kdn) // 2
+        for i in range(1, nsplit):
+            node = kdn[i]
+            if node['iDim'] < 0 or node['pUpper'] <= node['pLower']:
+                continue
+            m = (node['pLower'] + node['pUpper']) // 2
+            d = node['iDim']
+            low = pos[offsets[node['pLower']:m + 1], d]
+            high = pos[offsets[m + 1:node['pUpper'] + 1], d]
+            assert low.max() <= node['fSplit']
+            assert high.min() >= node['fSplit']
+            # the split must halve the node, which the tree layout relies on
+            assert (m - node['pLower'] + 1) - (node['pUpper'] - m) in (0, 1)
 
 
 @pytest.mark.parametrize("npart", [1, 10, 100, 1000, 100000])


### PR DESCRIPTION
The build handed a thread to each subtree as it recursed (`kd.cpp:201`), so the top of the tree was laid out on far fewer threads than were available: level 0 on one thread, level 1 on two, and so on. Timing each level of a 16M particle build separately, that ramp plus the serial `kdUpPass` puts a ceiling on the achievable speedup — around 8.5x in a cost model that counts only the work, and lower in practice once memory bandwidth is accounted for; measured on real snapshots, `master` plateaus at ~3.4x from 8 threads up and does not improve beyond that. On top of the ramp, `KDTree.__init__` rounded `num_threads` down to a power of two, because the symmetric branching wasted any threads beyond one.

## What changed

The build is now split into three phases:

- **While there are fewer nodes than threads**, all threads cooperate on each node's median selection, partitioning the range three ways about a sampled pivot with one contiguous block per thread. The ranges involved are enormous compared with the cost of a barrier — an isolated median-of-16M selection parallelises at 92% efficiency over 4 threads, in 6 partition passes — so the synchronisation this needs is negligible from the root down, not merely amortised at large N.
- **Once there is a node per thread**, one thread per node, in contiguous blocks so a thread stays on its own part of the particle list.
- **Below that**, subtrees are independent and are handed out through an atomic counter. This keeps every thread busy to the end of the build for any thread count, and folds the previously serial `kdUpPass` into the parallel phase.

The power-of-two rounding is therefore gone, and so is the per-subtree `std::thread` spawning: a small hand-rolled pool in `threadpool.h` runs each phase, with the calling thread taking part as rank 0.

## Measured

4M particles on 4 cores, clustered positions, best of 5, interleaved before/after over two rounds:

| threads | before | after |
| ------: | ------ | ----- |
| 1 | 1.75s (1.00x) | 1.83s (1.00x) |
| 2 | 0.97s (1.81x) | 0.95s (1.94x) |
| 3 | 0.96s (1.81x) | 0.67s (**2.75x**) |
| 4 | 0.59s (2.92x) | 0.49s (**3.79x**) |

Uniform and lattice positions give the same shape. The 3-thread row is the power-of-two fix; the 4-thread row is the ramp.

See the [benchmark comment below](https://github.com/pynbody/pynbody/pull/1023#issuecomment-5388586453) for figures on a 10-core machine against real snapshots up to 746M particles, where the branch reaches 5.2–6.3x at 10 threads against `master`'s ~3.4x, with the gap widening as both thread count and particle count grow.

## Leaf ordering

`kdUpPass` now sorts each leaf's offsets. Which particles land in a leaf does not depend on how the build was shared out, but the order the partitioning leaves them in does. Sorting keeps `particle_offsets` reproducible across thread counts, and has each leaf walk the position array in ascending order, which makes smoothing ~3% and density ~6% faster — so it pays for itself. It accounts for the single-threaded cost above (~5% on the 4M synthetic case, ~2–3% on the real snapshots); the serial path is otherwise untouched.

## Reproducibility

Unchanged except where particles share a coordinate exactly. There, which of them ends up on each side of a split is not defined, and the parallel and serial partitions may choose differently, so the tree — while still correct — can differ between thread counts.

This is worth being explicit about, because exact ties are not as rare as they sound: in single precision at N = 10<sup>6</sup> there are tens of thousands of duplicate coordinates and the tree does differ between thread counts, whereas below ~10<sup>5</sup> particles, and in double precision at any N, there are no ties at all and the result is bit-identical. It is documented on `KDTree`, and `num_threads=1` remains bit-reproducible.

Making the tree identical regardless would mean breaking ties on particle index, which needs a three-way partition on the serial path too and costs ~10% single-threaded (~23% on grid-like data). That trade was measured and deliberately not taken.

## Testing

- `test_kdtree_parallel_build` now spans thread counts 2, 3, 4, 5, 8 and 16, and compares `particle_offsets` as well as the nodes.
- New `test_kdtree_parallel_build_with_tied_coordinates` checks that a heavily tied input still yields a valid, correctly halved tree at every thread count.
- Separately, 576 configurations (6 distributions, N from 1 to 10<sup>5</sup>, leafsize 1/2/7/32, both dtypes) were checked across 7 thread counts: bit-identical to the serial build wherever untied, and a valid tree everywhere, including all-identical positions.
- `test_neighbour_list` hard-coded the first particle in tree order, which leaf sorting changes. It now seeks out particle 9 instead; every physics assertion about that particle is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxYzVFiakrM6GFv7LC9Ruy