### PR TITLE
Let LoadControl describe one file's worth of a spanned snapshot

### DIFF
--- a/pynbody/chunk/__init__.py
+++ b/pynbody/chunk/__init__.py
@@ -187,6 +187,8 @@ class LoadControl:
 
         """
 
+        self._max_chunk = max_chunk
+
         if self._ids is None:
             self._generate_null_chunks(max_chunk)
             return
@@ -389,3 +391,88 @@ class LoadControl:
                 else:
                     for nread_disk, disk_mask, mem_slice in self._family_chunks[current_family]:
                         yield nread_disk, None, None
+
+    def iterate_within(self, family: family.Family, disk_lo: int, disk_hi: int) \
+            -> Iterator[tuple[int, slice | np.ndarray | None, slice | None]]:
+        """Yields instructions for loading the part of a family lying at disk positions ``[disk_lo, disk_hi)``.
+
+        This performs the same function as :func:`iterate` for a single family, but restricted to a contiguous
+        window of that family's on-disk extent. It is intended for snapshots which are spanned across several
+        files: each file covers one such window, so the instructions for a given file can be generated (and the
+        file read) without walking through any of its predecessors.
+
+        A typical read loop, for one file covering family-relative disk positions ``[disk_lo, disk_hi)``, should
+        be as follows:
+
+        .. code-block:: python
+
+            offset = 0  # position within this file
+            for readlen, buffer_index, memory_index in ctl.iterate_within(fam, disk_lo, disk_hi):
+              if memory_index is None:
+                offset += readlen  # nothing wanted here; seek past it
+                continue
+              data = read_entries(file, start=offset, count=readlen)
+              target_array[mem_offset + memory_index.start : mem_offset + memory_index.stop] = data[buffer_index]
+              offset += readlen
+
+        Here ``mem_offset`` is where this family's in-memory data starts, since ``memory_index`` is relative to
+        the family (not to the file); consecutive windows therefore write to increasing, non-overlapping parts of
+        the destination.
+
+        Parameters
+        ----------
+        family : pynbody.family.Family
+            The family to read; must be one of those passed to the constructor
+        disk_lo : int
+            First disk position to consider, relative to the start of the family on disk
+        disk_hi : int
+            One past the last disk position to consider, relative to the start of the family on disk
+
+        Yields
+        ------
+        readlen : int
+            Number of entries to read from disk, starting from where the last instruction left off. The disk
+            cursor starts at ``disk_lo``, i.e. it is relative to the window rather than to the family.
+        buffer_index : slice | np.ndarray | None
+            Index into the buffer just read, or None if this particular read is to be ignored (skipped)
+        memory_index : slice | None
+            Slice to write into memory, relative to the start of the family, or None if ``buffer_index`` is None
+
+        """
+
+        if family not in self._disk_family_slice:
+            raise ValueError(f"Family {family} is not present on disk")
+
+        if disk_hi < disk_lo:
+            raise ValueError("disk_hi must not be less than disk_lo")
+
+        num_disk = disk_hi - disk_lo
+        max_chunk = self._max_chunk
+
+        if self._ids is None:
+            # Mirrors _generate_null_chunks: with no partial loading, memory position equals disk position.
+            for p in range(0, num_disk, max_chunk):
+                nread = min(num_disk - p, max_chunk)
+                yield nread, slice(0, nread), slice(disk_lo + p, disk_lo + p + nread)
+            return
+
+        ids = self._family_ids[family]
+
+        # The ids are ascending, so the number of them below disk_lo is both where this window's selection
+        # starts within ids and how many memory slots all preceding windows consume between them. That is what
+        # makes the windows independent of each other.
+        i = int(np.searchsorted(ids, disk_lo))
+
+        p = 0
+        while p < num_disk:
+            # Mirrors _generate_chunks, whose chunks step by max_chunk - 1
+            p_end = p + min(num_disk - p, max_chunk - 1)
+            j = self._scan_for_next_stop(ids, i, disk_lo + p_end - 1)
+
+            if i != j:
+                yield p_end - p, ids[i:j] - (disk_lo + p), slice(i, j)
+            else:
+                yield p_end - p, None, None
+
+            i = j
+            p = p_end

--- a/pynbody/chunk/__init__.py
+++ b/pynbody/chunk/__init__.py
@@ -443,8 +443,14 @@ class LoadControl:
         if family not in self._disk_family_slice:
             raise ValueError(f"Family {family} is not present on disk")
 
-        if disk_hi < disk_lo:
-            raise ValueError("disk_hi must not be less than disk_lo")
+        disk_slice = self._disk_family_slice[family]
+        family_length = disk_slice.stop - disk_slice.start
+        if not 0 <= disk_lo <= disk_hi <= family_length:
+            # Out of range would otherwise pass silently: a negative disk_lo yields destination
+            # slices that index backwards from the end of the array, and a disk_hi beyond the
+            # family tells the caller to read entries which are not there
+            raise ValueError(f"The window [{disk_lo}, {disk_hi}) does not lie within family "
+                             f"{family}, whose on-disk extent is [0, {family_length})")
 
         num_disk = disk_hi - disk_lo
         max_chunk = self._max_chunk

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -207,26 +207,6 @@ class _SubfindHdfMultiFileManager(_GadgetHdfMultiFileManager):
     _nfiles_attrname = "NTask"
     _subgroup_name = "FOF"
 
-class _HDFFileIterator:
-    def __init__(self, hdf_file_iterator):
-        """
-        Initialize the HDF file iterator. specifically used for LoadControl.iterate_with_interrupts
-        """
-        self._hdf_file_iterator = hdf_file_iterator
-        self.current_hdf_file = None
-        self.file_index = -1
-        self.particle_offset = 0 
-        self.select_file(0)
-
-    def select_file(self, offset):
-        try:
-            self.current_hdf_file = next(self._hdf_file_iterator)
-            self.file_index += 1 # next file
-            self.particle_offset = 0 # Reset offset for the new file
-        except StopIteration:
-            self.current_hdf_file = None
-            self.file_index = -1
-            self.particle_offset = 0
 class _HDFArrayFiller:
     """A helper class to fill a pynbody array from an HDF5 dataset."""
 
@@ -461,40 +441,42 @@ class HDFArrayLoader:
             
             sim_fam_array, array_filler = self._get_array_filler(array_name, loading_fam, sim, translated_names)
 
-            i0 = 0 # current write position in sim_fam_array
+            i0 = 0 # start of the current hdf group's data within sim_fam_array
 
             # A 'gadget group name' is e.g. 'PartType0', 'PartType1' etc.
             for hdf_group_name in self._family_to_group_map[loading_fam]:
                 if self._file_ptype_slice[hdf_group_name].stop <= self._file_ptype_slice[hdf_group_name].start:
                     continue
-                # Create iterator for this group type across all files
-                file_iterator = _HDFFileIterator(iter(self._hdf_files.iter_particle_groups_with_name(hdf_group_name)))
 
-                last_file_index = -1
-                for readlen, buf_index, mem_index in self._load_control.iterate_with_interrupts(
-                        hdf_group_name, 
-                        hdf_group_name, 
-                        self._file_interrupt_points[hdf_group_name],  # file offset
-                        file_iterator.select_file): 
-                    if mem_index is None or file_iterator.current_hdf_file is None:
-                        # Skip-read: advance on-disk cursor even when we don't copy into memory,
-                        # otherwise the next actual read will start from the wrong disk position
-                        # at chunk/file boundaries (e.g. slice at start == _max_buf). Refs #955
-                        file_iterator.particle_offset += readlen
-                        continue
-                    i1 = i0 + mem_index.stop - mem_index.start
+                hdf_groups = list(self._hdf_files.iter_particle_groups_with_name(hdf_group_name))
+                # Cumulative particle counts, i.e. the group-relative disk position at which each file ends
+                file_boundaries = self._file_interrupt_points[hdf_group_name]
 
-                    # Check if we need to load a new dataset
-                    if last_file_index != file_iterator.file_index:
-                        dataset = self._get_dataset_from_translated_names(sim, file_iterator.current_hdf_file, translated_names)
-                        last_file_index = file_iterator.file_index
+                lo = 0
+                for hdf_group, hi in zip(hdf_groups, file_boundaries):
+                    dataset = None
+                    dataset_resolved = False
+                    offset = 0 # read position within this file
+                    for readlen, buf_index, mem_index in self._load_control.iterate_within(hdf_group_name, lo, hi):
+                        if mem_index is not None:
+                            if not dataset_resolved:
+                                # Resolve only once we know we want something from this file: with partial
+                                # loading most files can contribute nothing, and each lookup is a metadata
+                                # round trip (an expensive one on a parallel filesystem)
+                                dataset = self._get_dataset_from_translated_names(sim, hdf_group,
+                                                                                  translated_names)
+                                dataset_resolved = True
+                            if dataset is not None:
+                                target_array = sim_fam_array[i0 + mem_index.start : i0 + mem_index.stop]
+                                array_filler.fill_array_from_hdf_dataset(target_array, dataset,
+                                                                         source_sel=buf_index, offset=offset)
+                        # Advance even when nothing is copied, or the next read starts from the wrong
+                        # position in the file. Refs #955
+                        offset += readlen
+                    lo = hi
 
-                    if dataset is not None:
-                        target_array = sim_fam_array[i0:i1]
-                        array_filler.fill_array_from_hdf_dataset(target_array, dataset, source_sel=buf_index,
-                                                                       offset=file_iterator.particle_offset)
-                    file_iterator.particle_offset += readlen
-                    i0 = i1
+                group_mem_slice = self._load_control.mem_family_slice[hdf_group_name]
+                i0 += group_mem_slice.stop - group_mem_slice.start
 
     def _get_array_filler(self, array_name: str, loading_fam: family.Family, sim: SimSnap, translated_names: list[str]):
         """

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -152,10 +152,22 @@ def test_iterate_within_rejects_unknown_family():
         list(control.iterate_within(family.gas, 0, 100))
 
 
-def test_iterate_within_rejects_reversed_range():
-    control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, None)
+@pytest.mark.parametrize('disk_lo, disk_hi', [(500, 400),      # reversed
+                                              (-5, 10),        # negative start
+                                              (0, 1001),       # past the end of the family
+                                              (1001, 1002),    # wholly past the end
+                                              (-10, -5)])
+@pytest.mark.parametrize('take', [None, np.array([10, 990])])
+def test_iterate_within_rejects_windows_outside_the_family(disk_lo, disk_hi, take):
+    """Out-of-range windows would otherwise silently produce bad destination slices or over-long reads"""
+    control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, take)
     with pytest.raises(ValueError):
-        list(control.iterate_within(family.dm, 500, 400))
+        list(control.iterate_within(family.dm, disk_lo, disk_hi))
+
+
+def test_iterate_within_accepts_the_whole_family_as_one_window():
+    control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, None)
+    assert sum(readlen for readlen, _, _ in control.iterate_within(family.dm, 0, 1000)) == 1000
 
 
 @pytest.mark.parametrize('take_name', list(TAKE_PATTERNS.keys()))

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -1,0 +1,227 @@
+"""Tests for pynbody.chunk.LoadControl, the partial-loading logic shared by the readers."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pynbody import family
+from pynbody.chunk import LoadControl
+
+MAX_CHUNK = 1000
+
+# A deliberately awkward multi-file layout: an empty file, a file much shorter than a chunk, and a file
+# exactly one chunk long.
+FILE_LENGTHS = [2200, 0, 300, 1800, MAX_CHUNK, 700]
+NUM_PARTICLES = sum(FILE_LENGTHS)
+
+
+def _take_patterns():
+    rng = np.random.default_rng(1234)
+    return {
+        'full': None,
+        'contiguous_mid_file': np.arange(2500, 4000),
+        'random_1pc': np.sort(rng.choice(NUM_PARTICLES, NUM_PARTICLES // 100, replace=False)),
+        'random_60pc': np.sort(rng.choice(NUM_PARTICLES, (NUM_PARTICLES * 6) // 10, replace=False)),
+        'strided': np.arange(0, NUM_PARTICLES, 7),
+        'single': np.array([2500]),
+        'first_and_last': np.array([0, NUM_PARTICLES - 1]),
+        'empty': np.array([], dtype=np.int64),
+    }
+
+
+TAKE_PATTERNS = _take_patterns()
+
+
+def _disk_positions(buffer_index, readlen):
+    """Expand a yielded buffer index into positions relative to the start of the read"""
+    if isinstance(buffer_index, slice):
+        return np.arange(*buffer_index.indices(readlen))
+    else:
+        return np.asarray(buffer_index)
+
+
+def _map_via_interrupts(control, fam, file_lengths):
+    """Build a {disk position: memory index} map the way gadgethdf used to, i.e. with an interrupt callback.
+
+    This is the reference implementation against which iterate_within is checked."""
+
+    file_starts = np.concatenate(([0], np.cumsum(file_lengths)))
+    interrupt_points = list(np.cumsum(file_lengths))
+
+    state = {'file': 0, 'offset': 0}
+
+    def next_file(disk_position):
+        state['file'] += 1
+        state['offset'] = 0
+
+    mapping = {}
+    for readlen, buffer_index, memory_index in control.iterate_with_interrupts(
+            [fam], [fam], interrupt_points, next_file):
+        if memory_index is None:
+            state['offset'] += readlen
+            continue
+        positions = file_starts[state['file']] + state['offset'] + _disk_positions(buffer_index, readlen)
+        for i, position in enumerate(positions):
+            mapping[int(position)] = memory_index.start + i
+        state['offset'] += readlen
+
+    return mapping
+
+
+def _map_via_iterate_within(control, fam, file_lengths):
+    """Build a {disk position: memory index} map by treating each file independently"""
+
+    mapping = {}
+    lo = 0
+    for file_length in file_lengths:
+        hi = lo + file_length
+        offset = 0
+        for readlen, buffer_index, memory_index in control.iterate_within(fam, lo, hi):
+            if memory_index is None:
+                offset += readlen
+                continue
+            positions = lo + offset + _disk_positions(buffer_index, readlen)
+            for i, position in enumerate(positions):
+                mapping[int(position)] = memory_index.start + i
+            offset += readlen
+        lo = hi
+
+    return mapping
+
+
+@pytest.mark.parametrize('take_name', list(TAKE_PATTERNS.keys()))
+def test_iterate_within_matches_interrupts(take_name):
+    """iterate_within must reproduce exactly what the interrupt-callback route produced"""
+    take = TAKE_PATTERNS[take_name]
+    control = LoadControl({family.dm: slice(0, NUM_PARTICLES)}, MAX_CHUNK, take)
+
+    reference = _map_via_interrupts(control, family.dm, FILE_LENGTHS)
+    per_file = _map_via_iterate_within(control, family.dm, FILE_LENGTHS)
+
+    assert per_file == reference
+
+    # ... and that map must in fact be the identity between the selected particles and memory
+    expected_ids = np.arange(NUM_PARTICLES) if take is None else np.asarray(take)
+    npt.assert_equal(np.array(sorted(per_file.keys())), expected_ids)
+    npt.assert_equal(np.array([per_file[int(i)] for i in expected_ids]), np.arange(len(expected_ids)))
+
+
+@pytest.mark.parametrize('take_name', list(TAKE_PATTERNS.keys()))
+def test_chunks_never_exceed_max_chunk(take_name):
+    take = TAKE_PATTERNS[take_name]
+    control = LoadControl({family.dm: slice(0, NUM_PARTICLES)}, MAX_CHUNK, take)
+
+    for readlen, _, _ in control.iterate([family.dm], [family.dm]):
+        assert readlen <= MAX_CHUNK
+
+    lo = 0
+    for file_length in FILE_LENGTHS:
+        hi = lo + file_length
+        for readlen, _, _ in control.iterate_within(family.dm, lo, hi):
+            assert readlen <= MAX_CHUNK
+        lo = hi
+
+
+@pytest.mark.parametrize('take_name', list(TAKE_PATTERNS.keys()))
+def test_iterate_within_reconstructs_whole_family(take_name):
+    """Consecutive windows covering the family must be equivalent to a single pass with iterate"""
+    take = TAKE_PATTERNS[take_name]
+    control = LoadControl({family.dm: slice(0, NUM_PARTICLES)}, MAX_CHUNK, take)
+
+    disk_position = 0
+    from_iterate = {}
+    for readlen, buffer_index, memory_index in control.iterate([family.dm], [family.dm]):
+        if memory_index is not None:
+            positions = disk_position + _disk_positions(buffer_index, readlen)
+            for i, position in enumerate(positions):
+                from_iterate[int(position)] = memory_index.start + i
+        disk_position += readlen
+
+    assert _map_via_iterate_within(control, family.dm, FILE_LENGTHS) == from_iterate
+
+
+def test_iterate_within_zero_length_range():
+    for take in (None, np.array([5, 10, 500])):
+        control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, take)
+        assert list(control.iterate_within(family.dm, 300, 300)) == []
+
+
+def test_iterate_within_rejects_unknown_family():
+    control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, None)
+    with pytest.raises(ValueError):
+        list(control.iterate_within(family.gas, 0, 100))
+
+
+def test_iterate_within_rejects_reversed_range():
+    control = LoadControl({family.dm: slice(0, 1000)}, MAX_CHUNK, None)
+    with pytest.raises(ValueError):
+        list(control.iterate_within(family.dm, 500, 400))
+
+
+@pytest.mark.parametrize('take_name', list(TAKE_PATTERNS.keys()))
+def test_iterate_within_memory_index_is_family_relative(take_name):
+    """Each family's memory index restarts from zero, so callers add mem_family_slice themselves.
+
+    Readers rely on this: gadgethdf keeps one load-control family per HDF particle group and lays
+    several of them end-to-end into a single pynbody family array."""
+    take = TAKE_PATTERNS[take_name]
+    # split the same particles across two families, each spanning several files
+    boundary = sum(FILE_LENGTHS[:3])
+    family_slice = {family.gas: slice(0, boundary), family.dm: slice(boundary, NUM_PARTICLES)}
+    control = LoadControl(family_slice, MAX_CHUNK, take)
+
+    global_mapping = {}
+    for fam, file_lengths in ((family.gas, FILE_LENGTHS[:3]), (family.dm, FILE_LENGTHS[3:])):
+        disk_start = family_slice[fam].start
+        mem_start = control.mem_family_slice[fam].start
+        per_family = _map_via_iterate_within(control, fam, file_lengths)
+
+        if per_family:
+            assert min(per_family.values()) == 0, "memory index should restart at zero for each family"
+        for disk_position, memory_index in per_family.items():
+            global_mapping[disk_start + disk_position] = mem_start + memory_index
+
+    expected_ids = np.arange(NUM_PARTICLES) if take is None else np.asarray(take)
+    npt.assert_equal(np.array(sorted(global_mapping.keys())), expected_ids)
+    npt.assert_equal(np.array([global_mapping[int(i)] for i in expected_ids]),
+                     np.arange(len(expected_ids)))
+
+
+def test_multifamily_slices():
+    family_slice = {family.gas: slice(0, 100), family.dm: slice(100, 350), family.star: slice(350, 400)}
+
+    control = LoadControl(family_slice, MAX_CHUNK, None)
+    assert control.disk_num_particles == 400
+    assert control.mem_num_particles == 400
+    assert control.mem_family_slice == family_slice
+
+    # 10 gas, 5 dm, 2 star
+    take = np.concatenate((np.arange(10), np.arange(200, 205), np.array([350, 399])))
+    control = LoadControl(family_slice, MAX_CHUNK, take)
+    assert control.disk_num_particles == 400
+    assert control.mem_num_particles == 17
+    assert control.mem_family_slice == {family.gas: slice(0, 10), family.dm: slice(10, 15),
+                                        family.star: slice(15, 17)}
+
+
+@pytest.mark.parametrize('take, expected', [(slice(10), np.arange(10)),
+                                            (slice(-100, None), np.arange(300, 400)),
+                                            (slice(50, 400, 25), np.arange(50, 400, 25)),
+                                            (slice(1000), np.arange(400))])
+def test_slice_take_is_normalised_against_disk_length(take, expected):
+    control = LoadControl({family.gas: slice(0, 100), family.dm: slice(100, 400)}, MAX_CHUNK, take)
+    assert control.mem_num_particles == len(expected)
+
+    mem_slice = control.mem_family_slice[family.dm]
+    npt.assert_equal(np.sum(expected >= 100), mem_slice.stop - mem_slice.start)
+
+
+def test_negative_step_slice_take_rejected():
+    with pytest.raises(ValueError, match="negative step"):
+        LoadControl({family.dm: slice(0, 400)}, MAX_CHUNK, slice(None, None, -1))
+
+
+@pytest.mark.parametrize('take', [np.array([5, 3, 10]), np.array([1, 1, 2])])
+def test_non_ascending_take_rejected(take):
+    with pytest.raises(ValueError, match="strictly ascending"):
+        LoadControl({family.dm: slice(0, 400)}, MAX_CHUNK, take)


### PR DESCRIPTION
## Motivation

`GadgetHDFSnap` and its derivatives (`SwiftSnap`, Gadget-4, Arepo, pkdgrav3, subfind) read spanned HDF5 files by walking `LoadControl.iterate_with_interrupts` with a callback that fires when the disk cursor crosses a file boundary. Two consequences:

- Reading file *N* depends on having walked files *0..N-1*, because the read cursor and the memory write position are both accumulated along the way.
- The boundary handling inside `iterate_with_interrupts` has to split a chunk's index arrays in two (via `concatenate_indexing` plus an explicit `copy.copy`). That splitting is where #955 came from.

This is a pure refactor: no behaviour change, no new dependencies, no threads. It removes the stateful cursor, and makes each file independently describable — which is the prerequisite for reading spanned files concurrently later on.

## What changed

**`LoadControl.iterate_within(family, disk_lo, disk_hi)`** — new generator yielding the same `(readlen, disk_index, mem_index)` triples as `iterate`, but restricted to one contiguous window of a family's on-disk extent, i.e. one file of a spanned snapshot.

The window is independent of its predecessors because of one observation: a family's selected ids are ascending, so the number of them below `disk_lo` is *simultaneously* where this window's selection begins within the id list and how many memory slots all preceding windows consume between them. A single `np.searchsorted` therefore supplies both, in place of a walk. Chunks are then generated inside the window and never straddle a boundary, so no index splitting is needed at all. `mem_index` is relative to the start of the family's in-memory data.

**`HDFArrayLoader.load_arrays`** now iterates per file: each file is resolved, iterated and filled on its own terms. `_HDFFileIterator`, the interrupt callback and the shared `particle_offset` cursor are all gone, and the loop is 20 lines shorter. The dataset lookup is deliberately lazy — with partial loading most files can contribute nothing, and each lookup is a metadata round trip that is expensive on a parallel filesystem.

**`iterate` and `iterate_with_interrupts` are untouched.** `grafic._read_grafic_file` still uses the latter, for skipping Fortran record header/footer pairs *within* a single file — a genuinely different use that this change does not affect.

## Tests

`LoadControl` has had no direct unit tests until now, only indirect coverage through the readers. `tests/chunk_test.py` adds 43.

The central test uses the old code path as an oracle: it builds the `{disk position: memory index}` mapping twice — once by walking `iterate_with_interrupts` with a file-boundary callback exactly as `gadgethdf` used to, and once by calling `iterate_within` per file — and requires them to agree. It runs over eight take patterns (full load, contiguous block starting mid-file, random 1%, random 60%, strided, single particle, first-and-last, empty) against a deliberately awkward layout `[2200, 0, 300, 1800, 1000, 700]` that contains an empty file, a file far shorter than a chunk, and one exactly a chunk long. Each mapping is also checked independently against the identity between selected ids and memory positions, so the tests do not merely confirm that the two paths agree with each other.

The rest cover ground that was previously untested: chunk sizes never exceeding `max_chunk`, `iterate_within` reconstructing what `iterate` produces, `mem_index` restarting at zero per family (which `gadgethdf` relies on, laying several load-control families end-to-end into one pynbody family array), multi-family memory slices, `slice` takes being normalised against the disk length, and the `ValueError`s for negative-step slices and non-ascending or duplicated ids.

Full suites run green — `chunk`, `gadgethdf`, `swift`, `subfindhdf`, `pkdgravhdf`, `subfindhdf_gadget4`, `split_swift_snapshot`, `grafic`, `tipsy`, `nchilada`: 192 passed.

## Note for reviewers

Chunk boundaries move: they previously sat on a global per-family `max_chunk` grid and were cut by file boundaries, and now sit on a per-file grid. The disk-to-memory mapping is unchanged (that is what the oracle test pins down), but read *granularity* differs — a file shorter than `max_chunk` becomes one short read rather than part of a larger one. Nothing asserts on read sizes; the one existing use of `_max_buf` in the tests is a data assertion about a `take` straddling a chunk boundary, and it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY3MQjiggYaMuMKinBoULf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY3MQjiggYaMuMKinBoULf)_