### PR TITLE
Fix incorrect time written by TipsySnap._write for non-cosmological snapshots

### DIFF
--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -135,7 +135,13 @@ class TipsySnap(SimSnap):
             pass
 
         if time_unit is not None:
-            self.properties['time'] *= time_unit
+            # Store as a SimArray (raw value + unit label) rather than folding the
+            # conversion into a bare Unit, consistent with how every other time-valued
+            # quantity (e.g. star['tform']) is represented. This keeps the raw,
+            # file-native value recoverable (needed so _write can round-trip it) while
+            # still allowing sim.properties['time'].in_units(...) to give the physical
+            # value, and lets it interoperate directly with other time SimArrays.
+            self.properties['time'] = array.SimArray(self.properties['time'], time_unit)
 
     def _load_main_file(self):
 
@@ -446,20 +452,6 @@ class TipsySnap(SimSnap):
                 t = snapshot.properties['a']
             else:
                 t = snapshot.properties['time']
-                if isinstance(snapshot, TipsySnap) and isinstance(t, units.UnitBase):
-                    # On loading, TipsySnap.properties['time'] is derived from the raw
-                    # header value by multiplying by the paramfile-inferred time unit
-                    # (see settime/__init__ above), so it is expressed in "physical"
-                    # units rather than the raw internal units the header expects.
-                    # Convert back to those raw units here, otherwise every write
-                    # bakes in an extra, spurious factor of the time unit.
-                    time_unit = snapshot.infer_original_units('yr')
-                    try:
-                        t = t.ratio(time_unit, **snapshot.conversion_context())
-                    except units.UnitsException:
-                        warnings.warn(
-                            "Could not convert time to the tipsy file's internal units; "
-                            "writing the value verbatim, which may be incorrect.", RuntimeWarning)
         except KeyError:
             warnings.warn(
                 "Time is unknown: writing zero in header", RuntimeWarning)

--- a/pynbody/snapshot/tipsy.py
+++ b/pynbody/snapshot/tipsy.py
@@ -446,6 +446,20 @@ class TipsySnap(SimSnap):
                 t = snapshot.properties['a']
             else:
                 t = snapshot.properties['time']
+                if isinstance(snapshot, TipsySnap) and isinstance(t, units.UnitBase):
+                    # On loading, TipsySnap.properties['time'] is derived from the raw
+                    # header value by multiplying by the paramfile-inferred time unit
+                    # (see settime/__init__ above), so it is expressed in "physical"
+                    # units rather than the raw internal units the header expects.
+                    # Convert back to those raw units here, otherwise every write
+                    # bakes in an extra, spurious factor of the time unit.
+                    time_unit = snapshot.infer_original_units('yr')
+                    try:
+                        t = t.ratio(time_unit, **snapshot.conversion_context())
+                    except units.UnitsException:
+                        warnings.warn(
+                            "Could not convert time to the tipsy file's internal units; "
+                            "writing the value verbatim, which may be incorrect.", RuntimeWarning)
         except KeyError:
             warnings.warn(
                 "Time is unknown: writing zero in header", RuntimeWarning)

--- a/tests/tipsy_test.py
+++ b/tests/tipsy_test.py
@@ -216,10 +216,11 @@ def test_time_roundtrip_noncosmological(tmp_path):
     # regression test for https://github.com/pynbody/pynbody/issues/996
     #
     # A non-cosmological tipsy snapshot's properties['time'] is stored on disk as a raw
-    # value in the simulation's internal time unit, but pynbody exposes it already
-    # converted using the unit system implied by the sidecar .param file. Writing it back
-    # out must undo that conversion, otherwise the value written to (and subsequently read
-    # from) the header is wrong.
+    # value in the simulation's internal time unit. On load, pynbody represents it as a
+    # SimArray carrying that raw value with the paramfile-inferred unit attached (the
+    # same representation used for any other time-valued array, e.g. star['tform']), so
+    # that a plain float() of it -- and hence a subsequent write -- recovers the original
+    # header value, while .in_units(...) still gives the physical value.
     (tmp_path / "sim.param").write_text("dKpcUnit = 1000\ndMsolUnit = 1e15\nbComove = 0\n")
 
     f = pynbody.new(gas=10)
@@ -232,6 +233,8 @@ def test_time_roundtrip_noncosmological(tmp_path):
     f.write(fmt=pynbody.snapshot.tipsy.TipsySnap, filename=orig_filename, cosmological=False)
 
     f2 = pynbody.load(orig_filename)
+    assert isinstance(f2.properties['time'], pynbody.array.SimArray)
+    assert f2.properties['time'] == f2._header_t
     original_time_gyr = f2.properties['time'].in_units('Gyr')
 
     roundtrip_filename = str(tmp_path / "roundtrip.tipsy")

--- a/tests/tipsy_test.py
+++ b/tests/tipsy_test.py
@@ -212,6 +212,36 @@ def test_write_noncosmo(test_noncosmo_output):
     assert f3.properties['a']==12
 
 
+def test_time_roundtrip_noncosmological(tmp_path):
+    # regression test for https://github.com/pynbody/pynbody/issues/996
+    #
+    # A non-cosmological tipsy snapshot's properties['time'] is stored on disk as a raw
+    # value in the simulation's internal time unit, but pynbody exposes it already
+    # converted using the unit system implied by the sidecar .param file. Writing it back
+    # out must undo that conversion, otherwise the value written to (and subsequently read
+    # from) the header is wrong.
+    (tmp_path / "sim.param").write_text("dKpcUnit = 1000\ndMsolUnit = 1e15\nbComove = 0\n")
+
+    f = pynbody.new(gas=10)
+    f['pos'] = np.random.rand(10, 3)
+    f['vel'] = np.random.rand(10, 3)
+    f['mass'] = np.ones(10)
+    f.properties['time'] = 12.0
+
+    orig_filename = str(tmp_path / "orig.tipsy")
+    f.write(fmt=pynbody.snapshot.tipsy.TipsySnap, filename=orig_filename, cosmological=False)
+
+    f2 = pynbody.load(orig_filename)
+    original_time_gyr = f2.properties['time'].in_units('Gyr')
+
+    roundtrip_filename = str(tmp_path / "roundtrip.tipsy")
+    f2.write(fmt=pynbody.snapshot.tipsy.TipsySnap, filename=roundtrip_filename, cosmological=False)
+    f3 = pynbody.load(roundtrip_filename)
+
+    npt.assert_allclose(f3._header_t, f2._header_t)
+    npt.assert_allclose(f3.properties['time'].in_units('Gyr'), original_time_gyr)
+
+
 def test_array_write(snap):
     f = snap
     f['array_write_test'] = np.random.rand(len(f))


### PR DESCRIPTION
## Summary

Fixes #996, where writing a non-cosmological Tipsy snapshot back out (`cosmological=False`) stores the wrong time in the header.

**Root cause**: On load, `TipsySnap.properties['time']` is set to the raw header value multiplied by a paramfile-inferred time unit (`self.properties['time'] *= time_unit` in `TipsySnap.__init__`). Because `Unit * float` folds the raw value directly into a `Unit`'s scale, `float(properties['time'])` no longer returns anything recoverable as the original raw header value — it returns an intermediate, not-directly-meaningful number. `TipsySnap._write` packed this straight into the header via `struct.pack`, which implicitly calls `float()` on it, so every write baked in an extra, spurious conversion factor (and this compounded further on repeated round trips).

**Fix (revised after discussion)**: rather than special-casing `_write` to convert the value back (an earlier version of this PR did that), `properties['time']` is now represented as a `SimArray` — the raw, file-native value with the time unit attached as a label, exactly like any other time-valued array in pynbody (e.g. `star['tform']`). `float()`/plain arithmetic on it recovers the raw value (so `_write` needs no special-casing at all — it's back to its original, two-line form), while `.in_units(...)` still gives the physical value on request. This is also more consistent for users: previously `properties['time']` behaved quite differently from other time-carrying quantities (e.g. it wouldn't interoperate directly with `star['tform']` the way two arrays would); as a `SimArray` it now does.

`physical_units()`/`set_units_system()` already have working, tested code paths for `SimArray`-typed properties, so this required no changes elsewhere — confirmed the existing test suite (tipsy, partial-tipsy, derived arrays, snapshot, nchilada, gadget, ramses, swift, pkdgravhdf) all still pass, and that derived quantities like `star['age']` produce bit-identical results to before.

## Test plan

- [x] `test_time_roundtrip_noncosmological` in `tests/tipsy_test.py`: builds a synthetic non-cosmological Tipsy snapshot (with its own `.param` file), checks `properties['time']` is a `SimArray` equal to the raw header value, and that a write → load → write → load round trip preserves both the raw header value and the physical time in Gyr. Confirmed this test fails against the original code (reproducing the exact corruption) and passes with the fix.
- [x] Ran `tests/tipsy_test.py` + `tests/partial_tipsy_test.py` (38 tests), plus `tests/derived_arrays_test.py`, `tests/snapshot_test.py`, `tests/nchilada_test.py`, `tests/gadget_test.py`, `tests/ramses_test.py`, `tests/swift_test.py`, `tests/pkdgravhdf_test.py` — all pass.
- [x] Verified `star['age']` (a derived array depending on `properties['time']`) and `properties['time'].in_units('Gyr')` produce identical numeric results before and after this change on a real cosmological test snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JnfB7JNzuWcJQxj7T7df1