### PR TITLE
Fix silent element-by-element fallback in to_shared_reference, and three redundant copies

### DIFF
--- a/pynbody/__init__.py
+++ b/pynbody/__init__.py
@@ -69,6 +69,6 @@ from .snapshot import load, new
 
 derived_array = snapshot.simsnap.SimSnap.derived_array
 
-__version__ = '2.7.0'
+__version__ = '2.7.1'
 
 __all__ = ['load', 'new', 'derived_array']

--- a/pynbody/array/shared/__init__.py
+++ b/pynbody/array/shared/__init__.py
@@ -233,12 +233,18 @@ def _shared_array_deconstruct(ar, transfer_ownership=False):
     process has it) to the reconstructing process. New code should use
     :func:`to_shared_reference` instead."""
 
-    assert isinstance(ar, SimArray)
+    if not isinstance(ar, SimArray):
+        raise TypeError(f"Cannot make a shared reference to a {type(ar).__name__}; it must be an array created "
+                        f"by make_shared_array, or a view of one. Note that np.asarray on a shared array "
+                        f"returns a base-class view, which no longer records where its memory came from; use "
+                        f"np.asanyarray instead if you need to pass it on.")
+
     ar_base = ar
     while isinstance(ar_base.base, SimArray):
         ar_base = ar_base.base
 
-    assert isinstance(ar_base, SharedMemorySimArray), "Cannot prepare an array for shared use unless it was created in shared memory"
+    if not isinstance(ar_base, SharedMemorySimArray):
+        raise TypeError("Cannot prepare an array for shared use unless it was created in shared memory")
 
     ownership_out = transfer_ownership and ar_base._shared_owner
     if transfer_ownership:
@@ -267,7 +273,10 @@ def _recursive_shared_array_deconstruct(input, transfer_ownership=False) :
     """Works through items in input, deconstructing any shared memory arrays
     into transferrable references. New code should use :func:`to_shared_reference` instead."""
     output = []
-    if isinstance(input, SimArray):
+    if isinstance(input, np.ndarray):
+        # NB the test is for any ndarray, not just a SimArray: one that cannot be referenced must be
+        # rejected by _shared_array_deconstruct rather than falling through to the loop below, which would
+        # iterate it and quietly return a python list of its every element
         return _shared_array_deconstruct(input, transfer_ownership)
 
     for item in input:
@@ -389,6 +398,18 @@ def to_shared_reference(array, transfer_ownership=False):
     array_description : SharedArrayReference
         A description of the array that can be passed between processes (e.g. using pickle to turn it into a short
         string that can be sent via a pipe).
+
+    Raises
+    ------
+
+    TypeError
+        If *array* is not backed onto shared memory.
+
+        .. versionchanged:: 2.7.1
+
+          Previously a plain ``ndarray`` was silently iterated, returning a python list of its every
+          element rather than a reference.
+
     """
 
     return _recursive_shared_array_deconstruct(array, transfer_ownership)

--- a/pynbody/halo/number_array.py
+++ b/pynbody/halo/number_array.py
@@ -27,7 +27,9 @@ class HaloNumberCatalogue(HaloCatalogue):
         sim[array] # noqa - trigger lazy-loading and/or kick up a fuss if unavailable
         self._array = array
         self._ignore = ignore
-        self._halo_numbers = np.unique(sim[array])
+        # NB the counts come free from the same pass as the unique numbers, and save re-deriving the halo
+        # boundaries from a sorted copy of the whole per-particle array later on
+        self._halo_numbers, self._num_particles_per_halo_number = np.unique(sim[array], return_counts=True)
         number_mapper = create_halo_number_mapper(self._trim_array_for_ignore(self._halo_numbers))
         HaloCatalogue.__init__(self, sim, number_mapper=number_mapper)
 
@@ -49,12 +51,16 @@ class HaloNumberCatalogue(HaloCatalogue):
         halo_number_per_particle = self.base[self._array]
 
         particle_index_list = np.argsort(halo_number_per_particle, kind='mergesort')
-        start = np.searchsorted(halo_number_per_particle[particle_index_list], self._halo_numbers)
-        stop = np.concatenate((start[1:], [len(particle_index_list)]))
 
-        particle_index_list_boundaries = self._trim_array_for_ignore(
-            np.hstack((start[:, np.newaxis], stop[:, np.newaxis]))
-        )
+        # the sorted index list groups the particles by halo number in the order of self._halo_numbers, so
+        # the boundaries follow from the counts alone; deriving them instead from a sorted copy of the whole
+        # per-particle array costs an extra full-length temporary for nothing
+        boundaries = np.empty((len(self._halo_numbers), 2), dtype=np.intp)
+        np.cumsum(self._num_particles_per_halo_number, out=boundaries[:, 1])
+        boundaries[1:, 0] = boundaries[:-1, 1]
+        boundaries[:1, 0] = 0
+
+        particle_index_list_boundaries = self._trim_array_for_ignore(boundaries)
 
         return HaloParticleIndices(particle_ids = particle_index_list, boundaries = particle_index_list_boundaries)
 

--- a/pynbody/halo/rockstar.py
+++ b/pynbody/halo/rockstar.py
@@ -97,12 +97,23 @@ class RockstarCatalogue(HaloCatalogue):
         return self._map_iords_to_fpos_one_halo(iords, halo_number)
 
     def _get_all_particle_indices(self):
-        iords = np.empty(0, dtype=int)
-        boundaries = np.empty((0, 2), dtype=int)
+        # NB accumulate then concatenate once; appending to a growing array copies everything read so far
+        # for every file, which is quadratic in the number of rockstar outputs
+        iords_per_cpu = []
+        boundaries_per_cpu = []
+        num_iords = 0
         for cpu in self._cpus:
             iords_this_cpu, boundaries_this_cpu = cpu.read_iords_for_all_halos()
-            boundaries = np.append(boundaries, boundaries_this_cpu + len(iords), axis=0)
-            iords = np.append(iords, iords_this_cpu)
+            boundaries_per_cpu.append(boundaries_this_cpu + num_iords)
+            iords_per_cpu.append(iords_this_cpu)
+            num_iords += len(iords_this_cpu)
+
+        if len(iords_per_cpu) > 0:
+            iords = np.concatenate(iords_per_cpu)
+            boundaries = np.concatenate(boundaries_per_cpu, axis=0)
+        else:
+            iords = np.empty(0, dtype=np.int64)
+            boundaries = np.empty((0, 2), dtype=np.int64)
 
         self._init_iord_to_fpos()
 

--- a/pynbody/halo/subfind.py
+++ b/pynbody/halo/subfind.py
@@ -215,7 +215,9 @@ class SubfindCatalogue(HaloCatalogue):
             return SubhaloCatalogue(self._subhalo_catalogue,
                                     self._get_children_of_group(parent_halo_number))
     def _read_ids(self):
-        data_ids = np.array([], dtype=self.dtype_int)
+        # NB accumulate then concatenate once; appending to a growing array copies everything read so far
+        # for every file, which is quadratic in the number of subfind outputs
+        ids_per_task = []
         iout = self._subfind_dir.split("_")[-1]
         for n in range(0, self._tasks):
             filename = os.path.join(
@@ -230,8 +232,10 @@ class SubfindCatalogue(HaloCatalogue):
             # TODO: include a check if both headers agree (they better)
             ids = np.fromfile(fd, dtype=self.dtype_int, sep="", count=-1)
             fd.close()
-            data_ids = np.append(data_ids, ids)
-        return data_ids
+            ids_per_task.append(ids)
+        if len(ids_per_task) == 0:
+            return np.array([], dtype=self.dtype_int)
+        return np.concatenate(ids_per_task)
 
     def _read_data(self, sim):
         halodat={}

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -354,6 +354,28 @@ def test_shared_reference_legacy_names():
     assert pyn_array.shared._deconstructed_shared_array is pyn_array.shared.SharedArrayReference
 
 
+def test_shared_reference_refuses_plain_array():
+    """A plain ndarray cannot be referenced, and must say so rather than being iterated element by element"""
+    shared_array = pyn_array.shared.make_shared_array((6,), np.int64, zeros=True)
+
+    assert isinstance(pyn_array.shared.to_shared_reference(shared_array),
+                      pyn_array.shared.SharedArrayReference)
+
+    # np.asarray gives a base-class view, which no longer knows where its memory came from
+    with pytest.raises(TypeError, match="Cannot make a shared reference"):
+        pyn_array.shared.to_shared_reference(np.asarray(shared_array))
+
+    with pytest.raises(TypeError, match="Cannot make a shared reference"):
+        pyn_array.shared.to_shared_reference(np.arange(6))
+
+    # a SimArray which is simply not in shared memory is refused too
+    with pytest.raises(TypeError, match="unless it was created in shared memory"):
+        pyn_array.shared.to_shared_reference(pyn_array.SimArray(np.arange(6)))
+
+    del shared_array
+    gc.collect()
+
+
 def _test_and_alter_shared_value(array_info):
     array = pynbody.array.shared.from_shared_reference(array_info)
     assert (array[:] == np.arange(3)[: , np.newaxis] * np.arange(5)[np.newaxis, :]).all()

--- a/tests/halos_test.py
+++ b/tests/halos_test.py
@@ -1087,6 +1087,34 @@ def test_grp_catalogue_with_ignore_value(snap_with_grp, do_load_all, ignore_valu
             if halo_number != ignore_value:
                 assert (h[halo_number]['id'] == f[f['grp'] == halo_number]['id']).all()
 
+
+@pytest.mark.parametrize("ignore_value", [None, -3, 7])
+def test_grp_catalogue_with_awkward_halo_numbers(ignore_value):
+    """Halo boundaries are derived from per-halo-number counts, so gaps and unequal sizes must line up.
+
+    The halo numbers here are non-contiguous, include negatives, and the halos have very different sizes,
+    so an off-by-one in the boundaries shows up as a halo getting another halo's particles."""
+    halo_number_per_particle = np.repeat([-3, -1, 0, 4, 7], [1, 17, 40, 2, 30])
+    np.random.seed(1337)
+    np.random.shuffle(halo_number_per_particle)
+
+    f = pynbody.new(dm=len(halo_number_per_particle))
+    f['grp'] = halo_number_per_particle
+    f['id'] = np.arange(len(f))
+
+    h = pynbody.halo.number_array.HaloNumberCatalogue(f, ignore=ignore_value)
+    h.load_all()
+
+    expected_numbers = [n for n in (-3, -1, 0, 4, 7) if n != ignore_value]
+    assert list(h.keys()) == expected_numbers
+
+    for halo_number in expected_numbers:
+        assert (np.sort(h[halo_number]['id']) == np.where(halo_number_per_particle == halo_number)[0]).all()
+
+    # every particle appears exactly once in the index list, whether or not its halo is ignored
+    assert (np.sort(h._index_lists.particle_index_list) == np.arange(len(f))).all()
+
+
 def test_grp_catalogue_cannot_determine_completeness(snap_with_grp):
     """The halo number array covers only the loaded particles, so completeness cannot be established"""
     h = pynbody.halo.number_array.HaloNumberCatalogue(snap_with_grp)


### PR DESCRIPTION
Three independent fixes extracted from #1026, which was closed as not worth its complexity. None of them depend on that change — no new API, no new helpers, no contract changes. 109 insertions across four source files.

## 1. `to_shared_reference` silently iterated arrays it could not reference

`_recursive_shared_array_deconstruct` tested `isinstance(input, SimArray)` and, failing that, fell through to its `for item in input:` loop — which iterates an ndarray:

```python
to_shared_reference(np.asarray(make_shared_array((6,), np.int64, False)))
# -> [np.int64(0), np.int64(1), np.int64(2), np.int64(3), np.int64(4), np.int64(5)]
```

So a caller who passed a large plain ndarray got a Python list of every element, with no error. That is an easy mistake to walk into, because `np.asarray` on a shared array returns a base-class view which no longer records where its memory came from — exactly the array you'd end up holding after a well-meaning `np.asarray` somewhere upstream.

It now raises `TypeError` and says why. The bare `assert` for a `SimArray` that is not in shared memory becomes an explicit `TypeError` in the same place.

The nested-item handling inside `remote_map` is deliberately left alone: ramses parallel reading returns plain ndarrays through `shared_array_remote` and relies on the existing behaviour.

## 2. `HaloNumberCatalogue` sorted the whole per-particle array to get the halo boundaries

```python
particle_index_list = np.argsort(halo_number_per_particle, kind='mergesort')
start = np.searchsorted(halo_number_per_particle[particle_index_list], self._halo_numbers)
```

`halo_number_per_particle[particle_index_list]` is a fancy-indexed copy of the entire per-particle array — allocated, searched once, and thrown away. `np.unique` in the constructor already sorts that array, and `return_counts=True` hands back the particles per halo number for free, so the boundaries are a `cumsum` of the counts. No particle-length temporary, and the `hstack` goes too.

Verified identical to the previous derivation over 2000 random inputs (gaps, negatives, repeats, single-element halos), and there is a new test with non-contiguous negative halo numbers and very unequal halo sizes — mutation-checked, i.e. it does fail if the boundaries are off by one.

## 3. Two quadratic `np.append` loops over finder output files

`RockstarCatalogue._get_all_particle_indices` and `SubfindCatalogue._read_ids` both grew their result with `np.append` inside a loop over the halo finder's output files:

```python
for cpu in self._cpus:
    ...
    boundaries = np.append(boundaries, boundaries_this_cpu + len(iords), axis=0)
    iords = np.append(iords, iords_this_cpu)
```

`np.append` always allocates and copies, so reading $N$ files copies the accumulated data $N$ times — $O(N^2)$ in total bytes moved. Both now accumulate into a list and `concatenate` once. Output is byte-for-byte identical, including dtypes.

## Testing

Full suite: **1019 passed, 1 skipped, 1 failed**. The failure is `ahf_halos_test.py::test_ahf_unwritable`, which fails identically on `master` in this environment because the tests run as root, so the `chmod` the test relies on does not make the directory unwritable; it passed in CI on the previous run of this branch.

New tests: `to_shared_reference` raising `TypeError` for a plain ndarray, a base-class view of a shared array, and a non-shared `SimArray`; and the awkward-halo-numbers case for `HaloNumberCatalogue`. Items 3 are pure refactors with identical output, covered by the existing `rockstar_test.py` and `subfind_test.py`.

Patch version bump, 2.7.0 → 2.7.1.

## Deliberately left out

#1026 also added a public `is_shared_array()` predicate, which would give callers a clean way to check before calling `to_shared_reference` rather than reaching for `hasattr(ar, "_shared_fname")` (wrong for views of a shared array). I've kept it out to hold this PR to the three fixes — happy to add it if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AL212J957VERirvoP5FX

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5AL212J957VERirvoP5FX)_